### PR TITLE
Add checkout and update permissions in claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -8,11 +8,13 @@ on:
     types: [opened, assigned]
   pull_request:
     types: [opened, ready_for_review]
+
 permissions:
   contents: write
   issues: write
   pull-requests: write
   id-token: write
+  actions: read
 
 jobs:
   claude:
@@ -20,6 +22,11 @@ jobs:
     timeout-minutes: 30
     if: github.event_name != 'pull_request'
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: true
+
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -32,6 +39,11 @@ jobs:
     timeout-minutes: 30
     if: github.event_name == 'pull_request' && (github.event.action == 'ready_for_review' || github.event.pull_request.draft == false)
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: true
+
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
Add actions/checkout@v6.0.2 (with persist-credentials: true) to both the non-PR and PR job paths so the workflow has access to repository code and credentials. Expand workflow permissions to include contents, issues, pull-requests, id-token (write) and actions (read) to allow the anthropics/claude-code-action to operate on repo files and interact with PRs/issues.