### PR TITLE
Fix Encounter DB: handle cross-format PKM generation via EntityConverter

### DIFF
--- a/Pkmds.Rcl/Components/MainTabPages/EncounterDatabaseTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/EncounterDatabaseTab.razor.cs
@@ -104,8 +104,12 @@ public partial class EncounterDatabaseTab : RefreshAwareComponent
 
         if (pkm is null)
         {
-            // Only null when no save file is loaded.
-            Snackbar.Add("No save file loaded.", Severity.Error);
+            // Null when no save file is loaded, or when the encounter's PKM format cannot be
+            // converted to the format required by the current save file (e.g. a Legends: Arceus
+            // encounter attempted against a BDSP save).
+            Snackbar.Add(
+                "Could not generate Pokémon. The encounter may be incompatible with the current save file format.",
+                Severity.Error);
             StateHasChanged();
             return;
         }

--- a/Pkmds.Rcl/Services/AppService.cs
+++ b/Pkmds.Rcl/Services/AppService.cs
@@ -1199,7 +1199,17 @@ public class AppService(IAppState appState, IRefreshService refreshService) : IA
         // Some encounter types (e.g. HOME Mystery Gifts) may not pass a strict legality
         // check even when generated correctly; the caller can run a legality check separately
         // and surface the result to the user.
-        return encounter.ConvertToPKM(sav);
+        var pkm = encounter.ConvertToPKM(sav);
+
+        // Some cross-game encounters (e.g. a Legends: Arceus static returning PA8 when the
+        // loaded save is BDSP, which requires PB8) produce a PKM in the wrong format.
+        // Attempt a format conversion via EntityConverter; return null if none is possible
+        // so the caller can surface a meaningful error instead of crashing.
+        var expectedType = sav.BlankPKM.GetType();
+        if (pkm.GetType() != expectedType)
+            pkm = EntityConverter.ConvertToType(pkm, expectedType, out _);
+
+        return pkm;
     }
 
     private EncounterSearchResult BuildEncounterResult(IEncounterable enc)


### PR DESCRIPTION
## Summary

- `IEncounterable.ConvertToPKM` always returns the encounter's native PKM type (e.g. `EncounterStatic8a` → `PA8`) regardless of the loaded save file — the save only provides trainer metadata.
- When the generated type differs from what the save file expects (e.g. PA8 from a Legends: Arceus encounter vs. PB8 required by a BDSP save), `SetBoxSlotAtIndex` was throwing `ArgumentException` and crashing.
- After `ConvertToPKM`, the format is now checked against `sav.BlankPKM.GetType()`. If they differ, `EntityConverter.ConvertToType` is attempted. This covers all cross-format combinations: Gen 8 side formats (PA8 ↔ PB8 ↔ PK8) via the HOME path, and older-gen encounters (PK1–PK7) via the sequential chain into HOME.
- If no transfer route exists (e.g. an incompatible species or a backwards conversion), `ConvertToType` returns `null`, and the caller now shows a clear "incompatible format" error snackbar instead of crashing.

## Test plan

- [ ] Load a BDSP save, search for Arceus in Encounter DB, select the Legends: Arceus static (Temple of Sinnoh, Lv. 75), click Generate — should no longer crash; either places a converted Pokémon (with legality warning) or shows the incompatible-format error.
- [ ] Load a SwSh save, search for a species with Gen 1–7 encounters, generate one — should convert via the sequential chain without crashing.
- [ ] Load any save, generate an encounter that matches the save's own format — should work exactly as before (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)