### PR TITLE
Refactor PKM helper calls and UI formatting

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     </PropertyGroup>
     <ItemGroup>
-        <PackageVersion Include="bUnit" Version="2.5.3"/>
+        <PackageVersion Include="bUnit" Version="2.6.2"/>
         <PackageVersion Include="coverlet.collector" Version="8.0.0"/>
         <PackageVersion Include="FluentAssertions" Version="8.8.0"/>
         <PackageVersion Include="Humanizer" Version="3.0.1"/>

--- a/Pkmds.Core/Extensions/PkmExtensions.cs
+++ b/Pkmds.Core/Extensions/PkmExtensions.cs
@@ -1,13 +1,13 @@
 ﻿namespace Pkmds.Core.Extensions;
 
 /// <summary>
-///     Extension methods for PKM (Pokémon) objects and related types.
-///     Provides utilities for species validation, type handling, markings, moves, shininess, and more.
+/// Extension methods for PKM (Pokémon) objects and related types.
+/// Provides utilities for species validation, type handling, markings, moves, shininess, and more.
 /// </summary>
 public static class PkmExtensions
 {
     /// <summary>
-    ///     Determines whether a species ID is valid (greater than None and less than MAX_COUNT).
+    /// Determines whether a species ID is valid (greater than None and less than MAX_COUNT).
     /// </summary>
     /// <param name="speciesId">The species ID to validate.</param>
     /// <returns>True if the species ID is valid; otherwise, false.</returns>
@@ -15,7 +15,7 @@ public static class PkmExtensions
         speciesId is > (ushort)Species.None and < (ushort)Species.MAX_COUNT;
 
     /// <summary>
-    ///     Determines whether a nullable species ID is valid.
+    /// Determines whether a nullable species ID is valid.
     /// </summary>
     /// <param name="speciesId">The nullable species ID to validate.</param>
     /// <returns>True if the species ID has a value and is valid; otherwise, false.</returns>
@@ -23,14 +23,14 @@ public static class PkmExtensions
         speciesId is { } species && species.IsValidSpecies();
 
     /// <summary>
-    ///     Determines whether a species ID is invalid (inverse of <see cref="IsValidSpecies(ushort)" />).
+    /// Determines whether a species ID is invalid (inverse of <see cref="IsValidSpecies(ushort)" />).
     /// </summary>
     /// <param name="speciesId">The species ID to validate.</param>
     /// <returns>True if the species ID is invalid; otherwise, false.</returns>
     public static bool IsInvalidSpecies(this ushort speciesId) => !speciesId.IsValidSpecies();
 
     /// <summary>
-    ///     Determines whether a nullable species ID is invalid.
+    /// Determines whether a nullable species ID is invalid.
     /// </summary>
     /// <param name="speciesId">The nullable species ID to validate.</param>
     /// <returns>True if the species ID is null or invalid; otherwise, false.</returns>
@@ -39,7 +39,7 @@ public static class PkmExtensions
     extension(PKM pkm)
     {
         /// <summary>
-        ///     Gets the FormArgument value for Pokémon that implement IFormArgument (e.g., Alcremie).
+        /// Gets the FormArgument value for Pokémon that implement IFormArgument (e.g., Alcremie).
         /// </summary>
         /// <param name="valueIfNull">The value to return if the Pokémon doesn't implement IFormArgument.</param>
         /// <returns>The FormArgument value, or the specified default value.</returns>
@@ -47,8 +47,8 @@ public static class PkmExtensions
             (pkm as IFormArgument)?.FormArgument ?? valueIfNull;
 
         /// <summary>
-        ///     Gets the type(s) of this Pokémon, converting Gen 1/2 type IDs to modern equivalents if needed.
-        ///     In Gen 1/2, some type IDs differ from later generations due to the introduction of Dark and Steel types.
+        /// Gets the type(s) of this Pokémon, converting Gen 1/2 type IDs to modern equivalents if needed.
+        /// In Gen 1/2, some type IDs differ from later generations due to the introduction of Dark and Steel types.
         /// </summary>
         /// <returns>A tuple containing the primary and secondary type IDs.</returns>
         public (byte Type1, byte Type2) GetGenerationTypes()
@@ -66,8 +66,8 @@ public static class PkmExtensions
         }
 
         /// <summary>
-        ///     Gets the value of a specific marking for this Pokémon.
-        ///     Different generations use different marking systems (boolean or color-based).
+        /// Gets the value of a specific marking for this Pokémon.
+        /// Different generations use different marking systems (boolean or color-based).
         /// </summary>
         /// <param name="index">The 0-based marking index.</param>
         /// <returns>The marking value (0 for unmarked/false, 1+ for marked/color value).</returns>
@@ -96,7 +96,7 @@ public static class PkmExtensions
         }
 
         /// <summary>
-        ///     Gets the current PP (Power Points) for all four move slots.
+        /// Gets the current PP (Power Points) for all four move slots.
         /// </summary>
         /// <returns>A read-only collection of PP values for moves 1-4.</returns>
         // ReSharper disable once InconsistentNaming
@@ -109,8 +109,8 @@ public static class PkmExtensions
         ]);
 
         /// <summary>
-        ///     Gets the PP Ups (Power Point upgrades) for all four move slots.
-        ///     Each PP Up increases a move's max PP by 20% of its base PP.
+        /// Gets the PP Ups (Power Point upgrades) for all four move slots.
+        /// Each PP Up increases a move's max PP by 20% of its base PP.
         /// </summary>
         /// <returns>A read-only collection of PP Up values (0-3) for moves 1-4.</returns>
         // ReSharper disable once InconsistentNaming
@@ -123,7 +123,7 @@ public static class PkmExtensions
         ]);
 
         /// <summary>
-        ///     Sets the current PP for a specific move slot.
+        /// Sets the current PP for a specific move slot.
         /// </summary>
         /// <param name="moveIndex">The move slot index (0-3).</param>
         /// <param name="pp">The PP value to set (will be clamped to 0 if negative).</param>
@@ -153,7 +153,7 @@ public static class PkmExtensions
         }
 
         /// <summary>
-        ///     Sets the PP Ups for a specific move slot.
+        /// Sets the PP Ups for a specific move slot.
         /// </summary>
         /// <param name="moveIndex">The move slot index (0-3).</param>
         /// <param name="ppUps">The PP Ups value to set (will be clamped to 0 if negative).</param>
@@ -183,8 +183,8 @@ public static class PkmExtensions
         }
 
         /// <summary>
-        ///     Calculates the maximum PP for a move slot based on the move's base PP and PP Ups applied.
-        ///     Formula: maxPP = basePP + (basePP * ppUps / 5)
+        /// Calculates the maximum PP for a move slot based on the move's base PP and PP Ups applied.
+        /// Formula: maxPP = basePP + (basePP * ppUps / 5)
         /// </summary>
         /// <param name="moveIndex">The move slot index (0-3).</param>
         /// <returns>The maximum PP for the move.</returns>
@@ -200,9 +200,9 @@ public static class PkmExtensions
         }
 
         /// <summary>
-        ///     Gets a specific relearn move by index.
-        ///     Relearn moves are available in Gen 6+ and represent moves a Pokémon can relearn.
-        ///     For pre-Gen 6 Pokemon, the properties exist but will typically be 0.
+        /// Gets a specific relearn move by index.
+        /// Relearn moves are available in Gen 6+ and represent moves a Pokémon can relearn.
+        /// For pre-Gen 6 Pokemon, the properties exist but will typically be 0.
         /// </summary>
         /// <param name="index">The relearn move slot index (0-3).</param>
         /// <returns>The move ID, or 0 if the index is invalid.</returns>
@@ -224,8 +224,8 @@ public static class PkmExtensions
         }
 
         /// <summary>
-        ///     Sets a specific relearn move by index.
-        ///     Relearn moves are available in Gen 6+ and represent moves a Pokémon can relearn.
+        /// Sets a specific relearn move by index.
+        /// Relearn moves are available in Gen 6+ and represent moves a Pokémon can relearn.
         /// </summary>
         /// <param name="index">The relearn move slot index (0-3).</param>
         /// <param name="move">The move ID to set.</param>
@@ -254,7 +254,7 @@ public static class PkmExtensions
         }
 
         /// <summary>
-        ///     Gets all relearn moves as a read-only collection.
+        /// Gets all relearn moves as a read-only collection.
         /// </summary>
         /// <returns>A read-only collection of the four relearn move IDs.</returns>
         public ReadOnlyCollection<ushort> GetRelearnMoves() => new(
@@ -266,15 +266,15 @@ public static class PkmExtensions
         ]);
 
         /// <summary>
-        ///     Determines if the Pokémon supports relearn moves (Gen 6+).
+        /// Determines if the Pokémon supports relearn moves (Gen 6+).
         /// </summary>
         /// <returns>True if the Pokémon has relearn move properties; otherwise, false.</returns>
         public bool HasRelearnMoves() => pkm.Format >= 6;
 
         /// <summary>
-        ///     Safely determines if the Pokémon is shiny, handling both Gen 1/2 (DV-based) and Gen 3+ (PID-based) shininess.
-        ///     In Gen 1/2, shininess is determined by specific DV (Determinant Value) patterns.
-        ///     In Gen 3+, shininess is determined by the PID (Personality ID) and trainer IDs.
+        /// Safely determines if the Pokémon is shiny, handling both Gen 1/2 (DV-based) and Gen 3+ (PID-based) shininess.
+        /// In Gen 1/2, shininess is determined by specific DV (Determinant Value) patterns.
+        /// In Gen 3+, shininess is determined by the PID (Personality ID) and trainer IDs.
         /// </summary>
         /// <returns>True if the Pokémon is shiny; otherwise, false.</returns>
         public bool GetIsShinySafe()
@@ -299,9 +299,9 @@ public static class PkmExtensions
         }
 
         /// <summary>
-        ///     Safely sets the shininess of the Pokémon, handling both Gen 1/2 and Gen 3+ mechanics.
-        ///     For Gen 3+, uses PKHeX.Core's SetIsShiny method.
-        ///     For Gen 1/2, randomizes IVs until the desired shininess is achieved.
+        /// Safely sets the shininess of the Pokémon, handling both Gen 1/2 and Gen 3+ mechanics.
+        /// For Gen 3+, uses PKHeX.Core's SetIsShiny method.
+        /// For Gen 1/2, randomizes IVs until the desired shininess is achieved.
         /// </summary>
         /// <param name="shiny">True to make the Pokémon shiny; false to make it non-shiny.</param>
         public void SetIsShinySafe(bool shiny)

--- a/Pkmds.Core/Pkmds.Core.csproj
+++ b/Pkmds.Core/Pkmds.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <ItemGroup>
-    <PackageReference Include="PKHeX.Core"/>
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="PKHeX.Core"/>
+    </ItemGroup>
 
 </Project>

--- a/Pkmds.Core/Utilities/GameInfoUtilities.cs
+++ b/Pkmds.Core/Utilities/GameInfoUtilities.cs
@@ -1,12 +1,12 @@
 ﻿namespace Pkmds.Core.Utilities;
 
 /// <summary>
-///     Utility methods for working with PKHeX GameInfo data.
+/// Utility methods for working with PKHeX GameInfo data.
 /// </summary>
 public static class GameInfoUtilities
 {
     /// <summary>
-    ///     Gets the localized name of a move category (Status, Physical, or Special).
+    /// Gets the localized name of a move category (Status, Physical, or Special).
     /// </summary>
     /// <param name="categoryId">The category ID (0 = Status, 1 = Physical, 2 = Special).</param>
     /// <returns>The category name, or "Unknown" if the ID is not recognized.</returns>

--- a/Pkmds.Core/Utilities/MarkingsHelper.cs
+++ b/Pkmds.Core/Utilities/MarkingsHelper.cs
@@ -1,14 +1,14 @@
 ﻿namespace Pkmds.Core.Utilities;
 
 /// <summary>
-///     Helper class for working with Pokémon markings.
-///     Provides enum definitions and unicode symbols for the six marking shapes.
+/// Helper class for working with Pokémon markings.
+/// Provides enum definitions and unicode symbols for the six marking shapes.
 /// </summary>
 public static class MarkingsHelper
 {
     /// <summary>
-    ///     Enum representing the six types of Pokémon markings.
-    ///     Used for organizing and categorizing Pokémon in the PC.
+    /// Enum representing the six types of Pokémon markings.
+    /// Used for organizing and categorizing Pokémon in the PC.
     /// </summary>
     public enum Markings
     {

--- a/Pkmds.Rcl/Components/Dialogs/MoveShopDialog.razor
+++ b/Pkmds.Rcl/Components/Dialogs/MoveShopDialog.razor
@@ -15,14 +15,17 @@
                          Height="500px"
                          FixedHeader>
                 <Columns>
-                    <PropertyColumn Property="@(x => x.Index)" Title="#"/>
+                    <PropertyColumn Property="@(x => x.Index)"
+                                    Title="#"/>
                     <TemplateColumn Title="">
                         <CellTemplate>
                             @MoveTypeSummary(context.Item.Type)
                         </CellTemplate>
                     </TemplateColumn>
-                    <PropertyColumn Property="@(x => x.Name)" Title="Move"/>
-                    <TemplateColumn Title="Purchased" Sortable="false">
+                    <PropertyColumn Property="@(x => x.Name)"
+                                    Title="Move"/>
+                    <TemplateColumn Title="Purchased"
+                                    Sortable="false">
                         <CellTemplate>
                             <MudCheckBox T="@bool"
                                          Value="@context.Item.IsPurchased"
@@ -32,7 +35,8 @@
                     </TemplateColumn>
                     @if (Pokemon is IMoveShop8Mastery)
                     {
-                        <TemplateColumn Title="Mastered" Sortable="false">
+                        <TemplateColumn Title="Mastered"
+                                        Sortable="false">
                             <CellTemplate>
                                 <MudCheckBox T="@bool"
                                              Value="@context.Item.IsMastered"

--- a/Pkmds.Rcl/Components/Dialogs/PidEcDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/PidEcDialog.razor.cs
@@ -25,7 +25,7 @@ public partial class PidEcDialog
         var pid = EntityPID.GetRandomPID(
             Random.Shared,
             Pokemon.Species,
-            (byte)Pokemon.Gender,
+            Pokemon.Gender,
             Pokemon.Version,
             Pokemon.Nature,
             Pokemon.Form,
@@ -43,7 +43,7 @@ public partial class PidEcDialog
             return;
         }
 
-        CommonEdits.SetIsShiny(Pokemon, true);
+        Pokemon.SetIsShiny(true);
         RefreshService.Refresh();
     }
 
@@ -54,7 +54,7 @@ public partial class PidEcDialog
             return;
         }
 
-        Pokemon.SetPIDGender((byte)Pokemon.Gender);
+        Pokemon.SetPIDGender(Pokemon.Gender);
         AppService.LoadPokemonStats(Pokemon);
         RefreshService.Refresh();
     }
@@ -95,7 +95,7 @@ public partial class PidEcDialog
                 var iv1 = LCRNG.Next15(ref seed);
                 LCRNG.Next16(ref seed); // skip one frame between IV halves
                 var iv2 = LCRNG.Next15(ref seed);
-                ivs = iv1 | (iv2 << 15);
+                ivs = iv1 | iv2 << 15;
                 break;
             default:
                 return;
@@ -114,7 +114,7 @@ public partial class PidEcDialog
             return;
         }
 
