### PR TITLE
Perf: Fix performance for bag / inventory management

### DIFF
--- a/PKHEX_PARITY_ROADMAP.md
+++ b/PKHEX_PARITY_ROADMAP.md
@@ -2,7 +2,7 @@
 
 This roadmap outlines the path to achieving 100% feature parity with PKHeX. Tasks are broken down into actionable items organized by feature category and priority.
 
-**Last Updated:** 2026-03-03 (Box pop-out dialogs planned — §6.2, tracks #14; Bag performance plan added — §7.2; Damage Calculator planned — §5.7; Feature Documentation planned — §4.5; One-Touch Evolve planned — §1.1, tracks #448; Theme-aware loading screen + three-way toggle implemented — §4.1, tracks #449)
+**Last Updated:** 2026-03-03 (Box pop-out dialogs plan corrected to §6.2, now tracks #352; cross-save Pokémon transfer planned — §5.8, tracks #14; Bag performance plan added — §7.2; Damage Calculator planned — §5.7; Feature Documentation planned — §4.5; One-Touch Evolve planned — §1.1, tracks #448; Theme-aware loading screen + three-way toggle implemented — §4.1, tracks #449)
 
 ---
 
@@ -790,6 +790,7 @@ Bring the Mystery Gift Database tab to full parity with PKHeX's `SAV_MysteryGift
 - [ ] Create backup management system
 
 ### 4.3 Box Management Enhancements
+**Tracks:** #352
 **Tasks:**
 - [ ] Add box cloning
 - [ ] Implement box sorting (by species, level, shiny, etc.)
@@ -1017,6 +1018,27 @@ Three parallel tracks — wiki content authoring, in-app help links (code), and 
 - Screens, doubles/triples modifiers
 - Tera type STAB (SV)
 
+### 5.8 Cross-Save Pokémon Transfer
+**Status:** ❌ Not Implemented
+**Complexity:** High
+**Priority:** Medium
+**Tracks:** #14
+**Note:** Browser sandboxing prevents the PKHeX model (two separate windows). PKMDS will instead support loading two save files within a single session.
+
+**Overview:** Allow a second save file to be loaded into memory alongside the primary save. A transfer UI lets the user move or copy Pokémon between the two saves. The secondary save's file can be written back to disk independently.
+
+**PKHeX Reference:** The PKHeX WinForms app supports opening a second save via `File > Open` in the `SAV_BoxViewer` context, allowing drag-and-drop between the two windows. PKMDS adapts this into a split-pane or dialog-based transfer UI within a single browser session.
+
+**Tasks:**
+- [ ] Extend `IAppState` with `SaveFile? SecondaryFile` and corresponding DI plumbing
+- [ ] Add "Open Second Save" button/menu item; loads a file into `SecondaryFile` without replacing `PrimaryFile`
+- [ ] Build `CrossSaveTransferDialog` (or a dedicated split-pane view) showing both saves' boxes side by side
+- [ ] Implement click-to-copy and/or drag-and-drop of Pokémon from secondary → primary (and bidirectionally)
+- [ ] Block transfers that PKHeX.Core would reject due to format incompatibility; surface a user-friendly error
+- [ ] Add "Save Secondary File" action to write the modified secondary save back to disk
+- [ ] Clear `SecondaryFile` on explicit close or when primary file is replaced
+- [ ] Write unit tests for the transfer logic (slot swap correctness, format-incompatibility guard)
+
 ---
 
 ## Priority 6: Minor Features & Polishing
@@ -1035,7 +1057,7 @@ Three parallel tracks — wiki content authoring, in-app help links (code), and 
 ### 6.2 Box Viewer Enhancements
 **Status:** ❌ Not Implemented
 **Complexity:** Medium
-**Tracks:** #14
+**Tracks:** #352
 **PKHeX Reference:** `SAVEditor.cs:503–528,1579–1594`, `SAV_BoxViewer.Designer.cs`, `SAV_BoxList.cs`
 **Tasks:**
 - [ ] **`SwapBoxes(int boxA, int boxB)`** — add to `IAppService` / `AppService`; swaps all Pokémon between two boxes, triggers `RefreshAppState`
@@ -1054,7 +1076,7 @@ Three parallel tracks — wiki content authoring, in-app help links (code), and 
   - Subscribes to both `OnAppStateChanged` and `OnBoxStateChanged`
 - [ ] **Add trigger buttons to `PokemonStorageComponent`** — "Pop Out Box" (`OpenInNew` icon) and "All Boxes" (`GridView` icon) buttons in the box nav bar; both open their respective dialogs via `IDialogService`
 - [ ] **Unit tests** — `SwapBoxes` correctness; bUnit render tests for both dialogs
-- [ ] Implement box group viewer (SAV_GroupViewer) — follow-up
+- [ ] Implement box group viewer (SAV_GroupViewer) — follow-up (was #362, closed as duplicate; break out a new issue when ready)
 - [ ] Add box preview on hover — follow-up
 - [ ] Implement box quick-peek — follow-up
 

--- a/Pkmds.Rcl/Components/MainTabPages/BagTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/BagTab.razor
@@ -5,8 +5,9 @@
     <MudTabs Outlined
              Rounded
              Border
+             ActivePanelIndexChanged="@OnActivePanelChanged"
              @ref="@PouchTabs">
-        @foreach (var pouch in Inventory.Pouches)
+        @foreach (var (pouch, pouchIndex) in Inventory.Pouches.Select((p, i) => (p, i)))
         {
             <MudTabPanel ID="@pouch.Type.ToString()">
                 <TabContent>
@@ -24,176 +25,188 @@
                     </MudStack>
                 </TabContent>
                 <ChildContent>
-                    <MudStack>
-                        <MudStack Row>
-                            <MudButton OnClick="@SaveChanges"
-                                       Color="@Color.Primary"
-                                       Variant="@Variant.Filled"
-                                       StartIcon="@Icons.Material.Filled.Save">
-                                Save
-                            </MudButton>
-                            <MudButton OnClick="@(() => SortByName(pouch))"
-                                       Color="@Color.Default"
-                                       Variant="@Variant.Filled"
-                                       StartIcon="@Icons.Material.Filled.SortByAlpha">
-                                Sort By Name
-                            </MudButton>
-                            <MudButton OnClick="@(() => SortByCount(pouch))"
-                                       Color="@Color.Default"
-                                       Variant="@Variant.Filled"
-                                       StartIcon="@Icons.Material.Filled.Sort">
-                                Sort By Count
-                            </MudButton>
-                            <MudButton OnClick="@(() => SortByIndex(pouch))"
-                                       Color="@Color.Default"
-                                       Variant="@Variant.Filled"
-                                       StartIcon="@Icons.Material.Filled.Sort">
-                                Sort By Index
-                            </MudButton>
-                            <MudSwitch @bind-Value="@ShouldVirtualize"
-                                       Color="@Color.Primary"
-                                       Label="Virtualize (may cause scrolling issues)"/>
-                        </MudStack>
-                        <MudDataGrid T="@InventoryItem"
-                                     Items="@pouch.Items"
-                                     ReadOnly="@false"
-                                     EditMode="@DataGridEditMode.Cell"
-                                     SortMode="@SortMode.None"
-                                     Dense
-                                     Hover
-                                     Striped
-                                     FixedHeader
-                                     EditTrigger="@DataGridEditTrigger.OnRowClick"
-                                     Height="calc(100vh - 300px)"
-                                     Virtualize="@ShouldVirtualize">
-                            <Columns>
-                                <PropertyColumn Property="@(item => item.Index)"
-                                                Title="Item">
-                                    <EditTemplate>
-                                        <MudStack Row
-                                                  Spacing="1"
-                                                  AlignItems="@AlignItems.Center">
-                                            <MudAutocomplete T="@ComboItem"
-                                                             Variant="@Variant.Outlined"
-                                                             Value="@GetItem(context)"
-                                                             ValueChanged="@(newItem => SetItem(context, newItem))"
-                                                             SearchFunc="@((string searchString, CancellationToken _) => SearchItemNames(pouch, searchString))"
-                                                             ToStringFunc="@(_ => ItemList[context.Item.Index])">
-                                                <ItemTemplate Context="item">
-                                                    <MudStack Row>
-                                                        @if (item.Value != 0)
-                                                        {
-                                                            <object class="item-sprite"
-                                                                    type="image/png"
-                                                                    style="object-fit: contain;"
-                                                                    data="@ImageHelper.GetItemSpriteFilename(item.Value, saveFile.Context)"
-                                                                    title="@item.Text">
-                                                                <img class="pkm-sprite"
-                                                                     src="@ImageHelper.ItemFallbackImageFileName"
-                                                                     title="@item.Text"
-                                                                     alt="@item.Text">
-                                                            </object>
-                                                        }
-                                                        <MudText>
-                                                            @item.Text
-                                                        </MudText>
-                                                    </MudStack>
-                                                </ItemTemplate>
-                                            </MudAutocomplete>
-                                            @if (context.Item.Index != 0)
-                                            {
-                                                var itemText = ItemList[context.Item.Index];
-                                                <object class="item-sprite"
-                                                        type="image/png"
-                                                        style="object-fit: contain;"
-                                                        data="@ImageHelper.GetItemSpriteFilename(context.Item.Index, saveFile.Context)"
-                                                        title="@itemText">
-                                                    <img class="pkm-sprite"
-                                                         src="@ImageHelper.ItemFallbackImageFileName"
-                                                         title="@itemText"
-                                                         alt="@itemText">
-                                                </object>
-                                            }
-                                        </MudStack>
-                                    </EditTemplate>
-                                </PropertyColumn>
-                                <PropertyColumn Property="@(item => item.Count)"
-                                                Title="Count">
-                                    <EditTemplate>
-                                        <MudNumericField T="@int"
-                                                         Variant="@Variant.Outlined"
-                                                         Max="@(AppState.IsHaXEnabled
-                                                                  ? saveFile.Generation <= 2
-                                                                      ? byte.MaxValue
-                                                                      : ushort.MaxValue
-                                                                  : pouch.MaxCount)"
-                                                         @bind-Value="@context.Item.Count"/>
-                                    </EditTemplate>
-                                </PropertyColumn>
-                                @if (HasFreeSpace)
-                                {
-                                    <TemplateColumn Title="Free">
+                    @if (RenderedPouches.Contains(pouchIndex))
+                    {
+                        <MudStack>
+                            <MudStack Row>
+                                <MudButton OnClick="@SaveChanges"
+                                           Color="@Color.Primary"
+                                           Variant="@Variant.Filled"
+                                           StartIcon="@Icons.Material.Filled.Save">
+                                    Save
+                                </MudButton>
+                                <MudButton OnClick="@(() => SortByName(pouch))"
+                                           Color="@Color.Default"
+                                           Variant="@Variant.Filled"
+                                           StartIcon="@Icons.Material.Filled.SortByAlpha">
+                                    Sort By Name
+                                </MudButton>
+                                <MudButton OnClick="@(() => SortByCount(pouch))"
+                                           Color="@Color.Default"
+                                           Variant="@Variant.Filled"
+                                           StartIcon="@Icons.Material.Filled.Sort">
+                                    Sort By Count
+                                </MudButton>
+                                <MudButton OnClick="@(() => SortByIndex(pouch))"
+                                           Color="@Color.Default"
+                                           Variant="@Variant.Filled"
+                                           StartIcon="@Icons.Material.Filled.Sort">
+                                    Sort By Index
+                                </MudButton>
+                                <MudSwitch @bind-Value="@ShowEmptySlots"
+                                           Color="@Color.Primary"
+                                           Label="Show Empty Slots"/>
+                            </MudStack>
+                            <MudDataGrid T="@InventoryItem"
+                                         Items="@(ShowEmptySlots
+                                                    ? pouch.Items
+                                                    : pouch.Items.Where(i => i.Count != 0).ToArray())"
+                                         ReadOnly="@false"
+                                         EditMode="@DataGridEditMode.Cell"
+                                         SortMode="@SortMode.None"
+                                         Dense
+                                         Hover
+                                         Striped
+                                         FixedHeader
+                                         EditTrigger="@DataGridEditTrigger.OnRowClick"
+                                         Height="calc(100vh - 300px)"
+                                         Class="bag-data-grid">
+                                <Columns>
+                                    <PropertyColumn Property="@(item => item.Index)"
+                                                    Title="Item">
+                                        <CellTemplate>
+                                            <MudText>@ItemList[context.Item.Index]</MudText>
+                                        </CellTemplate>
                                         <EditTemplate>
-                                            @if (context.Item is IItemFreeSpace freeSpaceItem)
-                                            {
-                                                <MudCheckBox Label="Free Space"
-                                                             Value="@freeSpaceItem.IsFreeSpace"
-                                                             ValueChanged="@((bool value) => freeSpaceItem.IsFreeSpace = value)"/>
-                                            }
-                                        </EditTemplate>
-                                    </TemplateColumn>
-                                }
-                                @if (HasFreeSpaceIndex)
-                                {
-                                    <TemplateColumn Title="Free">
-                                        <EditTemplate>
-                                            @if (context.Item is IItemFreeSpaceIndex freeSpaceIndexItem)
-                                            {
-                                                <MudNumericField T="@uint"
+                                            <MudStack Row
+                                                      Spacing="1"
+                                                      AlignItems="@AlignItems.Center">
+                                                <MudAutocomplete T="@ComboItem"
                                                                  Variant="@Variant.Outlined"
-                                                                 @bind-Value="@freeSpaceIndexItem.FreeSpaceIndex"/>
-                                            }
+                                                                 Value="@GetItem(context)"
+                                                                 ValueChanged="@(newItem => SetItem(context, newItem))"
+                                                                 SearchFunc="@((string searchString, CancellationToken _) => SearchItemNames(pouch, searchString))"
+                                                                 ToStringFunc="@(_ => ItemList[context.Item.Index])">
+                                                    <ItemTemplate Context="item">
+                                                        <MudStack Row>
+                                                            @if (item.Value != 0)
+                                                            {
+                                                                <object class="item-sprite"
+                                                                        type="image/png"
+                                                                        style="object-fit: contain;"
+                                                                        data="@ImageHelper.GetItemSpriteFilename(item.Value, saveFile.Context)"
+                                                                        title="@item.Text">
+                                                                    <img class="pkm-sprite"
+                                                                         src="@ImageHelper.ItemFallbackImageFileName"
+                                                                         title="@item.Text"
+                                                                         alt="@item.Text">
+                                                                </object>
+                                                            }
+                                                            <MudText>
+                                                                @item.Text
+                                                            </MudText>
+                                                        </MudStack>
+                                                    </ItemTemplate>
+                                                </MudAutocomplete>
+                                                @if (context.Item.Index != 0)
+                                                {
+                                                    var itemText = ItemList[context.Item.Index];
+                                                    <object class="item-sprite"
+                                                            type="image/png"
+                                                            style="object-fit: contain;"
+                                                            data="@ImageHelper.GetItemSpriteFilename(context.Item.Index, saveFile.Context)"
+                                                            title="@itemText">
+                                                        <img class="pkm-sprite"
+                                                             src="@ImageHelper.ItemFallbackImageFileName"
+                                                             title="@itemText"
+                                                             alt="@itemText">
+                                                    </object>
+                                                }
+                                            </MudStack>
                                         </EditTemplate>
-                                    </TemplateColumn>
-                                }
-                                @if (HasFavorite)
-                                {
-                                    <TemplateColumn Title="Favorite">
+                                    </PropertyColumn>
+                                    <PropertyColumn Property="@(item => item.Count)"
+                                                    Title="Count">
                                         <EditTemplate>
-                                            @if (context.Item is IItemFavorite favoriteItem)
-                                            {
-                                                <MudCheckBox Label="Favorite"
-                                                             Value="@favoriteItem.IsFavorite"
-                                                             ValueChanged="@((bool value) => favoriteItem.IsFavorite = value)"/>
-                                            }
+                                            <MudNumericField T="@int"
+                                                             Variant="@Variant.Outlined"
+                                                             Max="@(AppState.IsHaXEnabled
+                                                                      ? saveFile.Generation <= 2
+                                                                          ? byte.MaxValue
+                                                                          : ushort.MaxValue
+                                                                      : pouch.MaxCount)"
+                                                             @bind-Value="@context.Item.Count"/>
                                         </EditTemplate>
-                                    </TemplateColumn>
-                                }
-                                @if (HasNew)
-                                {
-                                    <TemplateColumn Title="New">
+                                    </PropertyColumn>
+                                    @if (HasFreeSpace)
+                                    {
+                                        <TemplateColumn Title="Free">
+                                            <EditTemplate>
+                                                @if (context.Item is IItemFreeSpace freeSpaceItem)
+                                                {
+                                                    <MudCheckBox Label="Free Space"
+                                                                 Value="@freeSpaceItem.IsFreeSpace"
+                                                                 ValueChanged="@((bool value) => freeSpaceItem.IsFreeSpace = value)"/>
+                                                }
+                                            </EditTemplate>
+                                        </TemplateColumn>
+                                    }
+                                    @if (HasFreeSpaceIndex)
+                                    {
+                                        <TemplateColumn Title="Free">
+                                            <EditTemplate>
+                                                @if (context.Item is IItemFreeSpaceIndex freeSpaceIndexItem)
+                                                {
+                                                    <MudNumericField T="@uint"
+                                                                     Variant="@Variant.Outlined"
+                                                                     @bind-Value="@freeSpaceIndexItem.FreeSpaceIndex"/>
+                                                }
+                                            </EditTemplate>
+                                        </TemplateColumn>
+                                    }
+                                    @if (HasFavorite)
+                                    {
+                                        <TemplateColumn Title="Favorite">
+                                            <EditTemplate>
+                                                @if (context.Item is IItemFavorite favoriteItem)
+                                                {
+                                                    <MudCheckBox Label="Favorite"
+                                                                 Value="@favoriteItem.IsFavorite"
+                                                                 ValueChanged="@((bool value) => favoriteItem.IsFavorite = value)"/>
+                                                }
+                                            </EditTemplate>
+                                        </TemplateColumn>
+                                    }
+                                    @if (HasNew)
+                                    {
+                                        <TemplateColumn Title="New">
+                                            <EditTemplate>
+                                                @if (context.Item is IItemNewFlag newFlagItem)
+                                                {
+                                                    <MudCheckBox Label="New"
+                                                                 Value="@newFlagItem.IsNew"
+                                                                 ValueChanged="@((bool value) => newFlagItem.IsNew = value)"/>
+                                                }
+                                            </EditTemplate>
+                                        </TemplateColumn>
+                                    }
+                                    <TemplateColumn>
                                         <EditTemplate>
-                                            @if (context.Item is IItemNewFlag newFlagItem)
-                                            {
-                                                <MudCheckBox Label="New"
-                                                             Value="@newFlagItem.IsNew"
-                                                             ValueChanged="@((bool value) => newFlagItem.IsNew = value)"/>
-                                            }
+                                            <MudIconButton OnClick="@(() => DeleteItem(context, pouch))"
+                                                           ButtonType="@ButtonType.Button"
+                                                           Color="@Color.Error"
+                                                           Variant="@Variant.Filled"
+                                                           Icon="@Icons.Material.Filled.Delete"/>
                                         </EditTemplate>
                                     </TemplateColumn>
-                                }
-                                <TemplateColumn>
-                                    <EditTemplate>
-                                        <MudIconButton OnClick="@(() => DeleteItem(context, pouch))"
-                                                       ButtonType="@ButtonType.Button"
-                                                       Color="@Color.Error"
-                                                       Variant="@Variant.Filled"
-                                                       Icon="@Icons.Material.Filled.Delete"/>
-                                    </EditTemplate>
-                                </TemplateColumn>
-                            </Columns>
-                        </MudDataGrid>
-                    </MudStack>
+                                </Columns>
+                            </MudDataGrid>
+                        </MudStack>
+                    }
+                    else
+                    {
+                        <MudProgressLinear Indeterminate="true"/>
+                    }
                 </ChildContent>
             </MudTabPanel>
         }

