### PR TITLE
Add Legality Checker

### DIFF
--- a/PKHEX_PARITY_ROADMAP.md
+++ b/PKHEX_PARITY_ROADMAP.md
@@ -34,6 +34,7 @@ This roadmap outlines the path to achieving 100% feature parity with PKHeX. Task
 - **Showdown Export** - Export Pokemon to Showdown format
 - **Multi-Save Support** - Load/save multiple save files
 - **PWA Support** - Offline functionality, installable web app
+- **Legality Checker (Core)** - `LegalityAnalysis` integration with per-check detail view, color-coded results, full verbose report, and slot-level valid/warn icon overlays
 
 ---
 
@@ -120,26 +121,26 @@ This roadmap outlines the path to achieving 100% feature parity with PKHeX. Task
 - [x] Implement generation-specific validation
 
 ### 1.2 Legality Checker
-**Status:** ❌ Not Implemented  
-**Complexity:** Very High  
-**Priority:** Critical  
+**Status:** ⚠️ Partial (core analysis + UI implemented; fix buttons, batch checking, and unit tests remain)
+**Complexity:** Very High
+**Priority:** Critical
 **Tasks:**
-- [ ] Design Legality Checker UI component
-- [ ] Integrate PKHeX.Core LegalityAnalysis
-- [ ] Display legality results with color coding (legal/illegal/suspicious)
-- [ ] Show detailed legality report with:
-  - [ ] Encounter type validation
-  - [ ] Relearn moves validation
-  - [ ] PID/EC validation
-  - [ ] Ribbon validation
-  - [ ] Memory validation
-  - [ ] Met location validation
-  - [ ] Ball legality
-  - [ ] Ability legality
-  - [ ] Level/experience validation
+- [x] Design Legality Checker UI component (`LegalityTab`)
+- [x] Integrate PKHeX.Core `LegalityAnalysis` (`IAppService.GetLegalityAnalysis`)
+- [x] Display legality results with color coding (legal/illegal/suspicious)
+- [x] Show detailed legality report with:
+  - [x] Encounter type validation (`CheckIdentifier.Encounter`)
+  - [x] Relearn moves validation (`CheckIdentifier.RelearnMove`)
+  - [x] PID/EC validation (`CheckIdentifier.PID` / `CheckIdentifier.EC`)
+  - [x] Ribbon validation (`CheckIdentifier.Ribbon` / `CheckIdentifier.RibbonMark`)
+  - [x] Memory validation (`CheckIdentifier.Memory`)
+  - [x] Met location validation (part of encounter analysis)
+  - [x] Ball legality (`CheckIdentifier.Ball`)
+  - [x] Ability legality (`CheckIdentifier.Ability`)
+  - [x] Level/experience validation (`CheckIdentifier.Level`)
 - [ ] Add "Fix" buttons for common legality issues
 - [ ] Implement batch legality checking
-- [ ] Show legality warnings on Pokemon slot display
+- [x] Show legality warnings on Pokémon slot display (valid/warn icon overlay)
 - [ ] Create comprehensive unit tests
 
 ### 1.3 Batch Editor
@@ -880,3 +881,4 @@ This roadmap is a living document. Community contributions are welcome!
 
 **Last Updated:** 2026-02-26
 **Next Review:** 2026-03-26
+<!-- Legality Checker (§1.2): core analysis + UI done 2026-02-26; fix buttons / batch / tests still pending -->

--- a/Pkmds.Rcl/Components/EditForms/PokemonEditForm.razor
+++ b/Pkmds.Rcl/Components/EditForms/PokemonEditForm.razor
@@ -128,6 +128,10 @@
                 <OtMiscTab Pokemon="@Pokemon"/>
             </MudTabPanel>
 
+            <MudTabPanel Text="Legality">
+                <LegalityTab Pokemon="@Pokemon"/>
+            </MudTabPanel>
+
         </MudTabs>
 
     </div>

