### PR TITLE
Enable frontend-design plugin in Claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "defaultMode": "dontAsk",
   "permissions": {
     "allow": [
       "Bash(dotnet *)",
@@ -15,5 +14,9 @@
       "mcp__*"
     ],
     "deny": []
+  },
+  "defaultMode": "dontAsk",
+  "enabledPlugins": {
+    "frontend-design@claude-plugins-official": true
   }
 }


### PR DESCRIPTION
Add an enabledPlugins section to .claude/settings.json to enable "frontend-design@claude-plugins-official". Repositioned the "defaultMode": "dontAsk" entry (no changes to the permissions allow/deny lists). This activates the frontend design plugin for Claude integrations.