-        CommonEdits.SetRandomEC(Pokemon);
+        Pokemon.SetRandomEC();
         AppService.LoadPokemonStats(Pokemon);
         RefreshService.Refresh();
     }
@@ -126,7 +126,7 @@ public partial class PidEcDialog
             return;
         }
 
-        CommonEdits.SetShiny(Pokemon, SelectedShinyType);
+        Pokemon.SetShiny(SelectedShinyType);
         RefreshService.Refresh();
     }
 

--- a/Pkmds.Rcl/Components/Dialogs/PlusFlagsDialog.razor
+++ b/Pkmds.Rcl/Components/Dialogs/PlusFlagsDialog.razor
@@ -15,7 +15,8 @@
                          Height="500px"
                          FixedHeader>
                 <Columns>
-                    <TemplateColumn Title="" Sortable="false">
+                    <TemplateColumn Title=""
+                                    Sortable="false">
                         <CellTemplate>
                             <MudCheckBox T="@bool"
                                          Value="@context.Item.IsPlus"
@@ -23,13 +24,15 @@
                                          Dense/>
                         </CellTemplate>
                     </TemplateColumn>
-                    <PropertyColumn Property="@(x => x.Index)" Title="#"/>
+                    <PropertyColumn Property="@(x => x.Index)"
+                                    Title="#"/>
                     <TemplateColumn Title="">
                         <CellTemplate>
                             @MoveTypeSummary(context.Item.Type)
                         </CellTemplate>
                     </TemplateColumn>
-                    <PropertyColumn Property="@(x => x.Name)" Title="Move"/>
+                    <PropertyColumn Property="@(x => x.Name)"
+                                    Title="Move"/>
                 </Columns>
             </MudDataGrid>
         }

--- a/Pkmds.Rcl/Components/Dialogs/RelearnFlagsDialog.razor
+++ b/Pkmds.Rcl/Components/Dialogs/RelearnFlagsDialog.razor
@@ -15,7 +15,8 @@
                          Height="500px"
                          FixedHeader>
                 <Columns>
-                    <TemplateColumn Title="" Sortable="false">
+                    <TemplateColumn Title=""
+                                    Sortable="false">
                         <CellTemplate>
                             <MudCheckBox T="@bool"
                                          Value="@context.Item.IsLearned"
@@ -23,13 +24,15 @@
                                          Dense/>
                         </CellTemplate>
                     </TemplateColumn>
-                    <PropertyColumn Property="@(x => x.Index)" Title="#"/>
+                    <PropertyColumn Property="@(x => x.Index)"
+                                    Title="#"/>
                     <TemplateColumn Title="">
                         <CellTemplate>
                             @MoveTypeSummary(context.Item.Type)
                         </CellTemplate>
                     </TemplateColumn>
-                    <PropertyColumn Property="@(x => x.Name)" Title="Move"/>
+                    <PropertyColumn Property="@(x => x.Name)"
+                                    Title="Move"/>
                 </Columns>
             </MudDataGrid>
         }

--- a/Pkmds.Rcl/Components/EditForms/PokemonEditForm.razor.cs
+++ b/Pkmds.Rcl/Components/EditForms/PokemonEditForm.razor.cs
@@ -98,10 +98,7 @@ public partial class PokemonEditForm : IDisposable
             var parameters = new DialogParameters
             {
                 { nameof(ConfirmActionDialog.Title), "Paste Pokémon" },
-                {
-                    nameof(ConfirmActionDialog.Message),
-                    "Are you sure you want to paste the copied Pokémon? The Pokémon in the selected slot will be replaced."
-                },
+                { nameof(ConfirmActionDialog.Message), "Are you sure you want to paste the copied Pokémon? The Pokémon in the selected slot will be replaced." },
                 { nameof(ConfirmActionDialog.ConfirmText), "Paste" },
                 { nameof(ConfirmActionDialog.ConfirmIcon), Icons.Material.Filled.ContentPaste },
                 { nameof(ConfirmActionDialog.ConfirmColor), Color.Default },

--- a/Pkmds.Rcl/Components/EditForms/Tabs/ContestStatsTab.razor.cs
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/ContestStatsTab.razor.cs
@@ -2,11 +2,11 @@ namespace Pkmds.Rcl.Components.EditForms.Tabs;
 
 public partial class ContestStatsTab : IDisposable
 {
+    private const byte ContestStatMax = byte.MaxValue;
+
     [Parameter]
     [EditorRequired]
     public PKM? Pokemon { get; set; }
-
-    private const byte ContestStatMax = byte.MaxValue;
 
     public void Dispose() =>
         RefreshService.OnAppStateChanged -= StateHasChanged;

--- a/Pkmds.Rcl/Components/EditForms/Tabs/LegalityTab.razor
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/LegalityTab.razor
@@ -7,9 +7,15 @@
     {
         <MudStack Class="pa-2">
 
-            <MudAlert Severity="@(IsLegal ? MudBlazor.Severity.Success : MudBlazor.Severity.Error)"
-                      Icon="@(IsLegal ? Icons.Material.Filled.CheckCircle : Icons.Material.Filled.Cancel)">
-                @(IsLegal ? "This Pokémon is legal." : "This Pokémon has legality issues.")
+            <MudAlert Severity="@(IsLegal
+                                    ? Severity.Success
+                                    : Severity.Error)"
+                      Icon="@(IsLegal
+                                ? Icons.Material.Filled.CheckCircle
+                                : Icons.Material.Filled.Cancel)">
+                @(IsLegal
+                    ? "This Pokémon is legal."
+                    : "This Pokémon has legality issues.")
             </MudAlert>
 
             @{
@@ -20,16 +26,21 @@
 
             @if (issues.Count > 0)
             {
-                <MudText Typo="@Typo.subtitle2" Class="mt-2">Issues (@issues.Count)</MudText>
+                <MudText Typo="@Typo.subtitle2"
+                         Class="mt-2">Issues (@issues.Count)
+                </MudText>
 
-                <MudList T="CheckResult" Dense>
+                <MudList T="CheckResult"
+                         Dense>
                     @foreach (var result in issues)
                     {
                         <MudListItem T="CheckResult"
                                      Icon="@GetSeverityIcon(result.Judgement)"
                                      IconColor="@GetSeverityColor(result.Judgement)"
                                      @key="@($"{result.Identifier}:{result.Result}")">
-                            <MudStack Row AlignItems="@AlignItems.Center" Spacing="1">
+                            <MudStack Row
+                                      AlignItems="@AlignItems.Center"
+                                      Spacing="1">
                                 <MudChip T="string"
                                          Size="@Size.Small"
                                          Color="@GetSeverityColor(result.Judgement)"
@@ -45,8 +56,12 @@
 
             @if (HasRibbonIssues || HasMoveIssues || HasRelearnMoveIssues || HasBallIssues || HasMetLocationIssues)
             {
-                <MudText Typo="@Typo.subtitle2" Class="mt-2">Quick Fixes</MudText>
-                <MudStack Row Wrap="@Wrap.Wrap" Spacing="1">
+                <MudText Typo="@Typo.subtitle2"
+                         Class="mt-2">Quick Fixes
+                </MudText>
+                <MudStack Row
+                          Wrap="@Wrap.Wrap"
+                          Spacing="1">
                     @if (HasBallIssues)
                     {
                         <MudButton Variant="@Variant.Outlined"
@@ -120,6 +135,8 @@
     }
     else
     {
-        <MudText Class="pa-2" Color="@Color.Default">No Pokémon selected.</MudText>
+        <MudText Class="pa-2"
+                 Color="@Color.Default">No Pokémon selected.
+        </MudText>
     }
 }

--- a/Pkmds.Rcl/Components/EditForms/Tabs/LegalityTab.razor.cs
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/LegalityTab.razor.cs
@@ -13,29 +13,29 @@ public partial class LegalityTab : IDisposable
     // Moves are validated in la.Info.Moves / la.Info.Relearn (MoveResult[]), not in la.Results.
     // A legal Pokémon must have all of those valid in addition to all CheckResults being valid.
     private bool IsLegal => Analysis is { } la
-        && la.Results.All(r => r.Valid)
-        && MoveResult.AllValid(la.Info.Moves)
-        && MoveResult.AllValid(la.Info.Relearn);
+                            && la.Results.All(r => r.Valid)
+                            && MoveResult.AllValid(la.Info.Moves)
+                            && MoveResult.AllValid(la.Info.Relearn);
 
     private bool HasRibbonIssues => Analysis is { } la &&
-        la.Results.Any(r => !r.Valid && r.Identifier is CheckIdentifier.Ribbon or CheckIdentifier.RibbonMark);
+                                    la.Results.Any(r => !r.Valid && r.Identifier is CheckIdentifier.Ribbon or CheckIdentifier.RibbonMark);
 
     private bool HasMoveIssues => Analysis is { } la &&
-        (!MoveResult.AllValid(la.Info.Moves) ||
-         la.Results.Any(r => !r.Valid && r.Identifier is CheckIdentifier.CurrentMove));
+                                  (!MoveResult.AllValid(la.Info.Moves) ||
+                                   la.Results.Any(r => !r.Valid && r.Identifier is CheckIdentifier.CurrentMove));
 
     private bool HasRelearnMoveIssues => Analysis is { } la &&
-        (!MoveResult.AllValid(la.Info.Relearn) ||
-         la.Results.Any(r => !r.Valid && r.Identifier is CheckIdentifier.RelearnMove));
+                                         (!MoveResult.AllValid(la.Info.Relearn) ||
+                                          la.Results.Any(r => !r.Valid && r.Identifier is CheckIdentifier.RelearnMove));
 
     private bool HasBallIssues => Analysis is { } la &&
-        la.Results.Any(r => !r.Valid && r.Identifier is CheckIdentifier.Ball);
+                                  la.Results.Any(r => !r.Valid && r.Identifier is CheckIdentifier.Ball);
 
     private bool HasEncounterIssues => Analysis is { } la &&
-        la.Results.Any(r => !r.Valid && r.Identifier is CheckIdentifier.Encounter);
+                                       la.Results.Any(r => !r.Valid && r.Identifier is CheckIdentifier.Encounter);
 
     private bool HasMetLocationIssues => Analysis is { } la &&
-        la.Results.Any(r => !r.Valid && r.Identifier is CheckIdentifier.Level or CheckIdentifier.Encounter);
+                                         la.Results.Any(r => !r.Valid && r.Identifier is CheckIdentifier.Level or CheckIdentifier.Encounter);
 
     public void Dispose() =>
         RefreshService.OnAppStateChanged -= Refresh;
@@ -69,7 +69,7 @@ public partial class LegalityTab : IDisposable
         var args = new RibbonVerifierArguments(Pokemon, la.EncounterMatch, la.Info.EvoChainsAllGens);
         RibbonApplicator.FixInvalidRibbons(in args);
         RefreshService.Refresh();
-        Snackbar.Add("Invalid ribbons removed. Click Save to apply changes.", MudBlazor.Severity.Success);
+        Snackbar.Add("Invalid ribbons removed. Click Save to apply changes.", Severity.Success);
     }
 
     private void AddValidRibbons()
@@ -81,7 +81,7 @@ public partial class LegalityTab : IDisposable
 
         RibbonApplicator.SetAllValidRibbons(la);
         RefreshService.Refresh();
-        Snackbar.Add("All obtainable ribbons added. Click Save to apply changes.", MudBlazor.Severity.Success);
+        Snackbar.Add("All obtainable ribbons added. Click Save to apply changes.", Severity.Success);
     }
 
     private void SuggestMoves()
@@ -91,7 +91,7 @@ public partial class LegalityTab : IDisposable
             return;
         }
 
-        MoveSetApplicator.SetMoveset(Pokemon, random: false);
+        Pokemon.SetMoveset(random: false);
 
         // Update Technical Records (Gen 8+ SwSh / SV / ZA) to reflect the new moves,
         // mirroring PKMEditor's SetSuggestedMoves behaviour.
@@ -103,7 +103,7 @@ public partial class LegalityTab : IDisposable
         }
 
         RefreshService.Refresh();
-        Snackbar.Add("Moves updated with a legal move set. Click Save to apply changes.", MudBlazor.Severity.Success);
+        Snackbar.Add("Moves updated with a legal move set. Click Save to apply changes.", Severity.Success);
     }
 
     private void SuggestRelearnMoves()
@@ -113,9 +113,9 @@ public partial class LegalityTab : IDisposable
             return;
         }
 
-        MoveSetApplicator.SetRelearnMoves(Pokemon, la);
+        Pokemon.SetRelearnMoves(la);
         RefreshService.Refresh();
-        Snackbar.Add("Relearn moves updated. Click Save to apply changes.", MudBlazor.Severity.Success);
+        Snackbar.Add("Relearn moves updated. Click Save to apply changes.", Severity.Success);
     }
 
     private void SuggestBall()
@@ -127,7 +127,7 @@ public partial class LegalityTab : IDisposable
 
         BallApplicator.ApplyBallLegalByColor(Pokemon, la, PersonalColorUtil.GetColor(Pokemon));
         RefreshService.Refresh();
-        Snackbar.Add("Ball updated to a legal option. Click Save to apply changes.", MudBlazor.Severity.Success);
+        Snackbar.Add("Ball updated to a legal option. Click Save to apply changes.", Severity.Success);
     }
 
     private void SuggestMetLocation()
@@ -140,7 +140,7 @@ public partial class LegalityTab : IDisposable
         var encounter = EncounterSuggestion.GetSuggestedMetInfo(Pokemon);
         if (encounter is null)
         {
-            Snackbar.Add("No met location suggestion is available for this Pokémon.", MudBlazor.Severity.Warning);
+            Snackbar.Add("No met location suggestion is available for this Pokémon.", Severity.Warning);
             return;
         }
 
@@ -172,21 +172,21 @@ public partial class LegalityTab : IDisposable
         }
 
         RefreshService.Refresh();
-        Snackbar.Add("Met location and level updated. Click Save to apply changes.", MudBlazor.Severity.Success);
+        Snackbar.Add("Met location and level updated. Click Save to apply changes.", Severity.Success);
     }
 
     private static Color GetSeverityColor(PKHexSeverity severity) => severity switch
     {
         PKHexSeverity.Valid => Color.Success,
         PKHexSeverity.Fishy => Color.Warning,
-        _ => Color.Error,
+        _ => Color.Error
     };
 
     private static string GetSeverityIcon(PKHexSeverity severity) => severity switch
     {
         PKHexSeverity.Valid => Icons.Material.Filled.CheckCircle,
         PKHexSeverity.Fishy => Icons.Material.Filled.Warning,
-        _ => Icons.Material.Filled.Cancel,
+        _ => Icons.Material.Filled.Cancel
     };
 
     private static string GetIdentifierLabel(CheckIdentifier id) => id switch
