### PR TITLE
Add origin mark & favorite UI; fix format checks, closes #418

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ Runtime wiring (Web)
 
 ## PKHeX.Core
 
-This app depends heavily on [PKHeX.Core](https://github.com/kwsch/PKHeX). When implementing features, use the PKHeX WinForms app as a reference for how to leverage PKHeX.Core — both for UI/UX patterns and for understanding the correct API usage.
+This app depends heavily on [PKHeX.Core](https://github.com/kwsch/PKHeX). When implementing features, use the PKHeX WinForms app as a reference for how to leverage PKHeX.Core — both for UI/UX patterns and for understanding the correct API usage. The first place you should look when referencing PKHeX is ../PKHeX/, which contains the PKHeX WinForms app source code. The `PKHeX.Core` project within that solution is the library we consume here, and the WinForms app is a separate project that references it. The PKHeX WinForms app is a great reference for how to use PKHeX.Core effectively, as it demonstrates real-world usage of the library's APIs in a production application. If you can't find the source there, the PKHeX Wiki and source code are also valuable resources for understanding how to work with PKHeX.Core.
 
 If you encounter bugs or limitations in PKHeX.Core while working on an issue or PR, note them in a code comment at the relevant site and report them on the GitHub issue or PR you are working on.
 

--- a/PKHEX_PARITY_ROADMAP.md
+++ b/PKHEX_PARITY_ROADMAP.md
@@ -28,7 +28,7 @@ This roadmap outlines the path to achieving 100% feature parity with PKHeX. Task
 - **Mystery Gift Database** - Browse, search, filter, import mystery gifts
 - **Met Data** - Met location, ball, level, origin game, Ground Tile (Gen 4), Fateful Encounter, Met Date (Gen 4+), Egg Location + Egg Date (Gen 4+), Met Time of Day (Gen 2) *(Battle Version and Obedience Level not yet implemented — see §1.1)*
 - **OT/Misc Data** - Original trainer info, TID/SID (16-bit and 6-digit), handling trainer name/gender/language (Gen 8+), memory editing (Gen 6+), affection/friendship, Geo Locations (Gen 6–7), Home Tracker (Gen 8+) *(Country/Sub-Region/Console Region and Affixed Ribbon not yet implemented — see §1.1)*
-- **Cosmetic Features** - Markings, height/weight scalars, scale rating *(Origin mark display and Favorite toggle not yet implemented — see §1.1)*
+- **Cosmetic Features** - Markings, height/weight scalars, scale rating, origin mark display (Gen 6+), Favorite toggle (Gen 7b+)
 - **Pokerus** - Infection status display/editing
 - **Hidden Power** - Type selection
 - **Showdown Export** - Export Pokemon to Showdown format
@@ -150,12 +150,12 @@ This roadmap outlines the path to achieving 100% feature parity with PKHeX. Task
 - [ ] **Affixed Ribbon / Mark** (`PKM.AffixedRibbon`, Gen 8+) — selects which ribbon or mark is displayed on the Pokémon's summary screen; stored as a `RibbonIndex` enum value
 
 #### Cosmetic Tab — Origin Mark Display and Favorite
-**Status:** ❌ Not Implemented
+**Status:** ✅ Implemented (#418)
 **Complexity:** Low
 **Tracks:** #418
 **PKHeX Reference:** `PB_Origin` and `PB_Favorite` in `PKMEditor.cs`; `OriginMarkUtil.GetOriginMark(pk)` in `PKHeX.Core/PKM/Enums/OriginMark.cs`
 **Tasks:**
-- [ ] **Origin Mark display** (`OriginMarkUtil.GetOriginMark(pk)`, Gen 6+) — read-only icon shown in the Cosmetic tab indicating which generation group the Pokémon originated from; derived from the entity's version, not editable directly:
+- [x] **Origin Mark display** (`OriginMarkUtil.GetOriginMark(pk)`, Gen 6+) — read-only icon shown in the Cosmetic tab indicating which generation group the Pokémon originated from; derived from the entity's version, not editable directly:
   - Gen 6 (X/Y, ORAS) → Pentagon mark
   - Gen 7 (SM, USUM) → Clover/flower mark
   - Gen 8 SWSH → Galar mark
@@ -166,7 +166,7 @@ This roadmap outlines the path to achieving 100% feature parity with PKHeX. Task
   - Virtual Console (Gen 1–2 VC) → Game Boy mark
   - Pokémon GO transfers → GO mark
   - LGPE (Let's Go) → Let's Go mark
-- [ ] **Favorite toggle** (`IFavorite.IsFavorite`) — clickable toggle; shown whenever the entity implements `IFavorite`: `PB7` (LGPE), `G8PKM` base (PK8 SWSH + PB8 BDSP), `PA8` (LA), `PK9`/`PA9` (SV); marks the Pokémon as a favorite in the PC box; in PKHeX, `ClickFavorite` uses `Entity is IFavorite` so it works for all these formats, not just LGPE
+- [x] **Favorite toggle** (`IFavorite.IsFavorite`) — clickable toggle; shown whenever the entity implements `IFavorite`: `PB7` (LGPE), `G8PKM` base (PK8 SWSH + PB8 BDSP), `PA8` (LA), `PK9`/`PA9` (SV); marks the Pokémon as a favorite in the PC box; in PKHeX, `ClickFavorite` uses `Entity is IFavorite` so it works for all these formats, not just LGPE
 
 #### Generation-Specific Fields Not Yet Implemented
 **Status:** ❌ Not Implemented

--- a/Pkmds.Rcl/Components/EditForms/Tabs/CosmeticTab.razor
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/CosmeticTab.razor
@@ -13,6 +13,28 @@
     <MarkingsContainer Pokemon="@Pokemon"/>
 }
 
+@if (OriginMarkSpriteFileName is { } originSrc)
+{
+    <MudStack Row
+              AlignItems="@AlignItems.Center"
+              Class="ma-2">
+        <MudText>Origin Mark:</MudText>
+        <MudImage Src="@originSrc"
+                  Alt="Origin Mark"
+                  title="Origin Mark"
+                  Width="24"
+                  ObjectFit="@ObjectFit.Contain"
+                  ObjectPosition="@ObjectPosition.Center"/>
+    </MudStack>
+}
+
+@if (Pokemon is IFavorite)
+{
+    <MudCheckBox Label="Favorite"
+                 @bind-Value="@IsFavorite"
+                 @bind-Value:after="@RefreshService.Refresh"/>
+}
+
 @if (Pokemon is IScaledSize scaledSize)
 {
     <MudNumericField T="@byte"

--- a/Pkmds.Rcl/Components/EditForms/Tabs/CosmeticTab.razor.cs
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/CosmeticTab.razor.cs
@@ -17,4 +17,18 @@ public partial class CosmeticTab : IDisposable
         PK9 => PokeSizeDetailedUtil.GetSizeRating(scaledSize3.Scale).ToString(),
         _ => PokeSizeUtil.GetSizeRating(scaledSize3.Scale).ToString()
     };
+
+    private string? OriginMarkSpriteFileName => Pokemon is { Format: >= 6 }
+        ? ImageHelper.GetOriginMarkSpriteFileName(OriginMarkUtil.GetOriginMark(Pokemon))
+        : null;
+
+    private bool IsFavorite
+    {
+        get => Pokemon is IFavorite fav && fav.IsFavorite;
+        set
+        {
+            if (Pokemon is IFavorite fav)
+                fav.IsFavorite = value;
+        }
+    }
 }

--- a/Pkmds.Rcl/Components/MarkingsContainer.razor
+++ b/Pkmds.Rcl/Components/MarkingsContainer.razor
@@ -1,4 +1,4 @@
-﻿@if (Pokemon is { Generation: var pokemonGeneration and >= 3 })
+﻿@if (Pokemon is { Format: var pokemonFormat and >= 3 })
 {
     <div class="@ContainerClass">
         <MarkingComponent Pokemon="@Pokemon"
@@ -13,7 +13,7 @@
         <MarkingComponent Pokemon="@Pokemon"
                           Shape="@MarkingsHelper.Markings.Heart"/>
 
-        @if (pokemonGeneration >= 4)
+        @if (pokemonFormat >= 4)
         {
             <MarkingComponent Pokemon="@Pokemon"
                               Shape="@MarkingsHelper.Markings.Star"/>

--- a/Pkmds.Rcl/Components/MarkingsContainer.razor.cs
+++ b/Pkmds.Rcl/Components/MarkingsContainer.razor.cs
@@ -7,7 +7,7 @@ public partial class MarkingsContainer : IDisposable
     public PKM? Pokemon { get; set; }
 
     private string ContainerClass =>
-        $"grid grid-rows-2 pt-[3px] justify-items-center items-center{(Pokemon is { Generation: 3 } ? " grid-cols-4 gap-0" : " grid-cols-3 gap-[25px]")}";
+        $"grid grid-rows-2 pt-[3px] justify-items-center items-center{(Pokemon is { Format: 3 } ? " grid-cols-4 gap-0" : " grid-cols-3 gap-[25px]")}";
 
     public void Dispose() => RefreshService.OnAppStateChanged -= StateHasChanged;
 

--- a/Pkmds.Rcl/ImageHelper.Accent.cs
+++ b/Pkmds.Rcl/ImageHelper.Accent.cs
@@ -32,4 +32,20 @@ public static partial class ImageHelper
     /// <summary>Gets the sprite filename for a ribbon affix state indicator.</summary>
     public static string GetRibbonAffixSpriteFileName(string affixState = "none") =>
         $"{SpritesRoot}ac/ribbon_affix_{affixState}.png";
+
+    /// <summary>Gets the sprite filename for an origin mark icon, or null if there is no origin mark.</summary>
+    public static string? GetOriginMarkSpriteFileName(OriginMark originMark) => originMark switch
+    {
+        OriginMark.Gen6Pentagon => $"{SpritesRoot}m/gen_6.png",
+        OriginMark.Gen7Clover => $"{SpritesRoot}m/gen_7.png",
+        OriginMark.Gen8Galar => $"{SpritesRoot}m/gen_8.png",
+        OriginMark.Gen8Trio => $"{SpritesRoot}m/gen_bs.png",
+        OriginMark.Gen8Arc => $"{SpritesRoot}m/gen_la.png",
+        OriginMark.Gen9Paldea => $"{SpritesRoot}m/gen_sv.png",
+        OriginMark.Gen9ZA => $"{SpritesRoot}m/gen_za.png",
+        OriginMark.GameBoy => $"{SpritesRoot}m/gen_vc.png",
+        OriginMark.GO => $"{SpritesRoot}m/gen_go.png",
+        OriginMark.LetsGo => $"{SpritesRoot}m/gen_gg.png",
+        _ => null,
+    };
 }


### PR DESCRIPTION
Implement origin mark display and favorite toggle in Cosmetic tab, add origin-mark sprite mappings, and correct marking layout checks to use PKM.Format instead of Generation. Files changed include CosmeticTab.razor/razor.cs (show origin icon for Format>=6, bind IFavorite.IsFavorite), ImageHelper.Accent.cs (GetOriginMarkSpriteFileName mapping), MarkingsContainer.razor/razor.cs (use Format for layout/feature gating), and documentation updates (AGENTS.md clarifies PKHeX source location; PKHEX_PARITY_ROADMAP marks Cosmetic features implemented). These changes enable origin mark visuals and favorite toggling for supported formats and fix incorrect generation-based checks.

Closes #418.