### PR TITLE
Add update check button and handler

### DIFF
--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor
@@ -29,7 +29,14 @@
             @Constants.AppShortTitle
         </MudText>
         <MudSpacer/>
-        <MudStack Row>
+        <MudStack Row
+                   AlignItems="@AlignItems.Center">
+            <MudTooltip Text="@(isCheckingForUpdate ? "Checking..." : "Check for updates")">
+                <MudIconButton Icon="@Icons.Material.Filled.SystemUpdateAlt"
+                               Color="@Color.Inherit"
+                               Disabled="@isCheckingForUpdate"
+                               OnClick="@CheckForUpdate"/>
+            </MudTooltip>
             <MudSwitch Value="@isDarkMode"
                        ValueChanged="@((bool value) => OnThemeSwitchChanged(value))"
                        Color="@Color.Primary"

--- a/Pkmds.Web/wwwroot/index.html
+++ b/Pkmds.Web/wwwroot/index.html
@@ -124,6 +124,31 @@
             DotNet.invokeMethodAsync('Pkmds.Web', 'ShowUpdateMessage');
         });
     };
+
+    window.checkForUpdate = async () => {
+        if (!('serviceWorker' in navigator)) {
+            return 'no-sw';
+        }
+        const registration = await navigator.serviceWorker.getRegistration();
+        if (!registration) {
+            return 'no-sw';
+        }
+        // Listen for a new worker before calling update()
+        const updatePromise = new Promise(resolve => {
+            const onUpdateFound = () => {
+                registration.removeEventListener('updatefound', onUpdateFound);
+                resolve('update-found');
+            };
+            registration.addEventListener('updatefound', onUpdateFound);
+            // If no update is found within 10 seconds, assume we're up to date
+            setTimeout(() => {
+                registration.removeEventListener('updatefound', onUpdateFound);
+                resolve('no-update');
+            }, 10000);
+        });
+        await registration.update();
+        return await updatePromise;
+    };
 </script>
 
 </body>


### PR DESCRIPTION
Adds a manual "Check for updates" icon button to the main layout with a tooltip and a disabled state while checking. Introduces isCheckingForUpdate and a CheckForUpdate async method that calls the new JS interop function 'checkForUpdate', shows success/info/warning snackbars based on the result, and handles JS exceptions. Adds a checkForUpdate function in index.html that queries the service worker registration, listens for an updatefound event (with a 10s fallback), calls registration.update(), and returns a status string indicating update-found, no-update, or no-sw.