@@ -225,7 +225,7 @@ public partial class LegalityTab : IDisposable
         CheckIdentifier.TrashBytes => "Trash Bytes",
         CheckIdentifier.SlotType => "Slot Type",
         CheckIdentifier.Handler => "Handler",
-        _ => id.ToString(),
+        _ => id.ToString()
     };
 
     private string HumanizeResult(CheckResult result)
@@ -235,7 +235,7 @@ public partial class LegalityTab : IDisposable
             return result.Result.ToString();
         }
 
-        var ctx = LegalityLocalizationContext.Create(la, "en");
+        var ctx = LegalityLocalizationContext.Create(la);
         return ctx.Humanize(in result, verbose: false);
     }
 }

--- a/Pkmds.Rcl/Components/EditForms/Tabs/MainTab.razor.cs
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/MainTab.razor.cs
@@ -116,10 +116,7 @@ public partial class MainTab : IDisposable
     {
         var parameters = new DialogParameters<PidEcDialog> { { x => x.Pokemon, Pokemon } };
 
-        var options = new DialogOptions
-        {
-            MaxWidth = MaxWidth.Small, FullWidth = true, CloseButton = true, CloseOnEscapeKey = true
-        };
+        var options = new DialogOptions { MaxWidth = MaxWidth.Small, FullWidth = true, CloseButton = true, CloseOnEscapeKey = true };
 
         await DialogService.ShowAsync<PidEcDialog>("PID / EC Generator", parameters, options);
     }
@@ -213,7 +210,7 @@ public partial class MainTab : IDisposable
         // not flagged before the user has had a chance to fix anything.
         if (Pokemon.EncryptionConstant == 0)
         {
-            CommonEdits.SetRandomEC(Pokemon);
+            Pokemon.SetRandomEC();
         }
 
         AppService.LoadPokemonStats(Pokemon);

--- a/Pkmds.Rcl/Components/EditForms/Tabs/MetTab.razor.cs
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/MetTab.razor.cs
@@ -9,7 +9,7 @@ public partial class MetTab : IDisposable
     private EntityContext originFormat = EntityContext.None;
 
     /// <summary>
-    ///     Currently loaded met location group that is populating Met and Egg location comboboxes
+    /// Currently loaded met location group that is populating Met and Egg location comboboxes
     /// </summary>
     private GameVersion origintrack;
 

--- a/Pkmds.Rcl/Components/EditForms/Tabs/MovesTab.razor.cs
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/MovesTab.razor.cs
@@ -137,10 +137,7 @@ public partial class MovesTab
     {
         var parameters = new DialogParameters<RelearnFlagsDialog> { { x => x.Pokemon, Pokemon } };
 
-        var options = new DialogOptions
-        {
-            MaxWidth = MaxWidth.Small, FullWidth = true, CloseButton = true, CloseOnEscapeKey = true
-        };
+        var options = new DialogOptions { MaxWidth = MaxWidth.Small, FullWidth = true, CloseButton = true, CloseOnEscapeKey = true };
 
         await DialogService.ShowAsync<RelearnFlagsDialog>("TR Relearn Editor", parameters, options);
     }
@@ -149,10 +146,7 @@ public partial class MovesTab
     {
         var parameters = new DialogParameters<PlusFlagsDialog> { { x => x.Pokemon, Pokemon } };
 
-        var options = new DialogOptions
-        {
-            MaxWidth = MaxWidth.Small, FullWidth = true, CloseButton = true, CloseOnEscapeKey = true
-        };
+        var options = new DialogOptions { MaxWidth = MaxWidth.Small, FullWidth = true, CloseButton = true, CloseOnEscapeKey = true };
 
         await DialogService.ShowAsync<PlusFlagsDialog>("Plus Flags Editor", parameters, options);
     }
@@ -161,10 +155,7 @@ public partial class MovesTab
     {
         var parameters = new DialogParameters<MoveShopDialog> { { x => x.Pokemon, Pokemon } };
 
-        var options = new DialogOptions
-        {
-            MaxWidth = MaxWidth.Small, FullWidth = true, CloseButton = true, CloseOnEscapeKey = true
-        };
+        var options = new DialogOptions { MaxWidth = MaxWidth.Small, FullWidth = true, CloseButton = true, CloseOnEscapeKey = true };
 
         await DialogService.ShowAsync<MoveShopDialog>("Move Shop Editor", parameters, options);
     }

--- a/Pkmds.Rcl/Components/EditForms/Tabs/OtMiscTab.razor
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/OtMiscTab.razor
@@ -74,7 +74,7 @@
             <MudTextField Label="OT"
                           Variant="@Variant.Outlined"
                           Text="@Pokemon.OriginalTrainerName"
-                          TextChanged="SetPokemonOTName"
+                          TextChanged="SetPokemonOtName"
                           MaxLength="@saveFile.MaxStringLengthTrainer"
                           For="@(() => Pokemon.OriginalTrainerName)"/>
         </MudItem>
@@ -167,7 +167,8 @@
             <MudItem xs="12">
                 <MudDivider Class="my-2"/>
                 <MudText Typo="@Typo.subtitle2"
-                         Class="mt-1 mb-1">Latest (Not OT) Handler</MudText>
+                         Class="mt-1 mb-1">Latest (Not OT) Handler
+                </MudText>
             </MudItem>
 
             <MudItem xs="6"
@@ -195,7 +196,8 @@
                                ValueChanged="@(v => htLang.HandlingTrainerLanguage = v)">
                         @foreach (var item in AppService.GetLanguageComboItems(saveGeneration, saveFile.Context))
                         {
-                            <MudSelectItem T="byte" Value="@((byte)item.Value)">@item.Text</MudSelectItem>
+                            <MudSelectItem T="byte"
+                                           Value="@((byte)item.Value)">@item.Text</MudSelectItem>
                         }
                     </MudSelect>
                 </MudItem>
@@ -310,8 +312,12 @@
                            Variant="@Variant.Outlined"
                            Value="@Pokemon.CurrentHandler"
                            ValueChanged="@(v => Pokemon.CurrentHandler = v)">
-                    <MudSelectItem T="byte" Value="@((byte)0)">OT</MudSelectItem>
-                    <MudSelectItem T="byte" Value="@((byte)1)">HT</MudSelectItem>
+                    <MudSelectItem T="byte"
+                                   Value="@((byte)0)">OT
+                    </MudSelectItem>
+                    <MudSelectItem T="byte"
+                                   Value="@((byte)1)">HT
+                    </MudSelectItem>
                 </MudSelect>
             </MudItem>
         }
@@ -336,7 +342,8 @@
             <MudItem xs="12">
                 <MudDivider Class="my-2"/>
                 <MudText Typo="@Typo.subtitle2"
-                         Class="mt-1 mb-1">OT Memory</MudText>
+                         Class="mt-1 mb-1">OT Memory
+                </MudText>
             </MudItem>
 
             <MudItem xs="12">
@@ -349,7 +356,8 @@
                            ValueChanged="@(v => otMemory.OriginalTrainerMemory = v)">
                     @foreach (var item in CachedMemoryItems)
                     {
-                        <MudSelectItem T="byte" Value="@((byte)item.Value)">@item.Text</MudSelectItem>
+                        <MudSelectItem T="byte"
+                                       Value="@((byte)item.Value)">@item.Text</MudSelectItem>
                     }
                 </MudSelect>
             </MudItem>
@@ -366,7 +374,8 @@
                                ValueChanged="@(v => otMemory.OriginalTrainerMemoryVariable = v)">
                         @foreach (var item in otArgItems)
                         {
-                            <MudSelectItem T="ushort" Value="@((ushort)item.Value)">@item.Text</MudSelectItem>
+                            <MudSelectItem T="ushort"
+                                           Value="@((ushort)item.Value)">@item.Text</MudSelectItem>
                         }
                     </MudSelect>
                 </MudItem>
@@ -382,7 +391,8 @@
                            ValueChanged="@(v => otMemory.OriginalTrainerMemoryIntensity = v)">
                     @foreach (var item in CachedQualityItems)
                     {
-                        <MudSelectItem T="byte" Value="@((byte)item.Value)">@item.Text</MudSelectItem>
+                        <MudSelectItem T="byte"
+                                       Value="@((byte)item.Value)">@item.Text</MudSelectItem>
                     }
                 </MudSelect>
             </MudItem>
@@ -397,7 +407,8 @@
                            ValueChanged="@(v => otMemory.OriginalTrainerMemoryFeeling = v)">
                     @foreach (var item in CachedFeelingItems)
                     {
-                        <MudSelectItem T="byte" Value="@((byte)item.Value)">@item.Text</MudSelectItem>
+                        <MudSelectItem T="byte"
+                                       Value="@((byte)item.Value)">@item.Text</MudSelectItem>
                     }
                 </MudSelect>
             </MudItem>
@@ -444,7 +455,8 @@
             <MudItem xs="12">
                 <MudDivider Class="my-2"/>
                 <MudText Typo="@Typo.subtitle2"
-                         Class="mt-1 mb-1">HT Memory</MudText>
+                         Class="mt-1 mb-1">HT Memory
+                </MudText>
             </MudItem>
 
             <MudItem xs="12">
@@ -457,7 +469,8 @@
                            ValueChanged="@(v => htMemory.HandlingTrainerMemory = v)">
                     @foreach (var item in CachedMemoryItems)
                     {
-                        <MudSelectItem T="byte" Value="@((byte)item.Value)">@item.Text</MudSelectItem>
+                        <MudSelectItem T="byte"
+                                       Value="@((byte)item.Value)">@item.Text</MudSelectItem>
                     }
                 </MudSelect>
             </MudItem>
@@ -474,7 +487,8 @@
                                ValueChanged="@(v => htMemory.HandlingTrainerMemoryVariable = v)">
                         @foreach (var item in htArgItems)
                         {
-                            <MudSelectItem T="ushort" Value="@((ushort)item.Value)">@item.Text</MudSelectItem>
+                            <MudSelectItem T="ushort"
+                                           Value="@((ushort)item.Value)">@item.Text</MudSelectItem>
                         }
                     </MudSelect>
                 </MudItem>
@@ -490,7 +504,8 @@
                            ValueChanged="@(v => htMemory.HandlingTrainerMemoryIntensity = v)">
                     @foreach (var item in CachedQualityItems)
                     {
-                        <MudSelectItem T="byte" Value="@((byte)item.Value)">@item.Text</MudSelectItem>
+                        <MudSelectItem T="byte"
+                                       Value="@((byte)item.Value)">@item.Text</MudSelectItem>
                     }
                 </MudSelect>
             </MudItem>
@@ -505,7 +520,8 @@
                            ValueChanged="@(v => htMemory.HandlingTrainerMemoryFeeling = v)">
                     @foreach (var item in CachedFeelingItems)
                     {
-                        <MudSelectItem T="byte" Value="@((byte)item.Value)">@item.Text</MudSelectItem>
+                        <MudSelectItem T="byte"
+                                       Value="@((byte)item.Value)">@item.Text</MudSelectItem>
                     }
                 </MudSelect>
             </MudItem>
@@ -540,7 +556,8 @@
             <MudItem xs="12">
                 <MudDivider Class="my-2"/>
                 <MudText Typo="@Typo.subtitle2"
-                         Class="mt-1 mb-1">Geo Locations</MudText>
+                         Class="mt-1 mb-1">Geo Locations
+                </MudText>
             </MudItem>
 
             @for (var geoSlot = 1; geoSlot <= 5; geoSlot++)
@@ -550,8 +567,12 @@
                 var slotRegions = slotCountry != 0
                     ? AppService.GetGeoRegionComboItems(slotCountry).ToList()
                     : null;
-                var slotLabel = slotIndex == 1 ? "Latest Country" : $"Past Country {slotIndex - 1}";
-                var regionLabel = slotIndex == 1 ? "Latest Region" : $"Past Region {slotIndex - 1}";
+                var slotLabel = slotIndex == 1
+                    ? "Latest Country"
+                    : $"Past Country {slotIndex - 1}";
+                var regionLabel = slotIndex == 1
+                    ? "Latest Region"
+                    : $"Past Region {slotIndex - 1}";
 
                 <MudItem xs="6"
                          Class="@ColumnClass">
@@ -564,7 +585,8 @@
                                ValueChanged="@(v => SetGeoCountry(geoTrack, slotIndex, v))">
                         @foreach (var item in countries)
                         {
-                            <MudSelectItem T="byte" Value="@((byte)item.Value)">@item.Text</MudSelectItem>
+                            <MudSelectItem T="byte"
+                                           Value="@((byte)item.Value)">@item.Text</MudSelectItem>
                         }
                     </MudSelect>
                 </MudItem>
@@ -582,7 +604,8 @@
                                    ValueChanged="@(v => SetGeoRegion(geoTrack, slotIndex, v))">
                             @foreach (var item in slotRegions)
                             {
-                                <MudSelectItem T="byte" Value="@((byte)item.Value)">@item.Text</MudSelectItem>
+                                <MudSelectItem T="byte"
+                                               Value="@((byte)item.Value)">@item.Text</MudSelectItem>
                             }
                         </MudSelect>
                     </MudItem>