--- a/Pkmds.Rcl/Components/MainTabPages/BagTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/BagTab.razor.cs
@@ -32,7 +32,11 @@ public partial class BagTab
 
     private bool IsSortedByIndex { get; set; } = true; // Set as true so first sort is ascending
 
-    private bool ShouldVirtualize { get; set; }
+    private int ActivePouchIndex { get; set; }
+
+    private HashSet<int> RenderedPouches { get; } = [];
+
+    private bool ShowEmptySlots { get; set; }
 
     protected override void OnParametersSet()
     {
@@ -42,6 +46,11 @@ public partial class BagTab
         {
             return;
         }
+
+        // Reset lazy rendering state for new inventory
+        RenderedPouches.Clear();
+        RenderedPouches.Add(0);
+        ActivePouchIndex = 0;
 
         ItemList = [.. GameInfo.Strings.GetItemStrings(saveFile.Context, saveFile.Version)];
 
@@ -63,6 +72,12 @@ public partial class BagTab
         // Build caches for improved performance
         BuildItemComboCache();
         BuildPouchValidItemsCache();
+    }
+
+    private void OnActivePanelChanged(int index)
+    {
+        ActivePouchIndex = index;
+        RenderedPouches.Add(index);
     }
 
     private void BuildItemComboCache()

