### PR TITLE
Improve service worker update detection and messages

### DIFF
--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
@@ -73,7 +73,9 @@ public partial class MainLayout : IDisposable
             {
                 "update-found" => ("Update found! It will be applied on next reload.", Severity.Success),
                 "no-update" => ("You're up to date — no updates available.", Severity.Info),
-                _ => ("Unable to check for updates (service worker not available).", Severity.Warning),
+                "no-sw" => ("Service worker is not available. Try reloading the page first.", Severity.Warning),
+                "error" => ("An error occurred while checking for updates.", Severity.Error),
+                _ => ($"Unexpected update check result: {result}", Severity.Warning),
             };
             Snackbar.Add(message, severity);
         }

--- a/Pkmds.Web/wwwroot/index.html
+++ b/Pkmds.Web/wwwroot/index.html
@@ -129,25 +129,34 @@
         if (!('serviceWorker' in navigator)) {
             return 'no-sw';
         }
-        const registration = await navigator.serviceWorker.getRegistration();
-        if (!registration) {
-            return 'no-sw';
+        try {
+            // Try getRegistration first, fall back to ready
+            let registration = await navigator.serviceWorker.getRegistration();
+            if (!registration) {
+                registration = await navigator.serviceWorker.ready;
+            }
+            if (!registration) {
+                return 'no-sw';
+            }
+            // Listen for a new worker before calling update()
+            const updatePromise = new Promise(resolve => {
+                const onUpdateFound = () => {
+                    registration.removeEventListener('updatefound', onUpdateFound);
+                    resolve('update-found');
+                };
+                registration.addEventListener('updatefound', onUpdateFound);
+                // If no update is found within 10 seconds, assume we're up to date
+                setTimeout(() => {
+                    registration.removeEventListener('updatefound', onUpdateFound);
+                    resolve('no-update');
+                }, 10000);
+            });
+            await registration.update();
+            return await updatePromise;
+        } catch (error) {
+            console.warn('checkForUpdate error:', error);
+            return 'error';
         }
-        // Listen for a new worker before calling update()
-        const updatePromise = new Promise(resolve => {
-            const onUpdateFound = () => {
-                registration.removeEventListener('updatefound', onUpdateFound);
-                resolve('update-found');
-            };
-            registration.addEventListener('updatefound', onUpdateFound);
-            // If no update is found within 10 seconds, assume we're up to date
-            setTimeout(() => {
-                registration.removeEventListener('updatefound', onUpdateFound);
-                resolve('no-update');
-            }, 10000);
-        });
-        await registration.update();
-        return await updatePromise;
     };
 </script>
 


### PR DESCRIPTION
Make service worker update checks more robust and surface clearer UI messages. In index.html the checkForUpdate script now tries navigator.serviceWorker.getRegistration() then falls back to navigator.serviceWorker.ready, attaches an updatefound listener before calling registration.update(), uses a 10s timeout to assume no update, and catches/report errors (returns 'error'). In MainLayout.razor.cs new result keys ('no-sw', 'error') map to clearer Snackbar messages and the default case now reports unexpected results. These changes improve reliability and provide better feedback when update checks fail or behave unexpectedly.