--- a/Pkmds.Rcl/Components/EditForms/Tabs/OtMiscTab.razor.cs
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/OtMiscTab.razor.cs
@@ -2,48 +2,6 @@ namespace Pkmds.Rcl.Components.EditForms.Tabs;
 
 public partial class OtMiscTab : IDisposable
 {
-    [Parameter]
-    [EditorRequired]
-    public PKM? Pokemon { get; set; }
-
-    private List<ComboItem>? CachedMemoryItems { get; set; }
-    private List<ComboItem>? CachedFeelingItems { get; set; }
-    private List<ComboItem>? CachedQualityItems { get; set; }
-
-    public void Dispose() =>
-        RefreshService.OnAppStateChanged -= StateHasChanged;
-
-    protected override void OnInitialized() =>
-        RefreshService.OnAppStateChanged += StateHasChanged;
-
-    protected override void OnParametersSet()
-    {
-        base.OnParametersSet();
-
-        if (Pokemon is IMemoryOT or IMemoryHT)
-        {
-            CachedMemoryItems = AppService.GetMemoryComboItems().ToList();
-            CachedFeelingItems = AppService.GetMemoryFeelingComboItems(MemoryGen).ToList();
-            CachedQualityItems = AppService.GetMemoryQualityComboItems().ToList();
-        }
-        else
-        {
-            CachedMemoryItems = null;
-            CachedFeelingItems = null;
-            CachedQualityItems = null;
-        }
-    }
-
-    /// <summary>
-    ///     Returns the memory generation (6 or 8) used for feeling/argument lookups.
-    ///     Gen 6/7 Pokémon use generation 6 memory sets; Gen 8+ use generation 8 memory sets.
-    /// </summary>
-    private int MemoryGen => Pokemon?.Context switch
-    {
-        EntityContext.Gen6 or EntityContext.Gen7 => 6,
-        _ => 8,
-    };
-
     // Memory ID → MemoryArgType mapping (based on PKHeX.Core memory text format strings)
     private static readonly MemoryArgType[] MemoryArgTypes =
     [
@@ -82,11 +40,55 @@ public partial class OtMiscTab : IDisposable
         // 80-89
         MemoryArgType.Move, MemoryArgType.Move, MemoryArgType.Species, MemoryArgType.Species,
         MemoryArgType.Item, MemoryArgType.None, MemoryArgType.GeneralLocation, MemoryArgType.Species,
-        MemoryArgType.Item, MemoryArgType.Move,
+        MemoryArgType.Item, MemoryArgType.Move
     ];
 
+    [Parameter]
+    [EditorRequired]
+    public PKM? Pokemon { get; set; }
+
+    private List<ComboItem>? CachedMemoryItems { get; set; }
+    private List<ComboItem>? CachedFeelingItems { get; set; }
+    private List<ComboItem>? CachedQualityItems { get; set; }
+
+    /// <summary>
+    /// Returns the memory generation (6 or 8) used for feeling/argument lookups.
+    /// Gen 6/7 Pokémon use generation 6 memory sets; Gen 8+ use generation 8 memory sets.
+    /// </summary>
+    private int MemoryGen => Pokemon?.Context switch
+    {
+        EntityContext.Gen6 or EntityContext.Gen7 => 6,
+        _ => 8
+    };
+
+    public void Dispose() =>
+        RefreshService.OnAppStateChanged -= StateHasChanged;
+
+    protected override void OnInitialized() =>
+        RefreshService.OnAppStateChanged += StateHasChanged;
+
+    protected override void OnParametersSet()
+    {
+        base.OnParametersSet();
+
+        if (Pokemon is IMemoryOT or IMemoryHT)
+        {
+            CachedMemoryItems = AppService.GetMemoryComboItems().ToList();
+            CachedFeelingItems = AppService.GetMemoryFeelingComboItems(MemoryGen).ToList();
+            CachedQualityItems = AppService.GetMemoryQualityComboItems().ToList();
+        }
+        else
+        {
+            CachedMemoryItems = null;
+            CachedFeelingItems = null;
+            CachedQualityItems = null;
+        }
+    }
+
     private static MemoryArgType GetMemoryArgType(byte memoryId) =>
-        memoryId < MemoryArgTypes.Length ? MemoryArgTypes[memoryId] : MemoryArgType.None;
+        memoryId < MemoryArgTypes.Length
+            ? MemoryArgTypes[memoryId]
+            : MemoryArgType.None;
 
     private static string GetMemoryArgLabel(MemoryArgType argType) => argType switch
     {
@@ -94,11 +96,11 @@ public partial class OtMiscTab : IDisposable
         MemoryArgType.Move => "Move",
         MemoryArgType.Item => "Item",
         MemoryArgType.GeneralLocation or MemoryArgType.SpecificLocation => "Location",
-        _ => "Variable",
+        _ => "Variable"
     };
 
     /// <summary>
-    ///     Builds the fully-formatted memory preview string, substituting all placeholders.
+    /// Builds the fully-formatted memory preview string, substituting all placeholders.
     /// </summary>
     private string FormatMemoryText(
         byte memoryId,
@@ -182,7 +184,7 @@ public partial class OtMiscTab : IDisposable
     }
 
     private void ClearGeoData(IGeoTrack geoTrack) =>
-        PKHeX.Core.Extensions.ClearGeoLocationData(geoTrack);
+        geoTrack.ClearGeoLocationData();
 
     private static byte GetGeoCountry(IGeoTrack geo, int slot) => slot switch
     {
@@ -191,7 +193,7 @@ public partial class OtMiscTab : IDisposable
         3 => geo.Geo3_Country,
         4 => geo.Geo4_Country,
         5 => geo.Geo5_Country,
-        _ => 0,
+        _ => 0
     };
 
     private static byte GetGeoRegion(IGeoTrack geo, int slot) => slot switch
@@ -201,18 +203,33 @@ public partial class OtMiscTab : IDisposable
         3 => geo.Geo3_Region,
         4 => geo.Geo4_Region,
         5 => geo.Geo5_Region,
-        _ => 0,
+        _ => 0
     };
 
     private static void SetGeoCountry(IGeoTrack geo, int slot, byte value)
     {
         switch (slot)
         {
-            case 1: geo.Geo1_Country = value; geo.Geo1_Region = 0; break;
-            case 2: geo.Geo2_Country = value; geo.Geo2_Region = 0; break;
-            case 3: geo.Geo3_Country = value; geo.Geo3_Region = 0; break;
-            case 4: geo.Geo4_Country = value; geo.Geo4_Region = 0; break;
-            case 5: geo.Geo5_Country = value; geo.Geo5_Region = 0; break;
+            case 1:
+                geo.Geo1_Country = value;
+                geo.Geo1_Region = 0;
+                break;
+            case 2:
+                geo.Geo2_Country = value;
+                geo.Geo2_Region = 0;
+                break;
+            case 3:
+                geo.Geo3_Country = value;
+                geo.Geo3_Region = 0;
+                break;
+            case 4:
+                geo.Geo4_Country = value;
+                geo.Geo4_Region = 0;
+                break;
+            case 5:
+                geo.Geo5_Country = value;
+                geo.Geo5_Region = 0;
+                break;
         }
     }
 
@@ -257,28 +274,28 @@ public partial class OtMiscTab : IDisposable
 
     private void OnGenderToggle(Gender newGender) => Pokemon?.OriginalTrainerGender = (byte)newGender;
 
-    private void SetPokemonOTName(string newOTName)
+    private void SetPokemonOtName(string newOtName)
     {
         if (Pokemon is null || AppState.SaveFile is not { } saveFile)
         {
             return;
         }
 
-        if (newOTName is not { Length: > 0 })
+        if (newOtName is not { Length: > 0 })
         {
-            newOTName = saveFile.OT;
+            newOtName = saveFile.OT;
         }
 
-        if (newOTName is not { Length: > 0 })
+        if (newOtName is not { Length: > 0 })
         {
             return;
         }
 
-        Pokemon.OriginalTrainerName = newOTName;
+        Pokemon.OriginalTrainerName = newOtName;
 
         // For Gen I/II, verify the OT name was set correctly
         // If it becomes empty, the characters were not valid for the Pokémon's language/encoding
-        if (Pokemon.Format <= 2 && string.IsNullOrEmpty(Pokemon.OriginalTrainerName) && newOTName.Length > 0)
+        if (Pokemon.Format <= 2 && string.IsNullOrEmpty(Pokemon.OriginalTrainerName) && newOtName.Length > 0)
         {
             // Fallback to save file's OT name if couldn't be encoded
             Pokemon.OriginalTrainerName = saveFile.OT;
@@ -305,7 +322,7 @@ public partial class OtMiscTab : IDisposable
             return;
         }
 
-        CommonEdits.SetRandomEC(Pokemon);
+        Pokemon.SetRandomEC();
         SetPokemonEc(Pokemon.EncryptionConstant);
     }
 

--- a/Pkmds.Rcl/Components/EditForms/Tabs/RibbonsTab.razor
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/RibbonsTab.razor
@@ -71,7 +71,9 @@
                                       Height="32"
                                       Alt="@ribbonDisplayName"
                                       title="@ribbonDisplayName"
-                                      Class="@(ribbon.HasRibbon ? "cursor-pointer" : "cursor-pointer opacity-30")"
+                                      Class="@(ribbon.HasRibbon
+                                                 ? "cursor-pointer"
+                                                 : "cursor-pointer opacity-30")"
                                       @onclick="@(() => ToggleRibbon(ribbon.Name))"/>
                         </MudTooltip>
                     }
@@ -92,7 +94,9 @@
                                   Height="32"
                                   Alt="@markDisplayName"
                                   title="@markDisplayName"
-                                  Class="@(mark.HasRibbon ? "cursor-pointer" : "cursor-pointer opacity-30")"
+                                  Class="@(mark.HasRibbon
+                                             ? "cursor-pointer"
+                                             : "cursor-pointer opacity-30")"
                                   @onclick="@(() => ToggleRibbon(mark.Name))"/>
                     </MudTooltip>
                 }

--- a/Pkmds.Rcl/Components/EditForms/Tabs/RibbonsTab.razor.cs
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/RibbonsTab.razor.cs
@@ -53,6 +53,7 @@ public partial class RibbonsTab : IDisposable
                 {
                     maxAllowed = ribbon.MaxCount;
                 }
+
                 break;
             }
         }
@@ -62,6 +63,7 @@ public partial class RibbonsTab : IDisposable
         {
             clamped = 0;
         }
+
         if (clamped > maxAllowed)
         {
             clamped = maxAllowed;
@@ -80,7 +82,9 @@ public partial class RibbonsTab : IDisposable
 
         foreach (var ribbon in GetAllRibbonInfo())
         {
-            var value = ribbon.Type is RibbonValueType.Boolean ? (object)true : (byte)ribbon.MaxCount;
+            var value = ribbon.Type is RibbonValueType.Boolean
+                ? (object)true
+                : (byte)ribbon.MaxCount;
             ReflectUtil.SetValue(Pokemon, ribbon.Name, value);
         }
 
@@ -96,7 +100,9 @@ public partial class RibbonsTab : IDisposable
 
         foreach (var ribbon in GetAllRibbonInfo())
         {
-            var value = ribbon.Type is RibbonValueType.Boolean ? (object)false : (byte)0;
+            var value = ribbon.Type is RibbonValueType.Boolean
+                ? (object)false
+                : (byte)0;
             ReflectUtil.SetValue(Pokemon, ribbon.Name, value);
         }
 

--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
@@ -1,6 +1,6 @@
-namespace Pkmds.Rcl.Components.Layout;
-
 using Pkmds.Rcl.Models;
+
+namespace Pkmds.Rcl.Components.Layout;
 
 public partial class MainLayout : IDisposable
 {
@@ -10,8 +10,8 @@ public partial class MainLayout : IDisposable
     private const string GitHubTooltip = "Source code on GitHub";
 
     private IBrowserFile? browserLoadSaveFile;
-    private bool isDarkMode;
     private bool isCheckingForUpdate;
+    private bool isDarkMode;
     private MudThemeProvider? mudThemeProvider;
 
     public void Dispose() => RefreshService.OnAppStateChanged -= StateHasChanged;
@@ -80,9 +80,9 @@ public partial class MainLayout : IDisposable
                 "no-update" => ("You're up to date — no updates available.", Severity.Info),
                 "no-sw" => ($"Service worker is not available. {detail}", Severity.Warning),
                 "error" => ($"An error occurred while checking for updates: {detail}", Severity.Error),
-                _ => ($"Unexpected update check result: {result}. {detail}", Severity.Warning),
+                _ => ($"Unexpected update check result: {result}. {detail}", Severity.Warning)
             };
-            
+
             Logger.LogInformation("Update check result: {Result} - {Detail}", result, detail);
             Snackbar.Add(message, severity);
         }

--- a/Pkmds.Rcl/Components/PokemonSlotComponent.razor
+++ b/Pkmds.Rcl/Components/PokemonSlotComponent.razor
@@ -39,9 +39,15 @@
             @if (GetLegalityValid() is { } isLegal)
             {
                 <div class="legality-indicator-icon"
-                     title="@(isLegal ? "Legal" : "Illegal")">
-                    <img src="@(isLegal ? ImageHelper.GetLegalityValidSpriteFileName() : ImageHelper.GetLegalityWarnSpriteFileName())"
-                         alt="@(isLegal ? "Legal" : "Illegal")"
+                     title="@(isLegal
+                                ? "Legal"
+                                : "Illegal")">
+                    <img src="@(isLegal
+                                  ? ImageHelper.GetLegalityValidSpriteFileName()
+                                  : ImageHelper.GetLegalityWarnSpriteFileName())"
+                         alt="@(isLegal
+                                  ? "Legal"
+                                  : "Illegal")"
                          class="w-full h-full object-contain">
                 </div>
             }

--- a/Pkmds.Rcl/Components/PokemonSlotComponent.razor.cs
+++ b/Pkmds.Rcl/Components/PokemonSlotComponent.razor.cs
@@ -2,6 +2,7 @@ namespace Pkmds.Rcl.Components;
 
 public partial class PokemonSlotComponent : IDisposable
 {
+    private bool? legalityValid;
     // Removed isDragOverWithFile field - no longer showing drag indicators
 
     [Parameter]
@@ -27,8 +28,6 @@ public partial class PokemonSlotComponent : IDisposable
     private IDragDropService DragDropService { get; set; } = null!;
 
     protected virtual int? BoxNumber => null;
-
-    private bool? _legalityValid;
 
     public void Dispose() =>
         RefreshService.OnAppStateChanged -= RefreshLegality;
@@ -57,14 +56,14 @@ public partial class PokemonSlotComponent : IDisposable
     {
         if (Pokemon is not { Species: > 0 })
         {
-            _legalityValid = null;
+            legalityValid = null;
             return;
         }
 
         var la = AppService.GetLegalityAnalysis(Pokemon);
-        _legalityValid = la.Results.All(r => r.Valid)
-            && MoveResult.AllValid(la.Info.Moves)
-            && MoveResult.AllValid(la.Info.Relearn);
+        legalityValid = la.Results.All(r => r.Valid)
+                         && MoveResult.AllValid(la.Info.Moves)
+                         && MoveResult.AllValid(la.Info.Relearn);
     }
 
     private string GetPokemonTitle() => Pokemon is { Species: > 0 }
@@ -83,10 +82,10 @@ public partial class PokemonSlotComponent : IDisposable
     };
 
     /// <returns>
-    ///   <see langword="true"/> = legal, <see langword="false"/> = illegal/fishy,
-    ///   <see langword="null"/> = no Pokémon in slot (skip indicator).
+    /// <see langword="true" /> = legal, <see langword="false" /> = illegal/fishy,
+    /// <see langword="null" /> = no Pokémon in slot (skip indicator).
     /// </returns>
