### PR TITLE
Update .NET SDK and Blazor package versions to 10.0.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,9 +8,9 @@
         <PackageVersion Include="FluentAssertions" Version="8.8.0"/>
         <PackageVersion Include="Humanizer" Version="3.0.1"/>
         <PackageVersion Include="KristofferStrube.Blazor.FileSystemAccess" Version="3.3.0"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="10.0.1"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.1"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.1"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="10.0.2"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.2"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.2"/>
         <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="9.0.120"/>
         <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="9.0.10"/>
         <PackageVersion Include="Microsoft.Maui.Controls" Version="9.0.120"/>

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "allowPrerelease": false,
     "rollForward": "latestMinor",
-    "version": "10.0.101"
+    "version": "10.0.102"
   }
 }


### PR DESCRIPTION
Updated .NET SDK version in global.json from 10.0.101 to 10.0.102. Bumped Microsoft.AspNetCore.Components.Web, WebAssembly, and WebAssembly.DevServer NuGet packages from 10.0.1 to 10.0.2 in Directory.Packages.props.