### PR TITLE
Update actions/checkout to v5.0.0 in workflows

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       # uses GitHub's checkout action to checkout code form the release branch
       - name: Checkout code
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v5.0.0
 
       # sets up .NET SDK
       - name: Setup .NET

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,7 @@ jobs:
           build-mode: none
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@v5.0.0
 
       # sets up .NET SDK
     - name: Setup .NET Core SDK

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       # uses GitHub's checkout action to checkout code form the release branch
       - name: Checkout code
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v5.0.0
 
       # sets up .NET SDK
       - name: Setup .NET


### PR DESCRIPTION
Bump actions/checkout from v4.2.2 to v5.0.0 in buildandtest.yml, codeql.yml, and main.yml to use the latest version and benefit from improvements and bug fixes.