### PR TITLE
Add wasm-tools install instructions for Pkmds.Web

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,9 @@
 Whenever you work on code, please ensure that the app version number in /.Directory.Build.props is updated correctly. I use the format yyyy.mm.dd.# - for instance, 2026.01.03.0 is for January 3, 2026. The last number is the zero-based build number, so 0 means it's the first build for that day. 1 would be the second build, 2 would be the third, etc.
 
 Please also do your best to respect the existing code format and style. You can reference /.editorconfig as well.
+
+Please note, in order to build Pkmds.Web, you will need to first install the wasm-tools workload like so:
+
+```
+dotnet workload install wasm-tools
+```


### PR DESCRIPTION
Updated copilot-instructions.md to include steps for installing the wasm-tools workload required to build Pkmds.Web.