--- a/Pkmds.Rcl/wwwroot/css/app.css
+++ b/Pkmds.Rcl/wwwroot/css/app.css
@@ -88,6 +88,10 @@ body, html {
     align-self: center;
 }
 
+.bag-data-grid .mud-table-container {
+    overflow-y: auto;
+}
+
 .square-slot {
     aspect-ratio: 1 / 1;
 }
@@ -173,23 +177,56 @@ body, html {
 
 /* System preference — no-JS path, always applied */
 @media (prefers-color-scheme: dark) {
-    body { background-color: #27272f; }
-    .loading-progress circle { stroke: #424242; }
-    .loading-progress circle:last-child { stroke: #90caf9; }
-    .loading-progress-text { color: #ffffff; }
+    body {
+        background-color: #27272f;
+    }
+
+    .loading-progress circle {
+        stroke: #424242;
+    }
+
+    .loading-progress circle:last-child {
+        stroke: #90caf9;
+    }
+
+    .loading-progress-text {
+        color: #ffffff;
+    }
 }
 
 /* Explicit dark override (set by inline script / Blazor JS interop) */
-[data-theme="dark"] body { background-color: #27272f; }
-[data-theme="dark"] .loading-progress circle { stroke: #424242; }
-[data-theme="dark"] .loading-progress circle:last-child { stroke: #90caf9; }
-[data-theme="dark"] .loading-progress-text { color: #ffffff; }
+[data-theme="dark"] body {
+    background-color: #27272f;
+}
+
+[data-theme="dark"] .loading-progress circle {
+    stroke: #424242;
+}
+
+[data-theme="dark"] .loading-progress circle:last-child {
+    stroke: #90caf9;
+}
+
+[data-theme="dark"] .loading-progress-text {
+    color: #ffffff;
+}
 
 /* Explicit light override (beats system dark preference when user chose light) */
-[data-theme="light"] body { background-color: #ffffff; }
-[data-theme="light"] .loading-progress circle { stroke: #e0e0e0; }
-[data-theme="light"] .loading-progress circle:last-child { stroke: #1b6ec2; }
-[data-theme="light"] .loading-progress-text { color: inherit; }
+[data-theme="light"] body {
+    background-color: #ffffff;
+}
+
+[data-theme="light"] .loading-progress circle {
+    stroke: #e0e0e0;
+}
+
+[data-theme="light"] .loading-progress circle:last-child {
+    stroke: #1b6ec2;
+}
+
+[data-theme="light"] .loading-progress-text {
+    color: inherit;
+}
 
 /* Drag and drop styles */
 .slot-dragging {


### PR DESCRIPTION
Closes #299

## Summary

- **Lazy pouch rendering**: only the first pouch's `MudDataGrid` is created on load; each additional pouch initialises on first tab visit and stays alive after that (switching back is instant). On a large save like SV with 9 pouches, this reduces grids created at startup from 9 to 1.
- **Empty-slot filtering**: items where `Count == 0` are hidden by default, matching PKHeX's own `ClearCount0()` criterion. A "Show Empty Slots" toggle (replacing the old unreliable "Virtualize" switch) restores them when needed. This eliminates hundreds of unowned TM rows and empty item slots from the rendered DOM.
- **Lightweight `CellTemplate`**: the Item column now renders a `MudText` in display mode instead of falling back to raw integer output, reducing per-row render work.
- **CSS fix**: `.bag-data-grid .mud-table-container { overflow-y: auto; }` added to `app.css` to support future virtualization.

## Virtualization status

`Virtualize="true"` is intentionally **not** enabled in this PR. Investigation revealed a bug in MudBlazor where `DataGridVirtualizeRow` passes `SpacerElement="div"` (the default) to `MudVirtualize` inside `<tbody>`. CSS table layout ignores `height` on `<div>` elements inside a table body, collapsing the spacers to 0 px. Blazor's `<Virtualize>` then treats the scroll position as always being at the top, causing rows to jump back on every scroll event.

A one-line fix (`SpacerElement="tr"`) has been submitted upstream: **MudBlazor/MudBlazor#12799**. Once that is merged and a new MudBlazor release is available, we can bump the version in `Directory.Packages.props` and enable `Virtualize="true"` on the bag grid.

## Test plan

- [ ] Load a large save (SV, SwSh) and verify the Bag tab opens noticeably faster than before.
- [ ] Switch between pouches and confirm each activates on first visit then stays instant.
- [ ] Verify only items with `Count > 0` are shown by default; toggle "Show Empty Slots" to confirm the full list appears.
- [ ] Confirm TMs with `Count == 0` (unowned) are hidden by default in the TMs/HMs pouch.
- [ ] Confirm all existing functionality works: Save, Sort By Name/Count/Index, item autocomplete, HaX mode max count, Delete.
- [ ] `dotnet build Pkmds.Web/Pkmds.Web.csproj -c Debug` — 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)