### PR TITLE
Update package versions and .NET SDK to latest

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,13 +4,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="KristofferStrube.Blazor.FileSystemAccess" Version="3.3.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="9.0.90" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="9.0.8" />
     <PackageVersion Include="Microsoft.Maui.Controls" Version="9.0.90" />
-    <PackageVersion Include="MudBlazor" Version="8.10.0" />
+    <PackageVersion Include="MudBlazor" Version="8.11.0" />
     <PackageVersion Include="PKHeX.Core" Version="25.6.9" />
   </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "allowPrerelease": false,
     "rollForward": "latestMinor",
-    "version": "9.0.303"
+    "version": "9.0.304"
   }
 }


### PR DESCRIPTION
Bumped several NuGet package versions including Microsoft.AspNetCore.Components and MudBlazor to their latest releases. Updated .NET SDK version in global.json from 9.0.303 to 9.0.304 for improved compatibility and bug fixes.