-    private bool? GetLegalityValid() => _legalityValid;
+    private bool? GetLegalityValid() => legalityValid;
 
     private int? GetLetsGoPartySlotNumber()
     {

--- a/Pkmds.Rcl/Components/RefreshAwareComponent.cs
+++ b/Pkmds.Rcl/Components/RefreshAwareComponent.cs
@@ -1,8 +1,8 @@
 namespace Pkmds.Rcl.Components;
 
 /// <summary>
-///     Base component that automatically subscribes to refresh events.
-///     Reduces boilerplate code for components that need to refresh on state changes.
+/// Base component that automatically subscribes to refresh events.
+/// Reduces boilerplate code for components that need to refresh on state changes.
 /// </summary>
 public abstract class RefreshAwareComponent : ComponentBase, IDisposable
 {
@@ -17,8 +17,8 @@ public abstract class RefreshAwareComponent : ComponentBase, IDisposable
     private IRefreshService RefreshServiceInternal => RefreshServiceField!;
 
     /// <summary>
-    ///     Override this property to control which refresh events trigger StateHasChanged.
-    ///     By default, only OnAppStateChanged is subscribed.
+    /// Override this property to control which refresh events trigger StateHasChanged.
+    /// By default, only OnAppStateChanged is subscribed.
     /// </summary>
     protected virtual RefreshEvents SubscribeTo => RefreshEvents.AppState;
 
@@ -68,7 +68,7 @@ public abstract class RefreshAwareComponent : ComponentBase, IDisposable
     }
 
     /// <summary>
-    ///     Override this method to add custom disposal logic.
+    /// Override this method to add custom disposal logic.
     /// </summary>
     protected virtual void Dispose(bool disposing)
     {
@@ -76,7 +76,7 @@ public abstract class RefreshAwareComponent : ComponentBase, IDisposable
 }
 
 /// <summary>
-///     Flags enum to control which refresh events a component subscribes to.
+/// Flags enum to control which refresh events a component subscribes to.
 /// </summary>
 [Flags]
 public enum RefreshEvents

--- a/Pkmds.Rcl/Components/SaveFileNameDisplay.cs
+++ b/Pkmds.Rcl/Components/SaveFileNameDisplay.cs
@@ -3,13 +3,13 @@
 namespace Pkmds.Rcl.Components;
 
 /// <summary>
-///     Utility class for generating display names for save files and game versions.
+/// Utility class for generating display names for save files and game versions.
 /// </summary>
 public static class SaveFileNameDisplay
 {
     /// <summary>
-    ///     Generates a formatted display string for the current save file.
-    ///     Includes trainer name, gender, TID, game version, and playtime.
+    /// Generates a formatted display string for the current save file.
+    /// Includes trainer name, gender, TID, game version, and playtime.
     /// </summary>
     /// <param name="appState">The application state containing the save file.</param>
     /// <param name="appService">The application service for formatting IDs.</param>
@@ -55,7 +55,7 @@ public static class SaveFileNameDisplay
     }
 
     /// <summary>
-    ///     Converts a GameVersion enum value to a user-friendly game name.
+    /// Converts a GameVersion enum value to a user-friendly game name.
     /// </summary>
     /// <param name="gameVersion">The game version to convert.</param>
     /// <returns>A human-readable game name.</returns>

--- a/Pkmds.Rcl/Constants.cs
+++ b/Pkmds.Rcl/Constants.cs
@@ -1,7 +1,7 @@
 ﻿namespace Pkmds.Rcl;
 
 /// <summary>
-///     Application-wide constants used throughout the PKMDS application.
+/// Application-wide constants used throughout the PKMDS application.
 /// </summary>
 public static class Constants
 {

--- a/Pkmds.Rcl/Extensions/VersionExtensions.cs
+++ b/Pkmds.Rcl/Extensions/VersionExtensions.cs
@@ -1,12 +1,12 @@
 ﻿namespace Pkmds.Rcl.Extensions;
 
 /// <summary>
-///     Extension methods for System.Version.
+/// Extension methods for System.Version.
 /// </summary>
 public static class VersionExtensions
 {
     /// <summary>
-    ///     Converts a Version to a formatted string in the format "YYYY.MM.DD.HHMM".
+    /// Converts a Version to a formatted string in the format "YYYY.MM.DD.HHMM".
     /// </summary>
     /// <param name="version">The version to format.</param>
     /// <returns>A formatted version string (e.g., "2026.01.27.0949").</returns>

--- a/Pkmds.Rcl/IAppState.cs
+++ b/Pkmds.Rcl/IAppState.cs
@@ -1,76 +1,76 @@
 ﻿namespace Pkmds.Rcl;
 
 /// <summary>
-///     Represents the global application state for the PKMDS application.
-///     This interface provides access to the currently loaded save file, selected Pokémon slots,
-///     clipboard data, and other application-wide state information.
+/// Represents the global application state for the PKMDS application.
+/// This interface provides access to the currently loaded save file, selected Pokémon slots,
+/// clipboard data, and other application-wide state information.
 /// </summary>
 public interface IAppState
 {
     /// <summary>
-    ///     Gets or sets the current language code used for displaying game data.
+    /// Gets or sets the current language code used for displaying game data.
     /// </summary>
     string CurrentLanguage { get; set; }
 
     /// <summary>
-    ///     Gets the numeric language ID corresponding to the <see cref="CurrentLanguage" />.
+    /// Gets the numeric language ID corresponding to the <see cref="CurrentLanguage" />.
     /// </summary>
     int CurrentLanguageId { get; }
 
     /// <summary>
-    ///     Gets or sets the currently loaded save file from a Pokémon game.
-    ///     This is null when no save file is loaded.
+    /// Gets or sets the currently loaded save file from a Pokémon game.
+    /// This is null when no save file is loaded.
     /// </summary>
     SaveFile? SaveFile { get; set; }
 
     /// <summary>
-    ///     Gets the box editor interface for the current save file.
-    ///     This provides access to box manipulation operations.
+    /// Gets the box editor interface for the current save file.
+    /// This provides access to box manipulation operations.
     /// </summary>
     BoxEdit? BoxEdit { get; }
 
     /// <summary>
-    ///     Gets or sets the Pokémon currently stored in the clipboard for copy/paste operations.
+    /// Gets or sets the Pokémon currently stored in the clipboard for copy/paste operations.
     /// </summary>
     PKM? CopiedPokemon { get; set; }
 
     /// <summary>
-    ///     Gets or sets the currently selected box number (0-based index).
-    ///     Null when no box is selected or when a party slot is selected.
+    /// Gets or sets the currently selected box number (0-based index).
+    /// Null when no box is selected or when a party slot is selected.
     /// </summary>
     int? SelectedBoxNumber { get; set; }
 
     /// <summary>
-    ///     Gets or sets the currently selected box slot number (0-based index within a box).
-    ///     Null when no box slot is selected or when a party slot is selected.
+    /// Gets or sets the currently selected box slot number (0-based index within a box).
+    /// Null when no box slot is selected or when a party slot is selected.
     /// </summary>
     int? SelectedBoxSlotNumber { get; set; }
 
     /// <summary>
-    ///     Gets or sets the currently selected party slot number (0-based index, 0-5 for party).
-    ///     Null when no party slot is selected or when a box slot is selected.
+    /// Gets or sets the currently selected party slot number (0-based index, 0-5 for party).
+    /// Null when no party slot is selected or when a box slot is selected.
     /// </summary>
     int? SelectedPartySlotNumber { get; set; }
 
     /// <summary>
-    ///     Gets or sets whether the progress indicator should be displayed.
-    ///     Used to show loading spinners during long-running operations.
+    /// Gets or sets whether the progress indicator should be displayed.
+    /// Used to show loading spinners during long-running operations.
     /// </summary>
     bool ShowProgressIndicator { get; set; }
 
     /// <summary>
-    ///     Gets the current application version string.
+    /// Gets the current application version string.
     /// </summary>
     string? AppVersion { get; }
 
     /// <summary>
-    ///     Gets the version of PKHeX.Core library being used.
+    /// Gets the version of PKHeX.Core library being used.
     /// </summary>
     static string? PkhexVersion => Assembly.GetAssembly(typeof(PKM))?.GetName().Version?.ToString();
 
     /// <summary>
-    ///     Gets whether the currently selected slots represent a valid selection.
-    ///     This is true when exactly one slot (either box or party) is selected.
+    /// Gets whether the currently selected slots represent a valid selection.
+    /// This is true when exactly one slot (either box or party) is selected.
     /// </summary>
     bool SelectedSlotsAreValid { get; }
 }

--- a/Pkmds.Rcl/RibbonHelper.cs
+++ b/Pkmds.Rcl/RibbonHelper.cs
@@ -6,12 +6,17 @@ namespace Pkmds.Rcl;
 public static class RibbonHelper
 {
     /// <summary>Gets a human-friendly display name for a ribbon property name.</summary>
-    /// <remarks>Uses <see cref="RibbonStrings"/> from <see cref="GameInfo.Strings"/> when available, falling back to the property name itself.</remarks>
+    /// <remarks>
+    /// Uses <see cref="RibbonStrings" /> from <see cref="GameInfo.Strings" /> when available, falling back to the
+    /// property name itself.
+    /// </remarks>
     /// <param name="propertyName">The property name, e.g. "RibbonChampionKalos".</param>
     public static string GetRibbonDisplayName(string propertyName) =>
-        GameInfo.Strings.Ribbons.GetNameSafe(propertyName, out var name) ? name : propertyName;
+        GameInfo.Strings.Ribbons.GetNameSafe(propertyName, out var name)
+            ? name
+            : propertyName;
 
-    /// <summary>Gets the sprite path for a ribbon by its <see cref="RibbonInfo"/>.</summary>
+    /// <summary>Gets the sprite path for a ribbon by its <see cref="RibbonInfo" />.</summary>
     public static string GetRibbonSprite(RibbonInfo info) =>
         ImageHelper.GetRibbonIconSpriteFileName(
             info.Name.StartsWith("Ribbon", StringComparison.Ordinal)
@@ -19,7 +24,7 @@ public static class RibbonHelper
                 : info.Name);
 
     /// <summary>
-    /// Returns <see langword="true"/> when the ribbon name corresponds to a personality mark
+    /// Returns <see langword="true" /> when the ribbon name corresponds to a personality mark
     /// (Gen 8 encounter marks or Gen 9 alpha/mightiest/titan marks).
     /// </summary>
     public static bool IsMarkEntry(string name)
@@ -33,11 +38,16 @@ public static class RibbonHelper
         }
 
         // Personality marks: Gen 8 (MarkLunchtime..MarkSlump) and Gen 9 (MarkAlpha, MarkMightiest, MarkTitan)
-        return index is (>= RibbonIndex.MarkLunchtime and <= RibbonIndex.MarkSlump)
+        return index is >= RibbonIndex.MarkLunchtime and <= RibbonIndex.MarkSlump
             or RibbonIndex.MarkAlpha or RibbonIndex.MarkMightiest or RibbonIndex.MarkTitan;
     }
 
-    /// <summary>Gets all ribbon info entries for the given Pokémon, or an empty list if <paramref name="pokemon"/> is <see langword="null"/>.</summary>
+    /// <summary>
+    /// Gets all ribbon info entries for the given Pokémon, or an empty list if <paramref name="pokemon" /> is
+    /// <see langword="null" />.
+    /// </summary>
     public static List<RibbonInfo> GetAllRibbonInfo(PKM? pokemon) =>
-        pokemon is not null ? RibbonInfo.GetRibbonInfo(pokemon) : [];
+        pokemon is not null
+            ? RibbonInfo.GetRibbonInfo(pokemon)
+            : [];
 }

--- a/Pkmds.Rcl/Services/AppService.cs
+++ b/Pkmds.Rcl/Services/AppService.cs
@@ -782,32 +782,6 @@ public class AppService(IAppState appState, IRefreshService refreshService) : IA
         }
     }
 
-    private void HandleNullOrEmptyPokemon()
-    {
-        if (AppState.SaveFile is not { } saveFile)
-        {
-            return;
-        }
-
-        // Empty box slots in PKHeX return a non-null PKM with Species=0, not null.
-        // Apply the template for both cases so new Pokémon start with the correct
-        // OT/ID/Language/Version/MetDate/Ball — matching EntityTemplates.TemplateFields.
-        if (EditFormPokemon is not (null or { Species: 0 }))
-        {
-            return;
-        }
-
-        // Apply trainer data and other defaults to the blank PKM so new Pokémon
-        // start with correct OT/ID/Language/Version/MetDate/Ball — matching what
-        // PKHeX WinForms does via EntityTemplates.TemplateFields.
-        // Species is reset to 0 afterward so the user is prompted to pick one.
-        var blank = saveFile.BlankPKM.Clone();
-        EntityTemplates.TemplateFields(blank, saveFile);
-        blank.Species = 0;
-        blank.ClearNickname(); // Remove the template species name set by TemplateFields
-        EditFormPokemon = blank;
-    }
-
     public IEnumerable<ComboItem> GetMemoryComboItems() =>
         new MemoryStrings(GameInfo.Strings).Memory;
 
@@ -865,6 +839,32 @@ public class AppService(IAppState appState, IRefreshService refreshService) : IA
     }
 
     public LegalityAnalysis GetLegalityAnalysis(PKM pkm) => new(pkm);
+
+    private void HandleNullOrEmptyPokemon()
+    {
+        if (AppState.SaveFile is not { } saveFile)
+        {
+            return;
+        }
+
+        // Empty box slots in PKHeX return a non-null PKM with Species=0, not null.
+        // Apply the template for both cases so new Pokémon start with the correct
+        // OT/ID/Language/Version/MetDate/Ball — matching EntityTemplates.TemplateFields.
+        if (EditFormPokemon is not (null or { Species: 0 }))
+        {
+            return;
+        }
+
+        // Apply trainer data and other defaults to the blank PKM so new Pokémon
+        // start with correct OT/ID/Language/Version/MetDate/Ball — matching what
+        // PKHeX WinForms does via EntityTemplates.TemplateFields.
+        // Species is reset to 0 afterward so the user is prompted to pick one.
+        var blank = saveFile.BlankPKM.Clone();
+        EntityTemplates.TemplateFields(blank, saveFile);
+        blank.Species = 0;
+        blank.ClearNickname(); // Remove the template species name set by TemplateFields
+        EditFormPokemon = blank;
+    }
 
     /// <summary>
     /// Compacts a box by shifting all Pokémon left to fill gaps (for Gen 1 and Gen 2 games).

--- a/Pkmds.Rcl/Services/DragDropService.cs
+++ b/Pkmds.Rcl/Services/DragDropService.cs
@@ -1,8 +1,8 @@
 namespace Pkmds.Rcl.Services;
 
 /// <summary>
