### PR TITLE
Fix Claude action MCP server initialization failures

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,4 +1,5 @@
 name: Claude Code
+
 on:
   issue_comment:
     types: [created]
@@ -10,8 +11,35 @@ on:
 jobs:
   claude:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write        # Allow Claude to commit and push changes
+      pull-requests: write   # Allow Claude to comment on and create PRs
+      issues: write          # Allow Claude to comment on issues
+      id-token: write
+      actions: read          # Required for Claude to read CI results on PRs
+
     steps:
-      - uses: anthropics/claude-code-action@v1
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Install WASM workload
+        run: dotnet workload install wasm-tools
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          additional_permissions: |
+            actions: read
           claude_args: "--max-turns 10"


### PR DESCRIPTION
Add permissions block, checkout step, and .NET environment setup so the bundled GitHub MCP server can acquire a valid token and the action has full repo context to work with.