--- a/Pkmds.Rcl/Components/EditForms/Tabs/LegalityTab.razor
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/LegalityTab.razor
@@ -1,0 +1,61 @@
+@inherits BasePkmdsComponent
+
+@if (Pokemon is not null &&
+     AppState is { SaveFile: { Context: not (EntityContext.None or EntityContext.SplitInvalid or EntityContext.MaxInvalid) }, SelectedSlotsAreValid: true })
+{
+    @if (Analysis is { } analysis)
+    {
+        <MudStack Class="pa-2">
+
+            <MudAlert Severity="@(IsLegal ? MudBlazor.Severity.Success : MudBlazor.Severity.Error)"
+                      Icon="@(IsLegal ? Icons.Material.Filled.CheckCircle : Icons.Material.Filled.Cancel)">
+                @(IsLegal ? "This Pokémon is legal." : "This Pokémon has legality issues.")
+            </MudAlert>
+
+            @{
+                var issues = analysis.Results
+                    .Where(r => !r.Valid)
+                    .ToList();
+            }
+
+            @if (issues.Count > 0)
+            {
+                <MudText Typo="@Typo.subtitle2" Class="mt-2">Issues (@issues.Count)</MudText>
+
+                <MudList T="CheckResult" Dense>
+                    @foreach (var result in issues)
+                    {
+                        <MudListItem T="CheckResult"
+                                     Icon="@GetSeverityIcon(result.Judgement)"
+                                     IconColor="@GetSeverityColor(result.Judgement)"
+                                     @key="@($"{result.Identifier}:{result.Result}")">
+                            <MudStack Row AlignItems="@AlignItems.Center" Spacing="1">
+                                <MudChip T="string"
+                                         Size="@Size.Small"
+                                         Color="@GetSeverityColor(result.Judgement)"
+                                         Variant="@Variant.Outlined">
+                                    @GetIdentifierLabel(result.Identifier)
+                                </MudChip>
+                                <MudText Typo="@Typo.body2">@HumanizeResult(result)</MudText>
+                            </MudStack>
+                        </MudListItem>
+                    }
+                </MudList>
+            }
+
+            <MudExpansionPanels>
+                <MudExpansionPanel Text="Full Legality Report">
+                    <MudText Typo="@Typo.body2"
+                             Style="white-space: pre-wrap; font-family: monospace; font-size: 0.75rem;">
+                        @analysis.Report(verbose: true)
+                    </MudText>
+                </MudExpansionPanel>
+            </MudExpansionPanels>
+
+        </MudStack>
+    }
+    else
+    {
+        <MudText Class="pa-2" Color="@Color.Default">No Pokémon selected.</MudText>
+    }
+}