-///     Implementation of drag-and-drop service for managing Pokémon drag operations.
-///     Maintains state about the current drag operation including source location and Pokémon data.
+/// Implementation of drag-and-drop service for managing Pokémon drag operations.
+/// Maintains state about the current drag operation including source location and Pokémon data.
 /// </summary>
 public class DragDropService : IDragDropService
 {

--- a/Pkmds.Rcl/Services/IAppService.cs
+++ b/Pkmds.Rcl/Services/IAppService.cs
@@ -1,110 +1,110 @@
 ﻿namespace Pkmds.Rcl.Services;
 
 /// <summary>
-///     Provides core application services for managing Pokémon data, UI state, and game information.
-///     This is the main service for interacting with the save file and Pokémon data.
+/// Provides core application services for managing Pokémon data, UI state, and game information.
+/// This is the main service for interacting with the save file and Pokémon data.
 /// </summary>
 public interface IAppService
 {
     /// <summary>
-    ///     Gets or sets the Pokémon currently being edited in the edit form.
-    ///     This is a clone of the selected Pokémon to allow for canceling edits.
+    /// Gets or sets the Pokémon currently being edited in the edit form.
+    /// This is a clone of the selected Pokémon to allow for canceling edits.
     /// </summary>
     PKM? EditFormPokemon { get; set; }
 
     /// <summary>
-    ///     Gets or sets whether the navigation drawer is currently open.
+    /// Gets or sets whether the navigation drawer is currently open.
     /// </summary>
     bool IsDrawerOpen { get; set; }
 
     /// <summary>
-    ///     Toggles the navigation drawer between open and closed states.
+    /// Toggles the navigation drawer between open and closed states.
     /// </summary>
     void ToggleDrawer();
 
     /// <summary>
-    ///     Clears the current selection (both box and party slots) and resets the edit form.
+    /// Clears the current selection (both box and party slots) and resets the edit form.
     /// </summary>
     void ClearSelection();
 
     /// <summary>
-    ///     Deletes a Pokémon from the party at the specified slot.
-    ///     Ensures at least one battle-ready Pokémon remains in the party.
+    /// Deletes a Pokémon from the party at the specified slot.
+    /// Ensures at least one battle-ready Pokémon remains in the party.
     /// </summary>
     /// <param name="partySlotNumber">The 0-based party slot index (0-5).</param>
     void DeletePokemon(int partySlotNumber);
 
     /// <summary>
-    ///     Deletes a Pokémon from a box by replacing it with a blank Pokémon.
+    /// Deletes a Pokémon from a box by replacing it with a blank Pokémon.
     /// </summary>
     /// <param name="boxNumber">The 0-based box number.</param>
     /// <param name="boxSlotNumber">The 0-based slot number within the box.</param>
     void DeletePokemon(int boxNumber, int boxSlotNumber);
 
     /// <summary>
-    ///     Gets the display name for a Pokémon species in the current language.
+    /// Gets the display name for a Pokémon species in the current language.
     /// </summary>
     /// <param name="speciesId">The species ID to look up.</param>
     /// <returns>The localized species name.</returns>
     string? GetPokemonSpeciesName(ushort speciesId);
 
     /// <summary>
-    ///     Searches for Pokémon species names matching the search string.
+    /// Searches for Pokémon species names matching the search string.
     /// </summary>
     /// <param name="searchString">The search term to filter species names.</param>
     /// <returns>A collection of matching species as combo items.</returns>
     IEnumerable<ComboItem> SearchPokemonNames(string searchString);
 
     /// <summary>
-    ///     Gets the combo item representation for a specific species.
+    /// Gets the combo item representation for a specific species.
     /// </summary>
     /// <param name="speciesId">The species ID to look up.</param>
     /// <returns>A combo item containing the species name and ID.</returns>
     ComboItem GetSpeciesComboItem(ushort speciesId);
 
     /// <summary>
-    ///     Gets a human-readable string describing a nature's stat modifiers.
+    /// Gets a human-readable string describing a nature's stat modifiers.
     /// </summary>
     /// <param name="nature">The nature to describe.</param>
     /// <returns>A string like "(Atk ↑, Def ↓)" or "(neutral)" for neutral natures.</returns>
     string GetStatModifierString(Nature nature);
 
     /// <summary>
-    ///     Calculates and loads the stats for a Pokémon based on its species, form, IVs, EVs, and level.
+    /// Calculates and loads the stats for a Pokémon based on its species, form, IVs, EVs, and level.
     /// </summary>
     /// <param name="pokemon">The Pokémon to load stats for.</param>
     void LoadPokemonStats(PKM? pokemon);
 
     /// <summary>
-    ///     Searches for items matching the search string.
+    /// Searches for items matching the search string.
     /// </summary>
     /// <param name="searchString">The search term to filter item names.</param>
     /// <returns>A collection of matching items as combo items.</returns>
     IEnumerable<ComboItem> SearchItemNames(string searchString);
 
     /// <summary>
-    ///     Gets the combo item representation for a specific item.
+    /// Gets the combo item representation for a specific item.
     /// </summary>
     /// <param name="itemId">The item ID to look up.</param>
     /// <returns>A combo item containing the item name and ID.</returns>
     ComboItem GetItemComboItem(int itemId);
 
     /// <summary>
-    ///     Gets the combo item representation for a specific ability.
+    /// Gets the combo item representation for a specific ability.
     /// </summary>
     /// <param name="abilityId">The ability ID to look up.</param>
     /// <returns>A combo item containing the ability name and ID.</returns>
     ComboItem GetAbilityComboItem(int abilityId);
 
     /// <summary>
-    ///     Searches for abilities matching the search string.
+    /// Searches for abilities matching the search string.
     /// </summary>
     /// <param name="searchString">The search term to filter ability names.</param>
     /// <returns>A collection of matching abilities as combo items.</returns>
     IEnumerable<ComboItem> SearchAbilityNames(string searchString);
 
     /// <summary>
-    ///     Searches for met locations matching the search string for a specific game version and context.
+    /// Searches for met locations matching the search string for a specific game version and context.
     /// </summary>
     /// <param name="searchString">The search term to filter location names.</param>
     /// <param name="gameVersion">The game version to get locations for.</param>
@@ -115,7 +115,7 @@ public interface IAppService
         bool isEggLocation = false);
 
     /// <summary>
-    ///     Gets the combo item representation for a specific met location.
+    /// Gets the combo item representation for a specific met location.
     /// </summary>
     /// <param name="metLocationId">The location ID to look up.</param>
     /// <param name="gameVersion">The game version for the location.</param>
@@ -126,48 +126,48 @@ public interface IAppService
         bool isEggLocation = false);
 
     /// <summary>
-    ///     Searches for moves matching the search string.
+    /// Searches for moves matching the search string.
     /// </summary>
     /// <param name="searchString">The search term to filter move names.</param>
     /// <returns>A collection of matching moves as combo items.</returns>
     IEnumerable<ComboItem> SearchMoves(string searchString);
 
     /// <summary>
-    ///     Gets all available moves for the current game context.
+    /// Gets all available moves for the current game context.
     /// </summary>
     /// <returns>A collection of all moves as combo items.</returns>
     IEnumerable<ComboItem> GetMoves();
 
     /// <summary>
-    ///     Gets the combo item representation for a specific move.
+    /// Gets the combo item representation for a specific move.
     /// </summary>
     /// <param name="moveId">The move ID to look up.</param>
     /// <returns>A combo item containing the move name and ID.</returns>
     ComboItem GetMoveComboItem(int moveId);
 
     /// <summary>
-    ///     Saves the edited Pokémon back to its original slot in the save file.
+    /// Saves the edited Pokémon back to its original slot in the save file.
     /// </summary>
     /// <param name="selectedPokemon">The Pokémon to save.</param>
     void SavePokemon(PKM? selectedPokemon);
 
     /// <summary>
-    ///     Generates a clean, standardized filename for exporting a Pokémon.
-    ///     Format varies by generation: Gen 1/2 use DV values, Gen 3+ use PID.
+    /// Generates a clean, standardized filename for exporting a Pokémon.
+    /// Format varies by generation: Gen 1/2 use DV values, Gen 3+ use PID.
     /// </summary>
     /// <param name="pkm">The Pokémon to generate a filename for.</param>
     /// <returns>A clean filename suitable for file export.</returns>
     string GetCleanFileName(PKM pkm);
 
     /// <summary>
-    ///     Sets the selected Pokémon from Let's Go Pikachu/Eevee storage.
+    /// Sets the selected Pokémon from Let's Go Pikachu/Eevee storage.
     /// </summary>
     /// <param name="pkm">The Pokémon to select.</param>
     /// <param name="slotNumber">The slot number in Let's Go storage.</param>
     void SetSelectedLetsGoPokemon(PKM? pkm, int slotNumber);
 
     /// <summary>
-    ///     Sets the selected Pokémon from a box slot.
+    /// Sets the selected Pokémon from a box slot.
     /// </summary>
     /// <param name="pkm">The Pokémon to select.</param>
     /// <param name="boxNumber">The box number (0-based).</param>
@@ -175,34 +175,34 @@ public interface IAppService
     void SetSelectedBoxPokemon(PKM? pkm, int boxNumber, int slotNumber);
 
     /// <summary>
-    ///     Sets the selected Pokémon from a party slot.
+    /// Sets the selected Pokémon from a party slot.
     /// </summary>
     /// <param name="pkm">The Pokémon to select.</param>
     /// <param name="slotNumber">The party slot number (0-5).</param>
     void SetSelectedPartyPokemon(PKM? pkm, int slotNumber);
 
     /// <summary>
-    ///     Exports a Pokémon to Pokémon Showdown format text.
+    /// Exports a Pokémon to Pokémon Showdown format text.
     /// </summary>
     /// <param name="pkm">The Pokémon to export.</param>
     /// <returns>A Showdown-formatted text representation of the Pokémon.</returns>
     string ExportPokemonAsShowdown(PKM? pkm);
 
     /// <summary>
-    ///     Exports all Pokémon in the party to Pokémon Showdown format text.
+    /// Exports all Pokémon in the party to Pokémon Showdown format text.
     /// </summary>
     /// <returns>A Showdown-formatted text representation of the entire party.</returns>
     string ExportPartyAsShowdown();
 
     /// <summary>
-    ///     Gets the format string for displaying trainer IDs based on the current save file's format.
+    /// Gets the format string for displaying trainer IDs based on the current save file's format.
     /// </summary>
     /// <param name="isSid">Whether to get the format for SID instead of TID.</param>
     /// <returns>A format string for use with string formatting (e.g., "D5" for 5-digit format).</returns>
     string GetIdFormatString(bool isSid = false);
 
     /// <summary>
-    ///     Determines which type of slot is currently selected and retrieves the slot coordinates.
+    /// Determines which type of slot is currently selected and retrieves the slot coordinates.
     /// </summary>
     /// <param name="partySlot">The party slot number if a party slot is selected.</param>
     /// <param name="boxNumber">The box number if a box slot is selected.</param>
@@ -211,7 +211,7 @@ public interface IAppService
     SelectedPokemonType GetSelectedPokemonSlot(out int partySlot, out int boxNumber, out int boxSlot);
 
     /// <summary>
-    ///     Imports a Mystery Gift into the save file.
+    /// Imports a Mystery Gift into the save file.
     /// </summary>
     /// <param name="gift">The Mystery Gift data to import.</param>
     /// <param name="isSuccessful">Output parameter indicating whether the import was successful.</param>
@@ -220,7 +220,7 @@ public interface IAppService
     Task ImportMysteryGift(DataMysteryGift gift, out bool isSuccessful, out string resultsMessage);
 
     /// <summary>
-    ///     Imports a Mystery Gift from raw data and file extension.
+    /// Imports a Mystery Gift from raw data and file extension.
     /// </summary>
     /// <param name="data">The raw Mystery Gift file data.</param>
     /// <param name="fileExtension">The file extension (e.g., ".wc7", ".pgf").</param>
@@ -230,8 +230,8 @@ public interface IAppService
     Task ImportMysteryGift(byte[] data, string fileExtension, out bool isSuccessful, out string resultsMessage);
 
     /// <summary>
-    ///     Moves or swaps a Pokémon between slots (box-to-box, party-to-box, box-to-party, or party-to-party).
-    ///     Handles special cases like Gen 1/2 box compacting and party compacting.
+    /// Moves or swaps a Pokémon between slots (box-to-box, party-to-box, box-to-party, or party-to-party).
+    /// Handles special cases like Gen 1/2 box compacting and party compacting.
     /// </summary>
     /// <param name="sourceBoxNumber">The source box number (null for party or Let's Go storage).</param>
     /// <param name="sourceSlotNumber">The source slot number.</param>
@@ -243,13 +243,13 @@ public interface IAppService
         int? destBoxNumber, int destSlotNumber, bool isDestParty);
 
     /// <summary>
-    ///     Gets all available memory combo items for the memory ID dropdown.
+    /// Gets all available memory combo items for the memory ID dropdown.
     /// </summary>
     /// <returns>A collection of memories as combo items.</returns>
     IEnumerable<ComboItem> GetMemoryComboItems();
 
     /// <summary>
-    ///     Gets all available memory feeling combo items for the given memory generation.
+    /// Gets all available memory feeling combo items for the given memory generation.
     /// </summary>
     /// <param name="memoryGen">The memory generation (6 for Gen 6/7, 8 for Gen 8+).</param>
     /// <returns>A collection of feelings as combo items.</returns>
@@ -265,22 +265,22 @@ public interface IAppService
     IEnumerable<ComboItem> GetLanguageComboItems(int generation, EntityContext context);
 
     /// <summary>
-    ///     Gets all valid geo-location country combo items (ID → English name).
-    ///     Entry 0 is the "none/blank" country (—).
+    /// Gets all valid geo-location country combo items (ID → English name).
+    /// Entry 0 is the "none/blank" country (—).
     /// </summary>
     IEnumerable<ComboItem> GetGeoCountryComboItems();
 
     /// <summary>
-    ///     Gets all geo-location region combo items for a given country (ID → English name).
-    ///     Only valid when <paramref name="country"/> is non-zero.
+    /// Gets all geo-location region combo items for a given country (ID → English name).
+    /// Only valid when <paramref name="country" /> is non-zero.
     /// </summary>
     IEnumerable<ComboItem> GetGeoRegionComboItems(byte country);
 
     /// <summary>
-    ///     Performs a full legality analysis on the given Pokémon using PKHeX.Core's
-    ///     <see cref="LegalityAnalysis"/> engine.
+    /// Performs a full legality analysis on the given Pokémon using PKHeX.Core's
+    /// <see cref="LegalityAnalysis" /> engine.
     /// </summary>
     /// <param name="pkm">The Pokémon to analyse.</param>
-    /// <returns>A <see cref="LegalityAnalysis"/> result.</returns>
+    /// <returns>A <see cref="LegalityAnalysis" /> result.</returns>
     LegalityAnalysis GetLegalityAnalysis(PKM pkm);
 }

--- a/Pkmds.Rcl/Services/IDragDropService.cs
+++ b/Pkmds.Rcl/Services/IDragDropService.cs
@@ -1,39 +1,39 @@
 namespace Pkmds.Rcl.Services;
 
 /// <summary>
