### PR TITLE
Add WARP.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -356,3 +356,4 @@ Pkmds.Rcl/wwwroot/css/tailwind.css
 Pkmds.Blazor/wwwroot/css/tailwind.css
 Pkmds.Maui/wwwroot/css/tailwind.css
 .idea
+WARP.md


### PR DESCRIPTION
Updated .gitignore to exclude WARP.md from version control.