--- a/Pkmds.Rcl/Components/EditForms/Tabs/LegalityTab.razor.cs
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/LegalityTab.razor.cs
@@ -1,0 +1,100 @@
+namespace Pkmds.Rcl.Components.EditForms.Tabs;
+
+using PKHexSeverity = PKHeX.Core.Severity;
+
+public partial class LegalityTab : IDisposable
+{
+    [Parameter]
+    [EditorRequired]
+    public PKM? Pokemon { get; set; }
+
+    private LegalityAnalysis? Analysis { get; set; }
+
+    private bool IsLegal => Analysis is { } la && la.Results.All(r => r.Valid);
+
+    public void Dispose() =>
+        RefreshService.OnAppStateChanged -= Refresh;
+
+    protected override void OnInitialized()
+    {
+        RefreshService.OnAppStateChanged += Refresh;
+        ComputeAnalysis();
+    }
+
+    protected override void OnParametersSet() => ComputeAnalysis();
+
+    private void Refresh()
+    {
+        ComputeAnalysis();
+        StateHasChanged();
+    }
+
+    private void ComputeAnalysis() =>
+        Analysis = Pokemon is { Species: > 0 }
+            ? AppService.GetLegalityAnalysis(Pokemon)
+            : null;
+
+    private static Color GetSeverityColor(PKHexSeverity severity) => severity switch
+    {
+        PKHexSeverity.Valid => Color.Success,
+        PKHexSeverity.Fishy => Color.Warning,
+        _ => Color.Error,
+    };
+
+    private static string GetSeverityIcon(PKHexSeverity severity) => severity switch
+    {
+        PKHexSeverity.Valid => Icons.Material.Filled.CheckCircle,
+        PKHexSeverity.Fishy => Icons.Material.Filled.Warning,
+        _ => Icons.Material.Filled.Cancel,
+    };
+
+    private static string GetIdentifierLabel(CheckIdentifier id) => id switch
+    {
+        CheckIdentifier.CurrentMove => "Move",
+        CheckIdentifier.RelearnMove => "Relearn Move",
+        CheckIdentifier.Encounter => "Encounter",
+        CheckIdentifier.Shiny => "Shiny",
+        CheckIdentifier.EC => "Encryption Constant",
+        CheckIdentifier.PID => "PID",
+        CheckIdentifier.Gender => "Gender",
+        CheckIdentifier.EVs => "EVs",
+        CheckIdentifier.Language => "Language",
+        CheckIdentifier.Nickname => "Nickname",
+        CheckIdentifier.Trainer => "Trainer",
+        CheckIdentifier.IVs => "IVs",
+        CheckIdentifier.Level => "Level",
+        CheckIdentifier.Ball => "Ball",
+        CheckIdentifier.Memory => "Memory",
+        CheckIdentifier.Geography => "Geo Locations",
+        CheckIdentifier.Form => "Form",
+        CheckIdentifier.Egg => "Egg",
+        CheckIdentifier.Misc => "Misc",
+        CheckIdentifier.Fateful => "Fateful Encounter",
+        CheckIdentifier.Ribbon => "Ribbon",
+        CheckIdentifier.Training => "Training",
+        CheckIdentifier.Ability => "Ability",
+        CheckIdentifier.Evolution => "Evolution",
+        CheckIdentifier.Nature => "Nature",
+        CheckIdentifier.GameOrigin => "Game Origin",
+        CheckIdentifier.HeldItem => "Held Item",
+        CheckIdentifier.RibbonMark => "Ribbon/Mark",
+        CheckIdentifier.GVs => "GVs",
+        CheckIdentifier.Marking => "Marking",
+        CheckIdentifier.AVs => "AVs",
+        CheckIdentifier.TrashBytes => "Trash Bytes",
+        CheckIdentifier.SlotType => "Slot Type",
+        CheckIdentifier.Handler => "Handler",
+        _ => id.ToString(),
+    };
+
+    private string HumanizeResult(CheckResult result)
+    {
+        if (Analysis is not { } la)
+        {
+            return result.Result.ToString();
+        }
+
+        var ctx = LegalityLocalizationContext.Create(la, "en");
+        return ctx.Humanize(in result, verbose: false);
+    }
+}

--- a/Pkmds.Rcl/Components/PokemonSlotComponent.razor
+++ b/Pkmds.Rcl/Components/PokemonSlotComponent.razor
@@ -36,6 +36,16 @@
                 </div>
             }
 
+            @if (GetLegalityValid() is { } isLegal)
+            {
+                <div class="legality-indicator-icon"
+                     title="@(isLegal ? "Legal" : "Illegal")">
+                    <img src="@(isLegal ? ImageHelper.GetLegalityValidSpriteFileName() : ImageHelper.GetLegalityWarnSpriteFileName())"
+                         alt="@(isLegal ? "Legal" : "Illegal")"
+                         class="w-full h-full object-contain">
+                </div>
+            }
+
             @if (IsAlphaPokemon())
             {
                 <div class="alpha-indicator-icon"

--- a/Pkmds.Rcl/Components/PokemonSlotComponent.razor.cs
+++ b/Pkmds.Rcl/Components/PokemonSlotComponent.razor.cs
@@ -55,6 +55,21 @@ public partial class PokemonSlotComponent : IDisposable
         _ => false
     };
 