-///     Service for managing drag-and-drop operations for Pokémon between slots.
-///     Tracks the source of a drag operation and provides state for drop targets.
+/// Service for managing drag-and-drop operations for Pokémon between slots.
+/// Tracks the source of a drag operation and provides state for drop targets.
 /// </summary>
 public interface IDragDropService
 {
     /// <summary>
-    ///     Gets or sets the Pokémon currently being dragged.
+    /// Gets or sets the Pokémon currently being dragged.
     /// </summary>
     PKM? DraggedPokemon { get; set; }
 
     /// <summary>
-    ///     Gets or sets the source box number where the drag started.
-    ///     Null for party slots or Let's Go storage.
+    /// Gets or sets the source box number where the drag started.
+    /// Null for party slots or Let's Go storage.
     /// </summary>
     int? DragSourceBoxNumber { get; set; }
 
     /// <summary>
-    ///     Gets or sets the source slot number where the drag started.
+    /// Gets or sets the source slot number where the drag started.
     /// </summary>
     int DragSourceSlotNumber { get; set; }
 
     /// <summary>
-    ///     Gets or sets whether the drag source is a party slot.
+    /// Gets or sets whether the drag source is a party slot.
     /// </summary>
     bool IsDragSourceParty { get; set; }
 
     /// <summary>
-    ///     Gets whether a drag operation is currently in progress.
+    /// Gets whether a drag operation is currently in progress.
     /// </summary>
     bool IsDragging { get; }
 
     /// <summary>
-    ///     Starts a drag operation with the specified Pokémon and source information.
+    /// Starts a drag operation with the specified Pokémon and source information.
     /// </summary>
     /// <param name="pokemon">The Pokémon being dragged.</param>
     /// <param name="boxNumber">The source box number (null for party or Let's Go storage).</param>
@@ -42,12 +42,12 @@ public interface IDragDropService
     void StartDrag(PKM? pokemon, int? boxNumber, int slotNumber, bool isParty);
 
     /// <summary>
-    ///     Ends the drag operation, indicating a successful drop.
+    /// Ends the drag operation, indicating a successful drop.
     /// </summary>
     void EndDrag();
 
     /// <summary>
-    ///     Cancels the drag operation without performing a drop.
+    /// Cancels the drag operation without performing a drop.
     /// </summary>
     void ClearDrag();
 }

--- a/Pkmds.Rcl/Services/ILoggingService.cs
+++ b/Pkmds.Rcl/Services/ILoggingService.cs
@@ -1,20 +1,20 @@
 namespace Pkmds.Rcl.Services;
 
 /// <summary>
-///     Service for controlling application logging levels.
-///     Allows users to toggle verbose logging for debugging purposes.
+/// Service for controlling application logging levels.
+/// Allows users to toggle verbose logging for debugging purposes.
 /// </summary>
 public interface ILoggingService
 {
     /// <summary>
-    ///     Gets or sets whether verbose logging is enabled.
-    ///     When true, sets log level to Verbose; when false, sets to Information.
+    /// Gets or sets whether verbose logging is enabled.
+    /// When true, sets log level to Verbose; when false, sets to Information.
     /// </summary>
     bool IsVerboseLoggingEnabled { get; set; }
 
     /// <summary>
-    ///     Event triggered when logging configuration changes.
-    ///     Provides the new log event level.
+    /// Event triggered when logging configuration changes.
+    /// Provides the new log event level.
     /// </summary>
     event Action<LogEventLevel>? OnLoggingConfigurationChanged;
 }

--- a/Pkmds.Rcl/Services/IRefreshService.cs
+++ b/Pkmds.Rcl/Services/IRefreshService.cs
@@ -1,65 +1,65 @@
 ﻿namespace Pkmds.Rcl.Services;
 
 /// <summary>
