### PR TITLE
Fix Claude GitHub Actions MCP server initialization failures

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,9 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
+      actions: read # Required for Claude to read CI results on PRs
 
     steps:
       - name: Checkout repository
@@ -36,9 +37,18 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: |
+            Review this pull request and post your findings as a review comment.
+
+            Focus on:
+            - Correctness and potential bugs
+            - C# and Blazor best practices (nullable reference types, async/await, DI patterns)
+            - PKHeX.Core API usage — reference PKHeX WinForms as the authoritative usage guide
+            - Performance and memory concerns (WASM constraints apply)
+            - Code style consistency with the existing codebase and .editorconfig rules
+
+            Keep feedback constructive and actionable. Note any PKHeX.Core limitations
+            as code comments per AGENTS.md guidance.
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,9 +19,9 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
@@ -35,10 +35,6 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-
-          # This is an optional setting that allows Claude to read CI results on PRs
-          additional_permissions: |
-            actions: read
 
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'


### PR DESCRIPTION
## Summary

- Upgrades `contents`/`pull-requests`/`issues` permissions from `read` to `write` in both workflows — `anthropics/claude-code-action@v1` sets up a built-in GitHub MCP server that requires write-capable tokens to initialize; read-only tokens caused both workflows to fail at startup
- Removes the deprecated `plugin_marketplaces` + `plugins` inputs from `claude-code-review.yml`, which were trying to clone and install a plugin-based MCP server from a git URL (broken approach)
- Replaces the broken plugin slash-command prompt with a direct review prompt tailored to this project (C#/Blazor/PKHeX.Core context)
- Removes the redundant `additional_permissions: actions: read` block from `claude.yml` (already set at job level)

## Test plan

- [ ] Trigger `claude.yml` by commenting `@claude` on an issue or PR — verify it no longer fails at MCP server init
- [ ] Open or push to a PR to trigger `claude-code-review.yml` — verify it posts a review comment without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)