+    /// <returns>
+    ///   <see langword="true"/> = legal, <see langword="false"/> = illegal/fishy,
+    ///   <see langword="null"/> = no Pokémon in slot (skip indicator).
+    /// </returns>
+    private bool? GetLegalityValid()
+    {
+        if (Pokemon is not { Species: > 0 })
+        {
+            return null;
+        }
+
+        var la = AppService.GetLegalityAnalysis(Pokemon);
+        return la.Results.All(r => r.Valid);
+    }
+
     private int? GetLetsGoPartySlotNumber()
     {
         // Only show party slot indicators for Let's Go games in the BOX view

--- a/Pkmds.Rcl/Services/AppService.cs
+++ b/Pkmds.Rcl/Services/AppService.cs
@@ -851,6 +851,8 @@ public class AppService(IAppState appState, IRefreshService refreshService) : IA
         return items;
     }
 
+    public LegalityAnalysis GetLegalityAnalysis(PKM pkm) => new(pkm);
+
     /// <summary>
     /// Compacts a box by shifting all Pokémon left to fill gaps (for Gen 1 and Gen 2 games).
     /// In these generations, boxes were lists, not grids, so they should have no gaps.

--- a/Pkmds.Rcl/Services/IAppService.cs
+++ b/Pkmds.Rcl/Services/IAppService.cs
@@ -275,4 +275,12 @@ public interface IAppService
     ///     Only valid when <paramref name="country"/> is non-zero.
     /// </summary>
     IEnumerable<ComboItem> GetGeoRegionComboItems(byte country);
+
+    /// <summary>
+    ///     Performs a full legality analysis on the given Pokémon using PKHeX.Core's
+    ///     <see cref="LegalityAnalysis"/> engine.
+    /// </summary>
+    /// <param name="pkm">The Pokémon to analyse.</param>
+    /// <returns>A <see cref="LegalityAnalysis"/> result.</returns>
+    LegalityAnalysis GetLegalityAnalysis(PKM pkm);
 }

--- a/Pkmds.Rcl/wwwroot/css/app.css
+++ b/Pkmds.Rcl/wwwroot/css/app.css
@@ -46,6 +46,17 @@ body, html {
     filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.5));
 }
 
+.legality-indicator-icon {
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    width: 16px;
+    height: 16px;
+    pointer-events: none;
+    z-index: 9;
+    filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.5));
+}
+
 .held-item-icon {
     position: absolute;
     bottom: 2px;


### PR DESCRIPTION
## Summary

Implements the core legality checking feature from #328 using PKHeX.Core's `LegalityAnalysis` engine.

- **`IAppService.GetLegalityAnalysis(PKM)`** — thin wrapper around `new LegalityAnalysis(pkm)`, making legality analysis available throughout the app via DI
- **`LegalityTab`** — new edit-form tab showing an overall legal/illegal status alert, a filtered list of individual issues (humanized via `LegalityLocalizationContext`) with severity chips and icons, and an expandable full verbose report
- **Slot indicator** — valid (✅) / warn (⚠️) icon overlay added to `PokemonSlotComponent` for at-a-glance legality status on every filled slot; uses the existing `ac/valid.png` and `ac/warn.png` sprites
- **CSS** — new `.legality-indicator-icon` rule in `app.css` (top-right, 16 × 16 px, below the alpha indicator's z-index)
- **Roadmap** — `PKHEX_PARITY_ROADMAP.md` §1.2 updated from ❌ Not Implemented to ⚠️ Partial

Remaining work (fix suggestions, batch checking, unit tests) is tracked in #401, #402, and #403.

## Test plan

- [ ] Load a save file and open the box view — every filled slot should show a green ✅ or red ⚠️ overlay
- [ ] Click a Pokémon and navigate to the **Legality** tab — legal Pokémon shows a green success alert with no issues listed; illegal Pokémon shows a red error alert with a list of labelled issues
- [ ] Expand "Full Legality Report" panel and verify verbose report text is present
- [ ] Verify a known-illegal Pokémon (e.g. wrong ability for its encounter) surfaces the correct `CheckIdentifier` chip (e.g. "Ability")
- [ ] Verify empty slots show no legality overlay
- [ ] `dotnet build Pkmds.Web/Pkmds.Web.csproj -c Debug` — 0 warnings, 0 errors
- [ ] `dotnet test Pkmds.Tests/Pkmds.Tests.csproj -c Release` — all existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)