-///     Service for managing UI refresh events across the application.
-///     Components can subscribe to specific events to re-render when relevant state changes.
+/// Service for managing UI refresh events across the application.
+/// Components can subscribe to specific events to re-render when relevant state changes.
 /// </summary>
 public interface IRefreshService
 {
     /// <summary>
-    ///     Event triggered when general application state changes (e.g., save file loaded, language changed).
+    /// Event triggered when general application state changes (e.g., save file loaded, language changed).
     /// </summary>
     event Action? OnAppStateChanged;
 
     /// <summary>
-    ///     Event triggered when box data changes (e.g., Pokémon moved, edited, or deleted in boxes).
+    /// Event triggered when box data changes (e.g., Pokémon moved, edited, or deleted in boxes).
     /// </summary>
     event Action? OnBoxStateChanged;
 
     /// <summary>
-    ///     Event triggered when party data changes (e.g., Pokémon moved, edited, or deleted in party).
+    /// Event triggered when party data changes (e.g., Pokémon moved, edited, or deleted in party).
     /// </summary>
     event Action? OnPartyStateChanged;
 
     /// <summary>
-    ///     Event triggered when an application update is available.
+    /// Event triggered when an application update is available.
     /// </summary>
     event Action? OnUpdateAvailable;
 
     /// <summary>
-    ///     Event triggered when the UI theme changes between light and dark modes.
+    /// Event triggered when the UI theme changes between light and dark modes.
     /// </summary>
     event Action<bool>? OnThemeChanged;
 
     /// <summary>
-    ///     Triggers a general application state refresh.
+    /// Triggers a general application state refresh.
     /// </summary>
     void Refresh();
 
     /// <summary>
-    ///     Triggers a refresh for components displaying box data.
+    /// Triggers a refresh for components displaying box data.
     /// </summary>
     void RefreshBoxState();
 
     /// <summary>
-    ///     Triggers a refresh for components displaying party data.
+    /// Triggers a refresh for components displaying party data.
     /// </summary>
     void RefreshPartyState();
 
     /// <summary>
-    ///     Triggers a refresh for both box and party data simultaneously.
-    ///     Useful for operations that affect both (e.g., Let's Go Pikachu/Eevee).
+    /// Triggers a refresh for both box and party data simultaneously.
+    /// Useful for operations that affect both (e.g., Let's Go Pikachu/Eevee).
     /// </summary>
     void RefreshBoxAndPartyState();
 
     /// <summary>
-    ///     Triggers a theme change event.
+    /// Triggers a theme change event.
     /// </summary>
     /// <param name="isDarkMode">True for dark mode, false for light mode.</param>
     void RefreshTheme(bool isDarkMode);
 
     /// <summary>
-    ///     Displays a message notifying the user that an application update is available.
+    /// Displays a message notifying the user that an application update is available.
     /// </summary>
     // ReSharper disable once UnusedMember.Global
     void ShowUpdateMessage();

--- a/Pkmds.Rcl/Services/LoggingService.cs
+++ b/Pkmds.Rcl/Services/LoggingService.cs
@@ -1,8 +1,8 @@
 namespace Pkmds.Rcl.Services;
 
 /// <summary>
-///     Implementation of logging service for controlling application log levels.
-///     Allows runtime toggling between Information and Debug log levels.
+/// Implementation of logging service for controlling application log levels.
+/// Allows runtime toggling between Information and Debug log levels.
 /// </summary>
 public class LoggingService : ILoggingService
 {

--- a/Pkmds.Rcl/Services/SelectedPokemonType.cs
+++ b/Pkmds.Rcl/Services/SelectedPokemonType.cs
@@ -1,7 +1,7 @@
 ﻿namespace Pkmds.Rcl.Services;
 
 /// <summary>
-///     Enum representing the type of Pokémon slot currently selected.
+/// Enum representing the type of Pokémon slot currently selected.
 /// </summary>
 public enum SelectedPokemonType
 {

--- a/Pkmds.Tests/AppServiceTests.cs
+++ b/Pkmds.Tests/AppServiceTests.cs
@@ -1,7 +1,7 @@
 namespace Pkmds.Tests;
 
 /// <summary>
-///     Tests for AppService functionality
+/// Tests for AppService functionality
 /// </summary>
 public class AppServiceTests
 {

--- a/Pkmds.Tests/CatchRateStatusConditionTests.cs
+++ b/Pkmds.Tests/CatchRateStatusConditionTests.cs
@@ -1,7 +1,7 @@
 namespace Pkmds.Tests;
 
 /// <summary>
-///     Tests for Gen 1-2 Catch Rate and Status Condition editing.
+/// Tests for Gen 1-2 Catch Rate and Status Condition editing.
 /// </summary>
 public class CatchRateStatusConditionTests
 {
@@ -105,25 +105,19 @@ public class CatchRateStatusConditionTests
     }
 
     [Fact]
-    public void PK1_HasCatchRateProperty()
-    {
+    public void PK1_HasCatchRateProperty() =>
         // Assert
         typeof(PK1).GetProperty(nameof(PK1.CatchRate)).Should().NotBeNull();
-    }
 
     [Fact]
-    public void PK1_HasStatusConditionProperty()
-    {
+    public void PK1_HasStatusConditionProperty() =>
         // Assert
         typeof(PK1).GetProperty(nameof(PKM.Status_Condition)).Should().NotBeNull();
-    }
 
     [Fact]
-    public void PK2_HasStatusConditionProperty()
-    {
+    public void PK2_HasStatusConditionProperty() =>
         // Assert
         typeof(PK2).GetProperty(nameof(PKM.Status_Condition)).Should().NotBeNull();
-    }
 
     [Fact]
     public void PK1_CatchRate_DefaultsToZero()

--- a/Pkmds.Tests/ContestStatsTests.cs
+++ b/Pkmds.Tests/ContestStatsTests.cs
@@ -1,7 +1,7 @@
 namespace Pkmds.Tests;
 
 /// <summary>
-///     Tests for contest stat validation and Pokémon contest stat support.
+/// Tests for contest stat validation and Pokémon contest stat support.
 /// </summary>
 public class ContestStatsTests
 {
@@ -15,20 +15,16 @@ public class ContestStatsTests
     [InlineData(typeof(PB8))]
     [InlineData(typeof(PA8))]
     [InlineData(typeof(PK9))]
-    public void PKM_ImplementsIContestStats(Type pkmType)
-    {
+    public void PKM_ImplementsIContestStats(Type pkmType) =>
         // Assert
         typeof(IContestStats).IsAssignableFrom(pkmType).Should().BeTrue();
-    }
 
     [Theory]
     [InlineData(typeof(PK1))]
     [InlineData(typeof(PK2))]
-    public void PKM_DoesNotImplementIContestStats(Type pkmType)
-    {
+    public void PKM_DoesNotImplementIContestStats(Type pkmType) =>
         // Assert
         typeof(IContestStats).IsAssignableFrom(pkmType).Should().BeFalse();
-    }
 
     [Fact]
     public void ContestStats_PK3_CanBeSetAndRead()
@@ -100,11 +96,9 @@ public class ContestStatsTests
     }
 
     [Fact]
-    public void ContestStats_MaxValue_IsByteMaxValue()
-    {
+    public void ContestStats_MaxValue_IsByteMaxValue() =>
         // Assert
         ((int)byte.MaxValue).Should().Be(255);
-    }
 
     [Fact]
     public void ContestStats_NewPKM_DefaultsToZero()

--- a/Pkmds.Tests/ExtensionTests.cs
+++ b/Pkmds.Tests/ExtensionTests.cs
@@ -1,7 +1,7 @@
 namespace Pkmds.Tests;
 
 /// <summary>
-///     Tests for extension methods in PkmExtensions
+/// Tests for extension methods in PkmExtensions
 /// </summary>
 public class ExtensionTests
 {

--- a/Pkmds.Tests/Gen2NicknameFallbackTests.cs
+++ b/Pkmds.Tests/Gen2NicknameFallbackTests.cs
@@ -1,7 +1,7 @@
 namespace Pkmds.Tests;
 
 /// <summary>
-///     Tests validating the fix for Gen II nickname encoding issues
+/// Tests validating the fix for Gen II nickname encoding issues
 /// </summary>
 public class Gen2NicknameFallbackTests
 {

--- a/Pkmds.Tests/Gen2SilverTest.cs
+++ b/Pkmds.Tests/Gen2SilverTest.cs
@@ -1,7 +1,7 @@
 namespace Pkmds.Tests;
 
 /// <summary>
-///     Test Gen II Silver save (English) for nickname handling
+/// Test Gen II Silver save (English) for nickname handling
 /// </summary>
 public class Gen2SilverTest
 {

--- a/Pkmds.Tests/MemoryEditorTests.cs
+++ b/Pkmds.Tests/MemoryEditorTests.cs
@@ -1,7 +1,7 @@
 namespace Pkmds.Tests;
 
 /// <summary>
-///     Tests for memory editing support (Gen 6+).
+/// Tests for memory editing support (Gen 6+).
 /// </summary>
 public class MemoryEditorTests
 {
@@ -13,10 +13,7 @@ public class MemoryEditorTests
     [InlineData(typeof(PA8))]
     [InlineData(typeof(PK9))]
     [InlineData(typeof(PA9))]
-    public void PKM_Gen6Plus_ImplementsIMemoryOT(Type pkmType)
-    {
-        typeof(IMemoryOT).IsAssignableFrom(pkmType).Should().BeTrue();
-    }
+    public void PKM_Gen6Plus_ImplementsIMemoryOT(Type pkmType) => typeof(IMemoryOT).IsAssignableFrom(pkmType).Should().BeTrue();
 
     [Theory]
     [InlineData(typeof(PK6))]
@@ -26,10 +23,7 @@ public class MemoryEditorTests
     [InlineData(typeof(PA8))]
     [InlineData(typeof(PK9))]
     [InlineData(typeof(PA9))]
-    public void PKM_Gen6Plus_ImplementsIMemoryHT(Type pkmType)
-    {
-        typeof(IMemoryHT).IsAssignableFrom(pkmType).Should().BeTrue();
-    }
+    public void PKM_Gen6Plus_ImplementsIMemoryHT(Type pkmType) => typeof(IMemoryHT).IsAssignableFrom(pkmType).Should().BeTrue();
 
     [Theory]
     [InlineData(typeof(PK1))]
@@ -37,18 +31,12 @@ public class MemoryEditorTests
     [InlineData(typeof(PK3))]
     [InlineData(typeof(PK4))]
     [InlineData(typeof(PK5))]
-    public void PKM_PreGen6_DoesNotImplementIMemoryOT(Type pkmType)
-    {
-        typeof(IMemoryOT).IsAssignableFrom(pkmType).Should().BeFalse();
-    }
+    public void PKM_PreGen6_DoesNotImplementIMemoryOT(Type pkmType) => typeof(IMemoryOT).IsAssignableFrom(pkmType).Should().BeFalse();
 
     [Theory]
     [InlineData(typeof(PK6))]
     [InlineData(typeof(PK7))]
-    public void PKM_Gen6And7_ImplementsIAffection(Type pkmType)
-    {
-        typeof(IAffection).IsAssignableFrom(pkmType).Should().BeTrue();
-    }
+    public void PKM_Gen6And7_ImplementsIAffection(Type pkmType) => typeof(IAffection).IsAssignableFrom(pkmType).Should().BeTrue();
 
     [Theory]
     [InlineData(typeof(PK8))]
@@ -56,10 +44,7 @@ public class MemoryEditorTests
     [InlineData(typeof(PA8))]
     [InlineData(typeof(PK9))]
     [InlineData(typeof(PA9))]
-    public void PKM_Gen8Plus_DoesNotImplementIAffection(Type pkmType)
-    {
-        typeof(IAffection).IsAssignableFrom(pkmType).Should().BeFalse();
-    }
+    public void PKM_Gen8Plus_DoesNotImplementIAffection(Type pkmType) => typeof(IAffection).IsAssignableFrom(pkmType).Should().BeFalse();
 
     [Fact]
     public void OTMemory_PK6_CanBeSetAndRead()
@@ -225,7 +210,7 @@ public class MemoryEditorTests
         htMemory.HandlingTrainerMemoryIntensity = 2;
 
         // Act
-        MemoryApplicator.ClearMemories(pk6);
+        pk6.ClearMemories();
 
         // Assert
         otMemory.OriginalTrainerMemory.Should().Be(0);

--- a/Pkmds.Tests/PokemonEncryptionTests.cs
+++ b/Pkmds.Tests/PokemonEncryptionTests.cs
@@ -1,7 +1,7 @@
 namespace Pkmds.Tests;
 
 /// <summary>
-///     Tests for Pokémon encryption, decryption, and checksum validation
+/// Tests for Pokémon encryption, decryption, and checksum validation
 /// </summary>
 public class PokemonEncryptionTests
 {

--- a/Pkmds.Tests/RefreshAwareComponentTests.cs
+++ b/Pkmds.Tests/RefreshAwareComponentTests.cs
@@ -1,7 +1,7 @@
 namespace Pkmds.Tests;
 
 /// <summary>
-///     Tests for RefreshAwareComponent functionality
+/// Tests for RefreshAwareComponent functionality
 /// </summary>
 public class RefreshAwareComponentTests
 {

--- a/Pkmds.Tests/RibbonEditorTests.cs
+++ b/Pkmds.Tests/RibbonEditorTests.cs
@@ -1,7 +1,7 @@
 namespace Pkmds.Tests;
 
 /// <summary>
-///     Tests for the ribbon editor logic in RibbonHelper.
+/// Tests for the ribbon editor logic in RibbonHelper.
 /// </summary>
 public class RibbonEditorTests
 {

--- a/Pkmds.Tests/SaveFileLoadingTests.cs
+++ b/Pkmds.Tests/SaveFileLoadingTests.cs
@@ -1,7 +1,7 @@
 namespace Pkmds.Tests;
 
 /// <summary>
-///     Tests for loading various save file formats
+/// Tests for loading various save file formats
 /// </summary>
 public class SaveFileLoadingTests
 {

--- a/Pkmds.Tests/SaveFileSavingTests.cs
+++ b/Pkmds.Tests/SaveFileSavingTests.cs
@@ -1,7 +1,7 @@
 namespace Pkmds.Tests;
 
 /// <summary>
-///     Tests for saving save files and verifying data integrity
+/// Tests for saving save files and verifying data integrity
 /// </summary>
 public class SaveFileSavingTests
 {

--- a/Pkmds.Web/AppState.cs
+++ b/Pkmds.Web/AppState.cs
@@ -1,9 +1,9 @@
 ﻿namespace Pkmds.Web;
 
 /// <summary>
-///     Blazor WebAssembly implementation of the application state.
-///     This record holds the global state for the PKMDS application including the current save file,
-///     selected slots, clipboard data, and UI preferences.
+/// Blazor WebAssembly implementation of the application state.
+/// This record holds the global state for the PKMDS application including the current save file,
+/// selected slots, clipboard data, and UI preferences.
 /// </summary>
 public record AppState : IAppState
 {

--- a/Pkmds.Web/Services/BlazorAesProvider.cs
+++ b/Pkmds.Web/Services/BlazorAesProvider.cs
@@ -1,15 +1,15 @@
 ﻿namespace Pkmds.Web.Services;
 
 /// <summary>
-///     Blazor WebAssembly implementation of AES cryptography provider.
-///     Uses JavaScript interop (via crypto-js) to perform AES encryption/decryption
-///     because System.Security.Cryptography is not fully supported in WASM.
-///     This is required for PKHeX.Core's encryption/decryption of save files and Pokémon data.
+/// Blazor WebAssembly implementation of AES cryptography provider.
+/// Uses JavaScript interop (via crypto-js) to perform AES encryption/decryption
+/// because System.Security.Cryptography is not fully supported in WASM.
+/// This is required for PKHeX.Core's encryption/decryption of save files and Pokémon data.
 /// </summary>
 public class BlazorAesProvider(JsService jsService) : IAesCryptographyProvider
 {
     /// <summary>
-    ///     Creates an AES cryptography instance with the specified parameters.
+    /// Creates an AES cryptography instance with the specified parameters.
     /// </summary>
     /// <param name="key">The encryption key.</param>
     /// <param name="mode">The cipher mode (ECB or CBC).</param>
@@ -20,7 +20,7 @@ public class BlazorAesProvider(JsService jsService) : IAesCryptographyProvider
         new CryptoJsAes(jsService, key, mode, padding, iv);
 
     /// <summary>
-    ///     Internal class that implements AES encryption/decryption using JavaScript interop.
+    /// Internal class that implements AES encryption/decryption using JavaScript interop.
     /// </summary>
 #pragma warning disable CS9113 // Parameter is unread.
     private class CryptoJsAes(JsService jsService, byte[] key, CipherMode mode, PaddingMode padding, byte[]? iv = null)
@@ -28,31 +28,31 @@ public class BlazorAesProvider(JsService jsService) : IAesCryptographyProvider
         : IAesCryptographyProvider.IAes
     {
         /// <summary>
-        ///     Encrypts data using AES in ECB mode.
+        /// Encrypts data using AES in ECB mode.
         /// </summary>
         public void EncryptEcb(ReadOnlySpan<byte> plaintext, Span<byte> destination) =>
             jsService.EncryptAes(plaintext, destination, key, CipherMode.ECB);
 
         /// <summary>
-        ///     Decrypts data using AES in ECB mode.
+        /// Decrypts data using AES in ECB mode.
         /// </summary>
         public void DecryptEcb(ReadOnlySpan<byte> ciphertext, Span<byte> destination) =>
             jsService.DecryptAes(ciphertext, destination, key, CipherMode.ECB);
 
         /// <summary>
-        ///     Encrypts data using AES in CBC mode.
+        /// Encrypts data using AES in CBC mode.
         /// </summary>
         public void EncryptCbc(ReadOnlySpan<byte> plaintext, Span<byte> destination) =>
             jsService.EncryptAes(plaintext, destination, key, CipherMode.CBC);
 
         /// <summary>
-        ///     Decrypts data using AES in CBC mode.
+        /// Decrypts data using AES in CBC mode.
         /// </summary>
         public void DecryptCbc(ReadOnlySpan<byte> ciphertext, Span<byte> destination) =>
             jsService.DecryptAes(ciphertext, destination, key, CipherMode.CBC);
 
         /// <summary>
-        ///     Disposes the AES instance (no-op for JavaScript-based implementation).
+        /// Disposes the AES instance (no-op for JavaScript-based implementation).
         /// </summary>
         public void Dispose() { }
     }

--- a/Pkmds.Web/Services/BlazorMd5Provider.cs
+++ b/Pkmds.Web/Services/BlazorMd5Provider.cs
@@ -1,15 +1,15 @@
 ﻿namespace Pkmds.Web.Services;
 
 /// <summary>
-///     Blazor WebAssembly implementation of MD5 hashing provider.
-///     Uses JavaScript interop (via crypto-js) to perform MD5 hashing
-///     because System.Security.Cryptography is not fully supported in WASM.
-///     This is required for PKHeX.Core's checksum validation of save files.
+/// Blazor WebAssembly implementation of MD5 hashing provider.
+/// Uses JavaScript interop (via crypto-js) to perform MD5 hashing
+/// because System.Security.Cryptography is not fully supported in WASM.
+/// This is required for PKHeX.Core's checksum validation of save files.
 /// </summary>
 public class BlazorMd5Provider(JsService jsService) : IMd5Provider
 {
     /// <summary>
-    ///     Computes the MD5 hash of the input data.
+    /// Computes the MD5 hash of the input data.
     /// </summary>
     /// <param name="source">The data to hash.</param>
     /// <param name="destination">The span to write the hash to (must be at least 16 bytes).</param>

--- a/Pkmds.Web/Services/JsService.cs
+++ b/Pkmds.Web/Services/JsService.cs
@@ -1,14 +1,14 @@
 ﻿namespace Pkmds.Web.Services;
 
 /// <summary>
-///     Service for JavaScript interop, providing cryptographic operations via crypto-js library.
-///     This service bridges .NET code with JavaScript implementations of AES and MD5,
-///     which are necessary because these cryptographic APIs are not fully supported in Blazor WebAssembly.
+/// Service for JavaScript interop, providing cryptographic operations via crypto-js library.
+/// This service bridges .NET code with JavaScript implementations of AES and MD5,
+/// which are necessary because these cryptographic APIs are not fully supported in Blazor WebAssembly.
 /// </summary>
 public class JsService(IJSRuntime js)
 {
     /// <summary>
-    ///     Gets the synchronous JavaScript runtime, throwing if not available.
+    /// Gets the synchronous JavaScript runtime, throwing if not available.
     /// </summary>
     /// <exception cref="NotSupportedException">Thrown when IJSInProcessRuntime is not available.</exception>
     private IJSInProcessRuntime SyncJs =>
@@ -16,7 +16,7 @@ public class JsService(IJSRuntime js)
         ?? throw new NotSupportedException("Requested an in process javascript interop, but none was found");
 
     /// <summary>
-    ///     Encrypts data using AES with the specified key and cipher mode.
+    /// Encrypts data using AES with the specified key and cipher mode.
     /// </summary>
     /// <param name="origin">The plaintext data to encrypt.</param>
     /// <param name="destination">The span to write the encrypted data to.</param>
@@ -34,7 +34,7 @@ public class JsService(IJSRuntime js)
     }
 
     /// <summary>
-    ///     Decrypts data using AES with the specified key and cipher mode.
+    /// Decrypts data using AES with the specified key and cipher mode.
     /// </summary>
     /// <param name="origin">The ciphertext data to decrypt.</param>
     /// <param name="destination">The span to write the decrypted data to.</param>
@@ -52,7 +52,7 @@ public class JsService(IJSRuntime js)
     }
 
     /// <summary>
-    ///     Converts a hexadecimal string to a byte array.
+    /// Converts a hexadecimal string to a byte array.
     /// </summary>
     /// <param name="hex">The hexadecimal string (without separators).</param>
     /// <returns>The byte array representation.</returns>
@@ -68,7 +68,7 @@ public class JsService(IJSRuntime js)
     }
 
     /// <summary>
-    ///     Computes the MD5 hash of the input data using JavaScript interop.
+    /// Computes the MD5 hash of the input data using JavaScript interop.
     /// </summary>
     /// <param name="toArray">The data to hash.</param>
     /// <returns>The MD5 hash as a byte array (16 bytes).</returns>

--- a/Pkmds.Web/Services/RefreshService.cs
+++ b/Pkmds.Web/Services/RefreshService.cs
@@ -1,18 +1,18 @@
 ﻿namespace Pkmds.Web.Services;
 
 /// <summary>
-///     Blazor WebAssembly implementation of the refresh service.
-///     Manages UI refresh events and provides JavaScript interop for service worker update notifications.
+/// Blazor WebAssembly implementation of the refresh service.
+/// Manages UI refresh events and provides JavaScript interop for service worker update notifications.
 /// </summary>
 public class RefreshService : IRefreshService
 {
     /// <summary>
-    ///     Initializes a new instance and sets the singleton instance for JavaScript interop.
+    /// Initializes a new instance and sets the singleton instance for JavaScript interop.
     /// </summary>
     public RefreshService() => Instance = this; // Set the singleton instance for JS interop
 
     /// <summary>
-    ///     Static singleton instance used by JavaScript to invoke update notifications.
+    /// Static singleton instance used by JavaScript to invoke update notifications.
     /// </summary>
     private static RefreshService? Instance { get; set; }
 
@@ -66,7 +66,7 @@ public class RefreshService : IRefreshService
     public void RefreshTheme(bool isDarkMode) => OnThemeChanged?.Invoke(isDarkMode);
 
     /// <summary>
-    ///     JavaScript-invokable method called by the service worker when an app update is detected.
+    /// JavaScript-invokable method called by the service worker when an app update is detected.
     /// </summary>
     [JSInvokable(nameof(ShowUpdateMessage))]
     public static void ShowUpdateMessage() => Instance?.OnUpdateAvailable?.Invoke();

--- a/Pkmds.slnx
+++ b/Pkmds.slnx
@@ -1,12 +1,12 @@
 <Solution>
-  <Folder Name="/Solution Items/">
-    <File Path=".editorconfig" />
-    <File Path="Directory.Build.props" />
-    <File Path="Directory.Packages.props" />
-    <File Path="global.json" />
-  </Folder>
-  <Project Path="Pkmds.Core/Pkmds.Core.csproj" />
-  <Project Path="Pkmds.Rcl/Pkmds.Rcl.csproj" />
-  <Project Path="Pkmds.Tests/Pkmds.Tests.csproj" />
-  <Project Path="Pkmds.Web/Pkmds.Web.csproj" />
+    <Folder Name="/Solution Items/">
+        <File Path=".editorconfig"/>
+        <File Path="Directory.Build.props"/>
+        <File Path="Directory.Packages.props"/>
+        <File Path="global.json"/>
+    </Folder>
+    <Project Path="Pkmds.Core/Pkmds.Core.csproj"/>
+    <Project Path="Pkmds.Rcl/Pkmds.Rcl.csproj"/>
+    <Project Path="Pkmds.Tests/Pkmds.Tests.csproj"/>
+    <Project Path="Pkmds.Web/Pkmds.Web.csproj"/>
 </Solution>


### PR DESCRIPTION
Replace static helper usages with instance-style PKM methods (e.g. SetIsShiny, SetRandomEC, SetMoveset, SetRelearnMoves, SetPIDGender) and switch Snackbar severity uses to the local Severity enum. Apply numerous Razor and C# formatting/documentation cleanups, minor switch/bitwise fixes, and UI layout tweaks (dialog options compacted, MudBlazor component attribute formatting). Update Directory.Packages.props to bump bUnit to 2.6.2 and normalize Pkmds.Core csproj formatting. Reorganize OtMiscTab logic (parameter/cache initialization moved and formatting adjusted), use instance ClearGeoLocationData, and remove an explicit locale parameter for LegalityLocalizationContext.Create. Tests and other callers were updated accordingly.