### PR TITLE
Bump coverlet and SDK; scope coverlet reference

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
     <ItemGroup>
         <PackageVersion Include="BlazorExpress.ChartJS" Version="1.2.0"/>
         <PackageVersion Include="bUnit" Version="2.5.3"/>
-        <PackageVersion Include="coverlet.collector" Version="6.0.4"/>
+        <PackageVersion Include="coverlet.collector" Version="8.0.0"/>
         <PackageVersion Include="FluentAssertions" Version="8.8.0"/>
         <PackageVersion Include="Humanizer" Version="3.0.1"/>
         <PackageVersion Include="KristofferStrube.Blazor.FileSystemAccess" Version="3.3.0"/>

--- a/Pkmds.Tests/Pkmds.Tests.csproj
+++ b/Pkmds.Tests/Pkmds.Tests.csproj
@@ -11,7 +11,10 @@
 
     <ItemGroup>
         <PackageReference Include="bUnit"/>
-        <PackageReference Include="coverlet.collector"/>
+        <PackageReference Include="coverlet.collector">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="FluentAssertions"/>
         <PackageReference Include="xunit.v3"/>
         <PackageReference Include="xunit.runner.visualstudio">

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "allowPrerelease": false,
     "rollForward": "latestMinor",
-    "version": "10.0.102"
+    "version": "10.0.103"
   }
 }


### PR DESCRIPTION
Upgrade coverlet.collector to 8.0.0 in Directory.Packages.props and add <PrivateAssets>all</PrivateAssets> with explicit <IncludeAssets> to the Pkmds.Tests project reference so the collector doesn't flow to consumers. Also update global.json to use .NET SDK 10.0.103. These changes update the coverage tool to a newer release and scope its assets to the test project.