### PR TITLE
Bump packages; remove Humanize false args

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,13 +6,13 @@
         <PackageVersion Include="bUnit" Version="2.6.2"/>
         <PackageVersion Include="coverlet.collector" Version="8.0.0"/>
         <PackageVersion Include="FluentAssertions" Version="8.8.0"/>
-        <PackageVersion Include="Humanizer" Version="3.0.1"/>
+        <PackageVersion Include="Humanizer" Version="3.0.8"/>
         <PackageVersion Include="KristofferStrube.Blazor.FileSystemAccess" Version="3.3.0"/>
         <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.3"/>
         <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.3"/>
         <PackageVersion Include="Microsoft.JSInterop" Version="10.0.3"/>
         <PackageVersion Include="Microsoft.JSInterop.WebAssembly" Version="10.0.3"/>
-        <PackageVersion Include="MudBlazor" Version="9.0.0"/>
+        <PackageVersion Include="MudBlazor" Version="9.1.0"/>
         <PackageVersion Include="PKHeX.Core" Version="26.1.31"/>
         <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0"/>
         <PackageVersion Include="Serilog.Sinks.BrowserConsole" Version="8.0.0"/>

--- a/Pkmds.Core/Extensions/PkmExtensions.cs
+++ b/Pkmds.Core/Extensions/PkmExtensions.cs
@@ -1,13 +1,13 @@
 ﻿namespace Pkmds.Core.Extensions;
 
 /// <summary>
-///     Extension methods for PKM (Pokémon) objects and related types.
-///     Provides utilities for species validation, type handling, markings, moves, shininess, and more.
+/// Extension methods for PKM (Pokémon) objects and related types.
+/// Provides utilities for species validation, type handling, markings, moves, shininess, and more.
 /// </summary>
 public static class PkmExtensions
 {
     /// <summary>
-    ///     Determines whether a species ID is valid (greater than None and less than MAX_COUNT).
+    /// Determines whether a species ID is valid (greater than None and less than MAX_COUNT).
     /// </summary>
     /// <param name="speciesId">The species ID to validate.</param>
     /// <returns>True if the species ID is valid; otherwise, false.</returns>
@@ -15,7 +15,7 @@ public static class PkmExtensions
         speciesId is > (ushort)Species.None and < (ushort)Species.MAX_COUNT;
 
     /// <summary>
-    ///     Determines whether a nullable species ID is valid.
+    /// Determines whether a nullable species ID is valid.
     /// </summary>
     /// <param name="speciesId">The nullable species ID to validate.</param>
     /// <returns>True if the species ID has a value and is valid; otherwise, false.</returns>
@@ -23,14 +23,14 @@ public static class PkmExtensions
         speciesId is { } species && species.IsValidSpecies();
 
     /// <summary>
-    ///     Determines whether a species ID is invalid (inverse of <see cref="IsValidSpecies(ushort)" />).
+    /// Determines whether a species ID is invalid (inverse of <see cref="IsValidSpecies(ushort)" />).
     /// </summary>
     /// <param name="speciesId">The species ID to validate.</param>
     /// <returns>True if the species ID is invalid; otherwise, false.</returns>
     public static bool IsInvalidSpecies(this ushort speciesId) => !speciesId.IsValidSpecies();
 
     /// <summary>
-    ///     Determines whether a nullable species ID is invalid.
+    /// Determines whether a nullable species ID is invalid.
     /// </summary>
     /// <param name="speciesId">The nullable species ID to validate.</param>
     /// <returns>True if the species ID is null or invalid; otherwise, false.</returns>
@@ -39,7 +39,7 @@ public static class PkmExtensions
     extension(PKM pkm)
     {
         /// <summary>
-        ///     Gets the FormArgument value for Pokémon that implement IFormArgument (e.g., Alcremie).
+        /// Gets the FormArgument value for Pokémon that implement IFormArgument (e.g., Alcremie).
         /// </summary>
         /// <param name="valueIfNull">The value to return if the Pokémon doesn't implement IFormArgument.</param>
         /// <returns>The FormArgument value, or the specified default value.</returns>
@@ -47,8 +47,8 @@ public static class PkmExtensions
             (pkm as IFormArgument)?.FormArgument ?? valueIfNull;
 
         /// <summary>
-        ///     Gets the type(s) of this Pokémon, converting Gen 1/2 type IDs to modern equivalents if needed.
-        ///     In Gen 1/2, some type IDs differ from later generations due to the introduction of Dark and Steel types.
+        /// Gets the type(s) of this Pokémon, converting Gen 1/2 type IDs to modern equivalents if needed.
+        /// In Gen 1/2, some type IDs differ from later generations due to the introduction of Dark and Steel types.
         /// </summary>
         /// <returns>A tuple containing the primary and secondary type IDs.</returns>
         public (byte Type1, byte Type2) GetGenerationTypes()
@@ -66,8 +66,8 @@ public static class PkmExtensions
         }
 
         /// <summary>
-        ///     Gets the value of a specific marking for this Pokémon.
-        ///     Different generations use different marking systems (boolean or color-based).
+        /// Gets the value of a specific marking for this Pokémon.
+        /// Different generations use different marking systems (boolean or color-based).
         /// </summary>
         /// <param name="index">The 0-based marking index.</param>
         /// <returns>The marking value (0 for unmarked/false, 1+ for marked/color value).</returns>
@@ -96,7 +96,7 @@ public static class PkmExtensions
         }
 
         /// <summary>
-        ///     Gets the current PP (Power Points) for all four move slots.
+        /// Gets the current PP (Power Points) for all four move slots.
         /// </summary>
         /// <returns>A read-only collection of PP values for moves 1-4.</returns>
         // ReSharper disable once InconsistentNaming
@@ -109,8 +109,8 @@ public static class PkmExtensions
         ]);
 
         /// <summary>
-        ///     Gets the PP Ups (Power Point upgrades) for all four move slots.
-        ///     Each PP Up increases a move's max PP by 20% of its base PP.
+        /// Gets the PP Ups (Power Point upgrades) for all four move slots.
+        /// Each PP Up increases a move's max PP by 20% of its base PP.
         /// </summary>
         /// <returns>A read-only collection of PP Up values (0-3) for moves 1-4.</returns>
         // ReSharper disable once InconsistentNaming
@@ -123,7 +123,7 @@ public static class PkmExtensions
         ]);
 
         /// <summary>
-        ///     Sets the current PP for a specific move slot.
+        /// Sets the current PP for a specific move slot.
         /// </summary>
         /// <param name="moveIndex">The move slot index (0-3).</param>
         /// <param name="pp">The PP value to set (will be clamped to 0 if negative).</param>
@@ -153,7 +153,7 @@ public static class PkmExtensions
         }
 
         /// <summary>
-        ///     Sets the PP Ups for a specific move slot.
+        /// Sets the PP Ups for a specific move slot.
         /// </summary>
         /// <param name="moveIndex">The move slot index (0-3).</param>
         /// <param name="ppUps">The PP Ups value to set (will be clamped to 0 if negative).</param>
@@ -183,8 +183,8 @@ public static class PkmExtensions
         }
 
         /// <summary>
-        ///     Calculates the maximum PP for a move slot based on the move's base PP and PP Ups applied.
-        ///     Formula: maxPP = basePP + (basePP * ppUps / 5)
+        /// Calculates the maximum PP for a move slot based on the move's base PP and PP Ups applied.
+        /// Formula: maxPP = basePP + (basePP * ppUps / 5)
         /// </summary>
         /// <param name="moveIndex">The move slot index (0-3).</param>
         /// <returns>The maximum PP for the move.</returns>
@@ -200,9 +200,9 @@ public static class PkmExtensions
         }
 
         /// <summary>
-        ///     Gets a specific relearn move by index.
-        ///     Relearn moves are available in Gen 6+ and represent moves a Pokémon can relearn.
-        ///     For pre-Gen 6 Pokemon, the properties exist but will typically be 0.
+        /// Gets a specific relearn move by index.
+        /// Relearn moves are available in Gen 6+ and represent moves a Pokémon can relearn.
+        /// For pre-Gen 6 Pokemon, the properties exist but will typically be 0.
         /// </summary>
         /// <param name="index">The relearn move slot index (0-3).</param>
         /// <returns>The move ID, or 0 if the index is invalid.</returns>
@@ -224,8 +224,8 @@ public static class PkmExtensions
         }
 
         /// <summary>
-        ///     Sets a specific relearn move by index.
-        ///     Relearn moves are available in Gen 6+ and represent moves a Pokémon can relearn.
+        /// Sets a specific relearn move by index.
+        /// Relearn moves are available in Gen 6+ and represent moves a Pokémon can relearn.
         /// </summary>
         /// <param name="index">The relearn move slot index (0-3).</param>
         /// <param name="move">The move ID to set.</param>
@@ -254,7 +254,7 @@ public static class PkmExtensions
         }
 
         /// <summary>
-        ///     Gets all relearn moves as a read-only collection.
+        /// Gets all relearn moves as a read-only collection.
         /// </summary>
         /// <returns>A read-only collection of the four relearn move IDs.</returns>
         public ReadOnlyCollection<ushort> GetRelearnMoves() => new(
@@ -266,15 +266,15 @@ public static class PkmExtensions
         ]);
 
         /// <summary>
-        ///     Determines if the Pokémon supports relearn moves (Gen 6+).
+        /// Determines if the Pokémon supports relearn moves (Gen 6+).
         /// </summary>
         /// <returns>True if the Pokémon has relearn move properties; otherwise, false.</returns>
         public bool HasRelearnMoves() => pkm.Format >= 6;
 
         /// <summary>
-        ///     Safely determines if the Pokémon is shiny, handling both Gen 1/2 (DV-based) and Gen 3+ (PID-based) shininess.
-        ///     In Gen 1/2, shininess is determined by specific DV (Determinant Value) patterns.
-        ///     In Gen 3+, shininess is determined by the PID (Personality ID) and trainer IDs.
+        /// Safely determines if the Pokémon is shiny, handling both Gen 1/2 (DV-based) and Gen 3+ (PID-based) shininess.
+        /// In Gen 1/2, shininess is determined by specific DV (Determinant Value) patterns.
+        /// In Gen 3+, shininess is determined by the PID (Personality ID) and trainer IDs.
         /// </summary>
         /// <returns>True if the Pokémon is shiny; otherwise, false.</returns>
         public bool GetIsShinySafe()
@@ -299,9 +299,9 @@ public static class PkmExtensions
         }
 
         /// <summary>
-        ///     Safely sets the shininess of the Pokémon, handling both Gen 1/2 and Gen 3+ mechanics.
-        ///     For Gen 3+, uses PKHeX.Core's SetIsShiny method.
-        ///     For Gen 1/2, randomizes IVs until the desired shininess is achieved.
+        /// Safely sets the shininess of the Pokémon, handling both Gen 1/2 and Gen 3+ mechanics.
+        /// For Gen 3+, uses PKHeX.Core's SetIsShiny method.
+        /// For Gen 1/2, randomizes IVs until the desired shininess is achieved.
         /// </summary>
         /// <param name="shiny">True to make the Pokémon shiny; false to make it non-shiny.</param>
         public void SetIsShinySafe(bool shiny)

--- a/Pkmds.Core/Utilities/GameInfoUtilities.cs
+++ b/Pkmds.Core/Utilities/GameInfoUtilities.cs
@@ -1,12 +1,12 @@
 ﻿namespace Pkmds.Core.Utilities;
 
 /// <summary>
-///     Utility methods for working with PKHeX GameInfo data.
+/// Utility methods for working with PKHeX GameInfo data.
 /// </summary>
 public static class GameInfoUtilities
 {
     /// <summary>
-    ///     Gets the localized name of a move category (Status, Physical, or Special).
+    /// Gets the localized name of a move category (Status, Physical, or Special).
     /// </summary>
     /// <param name="categoryId">The category ID (0 = Status, 1 = Physical, 2 = Special).</param>
     /// <returns>The category name, or "Unknown" if the ID is not recognized.</returns>

--- a/Pkmds.Core/Utilities/MarkingsHelper.cs
+++ b/Pkmds.Core/Utilities/MarkingsHelper.cs
@@ -1,14 +1,14 @@
 ﻿namespace Pkmds.Core.Utilities;
 
 /// <summary>
-///     Helper class for working with Pokémon markings.
-///     Provides enum definitions and unicode symbols for the six marking shapes.
+/// Helper class for working with Pokémon markings.
+/// Provides enum definitions and unicode symbols for the six marking shapes.
 /// </summary>
 public static class MarkingsHelper
 {
     /// <summary>
-    ///     Enum representing the six types of Pokémon markings.
-    ///     Used for organizing and categorizing Pokémon in the PC.
+    /// Enum representing the six types of Pokémon markings.
+    /// Used for organizing and categorizing Pokémon in the PC.
     /// </summary>
     public enum Markings
     {

--- a/Pkmds.Rcl/Components/EditForms/PokemonEditForm.razor.cs
+++ b/Pkmds.Rcl/Components/EditForms/PokemonEditForm.razor.cs
@@ -116,10 +116,7 @@ public partial class PokemonEditForm : IDisposable
             var parameters = new DialogParameters
             {
                 { nameof(ConfirmActionDialog.Title), "Paste Pokémon" },
-                {
-                    nameof(ConfirmActionDialog.Message),
-                    "Are you sure you want to paste the copied Pokémon? The Pokémon in the selected slot will be replaced."
-                },
+                { nameof(ConfirmActionDialog.Message), "Are you sure you want to paste the copied Pokémon? The Pokémon in the selected slot will be replaced." },
                 { nameof(ConfirmActionDialog.ConfirmText), "Paste" },
                 { nameof(ConfirmActionDialog.ConfirmIcon), Icons.Material.Filled.ContentPaste },
                 { nameof(ConfirmActionDialog.ConfirmColor), Color.Default },

--- a/Pkmds.Rcl/Components/EditForms/Tabs/LegalityTab.razor.cs
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/LegalityTab.razor.cs
@@ -85,7 +85,7 @@ public partial class LegalityTab : IDisposable
             return;
         }
 
-        Pokemon.SetMoveset(false);
+        Pokemon.SetMoveset();
 
         // Update Technical Records (Gen 8+ SwSh / SV / ZA) to reflect the new moves,
         // mirroring PKMEditor's SetSuggestedMoves behaviour.
@@ -281,6 +281,6 @@ public partial class LegalityTab : IDisposable
         }
 
         var ctx = LegalityLocalizationContext.Create(la);
-        return ctx.Humanize(in result, false);
+        return ctx.Humanize(in result);
     }
 }

--- a/Pkmds.Rcl/Components/EditForms/Tabs/MainTab.razor.cs
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/MainTab.razor.cs
@@ -40,7 +40,7 @@ public partial class MainTab : IDisposable
         }
 
         var ctx = LegalityLocalizationContext.Create(la);
-        return ctx.Humanize(in r, false);
+        return ctx.Humanize(in r);
     }
 
     protected override void OnInitialized() =>
@@ -257,10 +257,7 @@ public partial class MainTab : IDisposable
     {
         var parameters = new DialogParameters<PidEcDialog> { { x => x.Pokemon, Pokemon } };
 
-        var options = new DialogOptions
-        {
-            MaxWidth = MaxWidth.Small, FullWidth = true, CloseButton = true, CloseOnEscapeKey = true
-        };
+        var options = new DialogOptions { MaxWidth = MaxWidth.Small, FullWidth = true, CloseButton = true, CloseOnEscapeKey = true };
 
         await DialogService.ShowAsync<PidEcDialog>("PID / EC Generator", parameters, options);
     }

--- a/Pkmds.Rcl/Components/EditForms/Tabs/MetTab.razor.cs
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/MetTab.razor.cs
@@ -9,7 +9,7 @@ public partial class MetTab : IDisposable
     private EntityContext originFormat = EntityContext.None;
 
     /// <summary>
-    ///     Currently loaded met location group that is populating Met and Egg location comboboxes
+    /// Currently loaded met location group that is populating Met and Egg location comboboxes
     /// </summary>
     private GameVersion origintrack;
 
@@ -97,7 +97,7 @@ public partial class MetTab : IDisposable
         }
 
         var ctx = LegalityLocalizationContext.Create(la);
-        return ctx.Humanize(in r, false);
+        return ctx.Humanize(in r);
     }
 
     protected override void OnInitialized() =>

--- a/Pkmds.Rcl/Components/EditForms/Tabs/MovesTab.razor.cs
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/MovesTab.razor.cs
@@ -151,10 +151,7 @@ public partial class MovesTab
     {
         var parameters = new DialogParameters<RelearnFlagsDialog> { { x => x.Pokemon, Pokemon } };
 
-        var options = new DialogOptions
-        {
-            MaxWidth = MaxWidth.Small, FullWidth = true, CloseButton = true, CloseOnEscapeKey = true
-        };
+        var options = new DialogOptions { MaxWidth = MaxWidth.Small, FullWidth = true, CloseButton = true, CloseOnEscapeKey = true };
 
         await DialogService.ShowAsync<RelearnFlagsDialog>("TR Relearn Editor", parameters, options);
     }
@@ -163,10 +160,7 @@ public partial class MovesTab
     {
         var parameters = new DialogParameters<PlusFlagsDialog> { { x => x.Pokemon, Pokemon } };
 
-        var options = new DialogOptions
-        {
-            MaxWidth = MaxWidth.Small, FullWidth = true, CloseButton = true, CloseOnEscapeKey = true
-        };
+        var options = new DialogOptions { MaxWidth = MaxWidth.Small, FullWidth = true, CloseButton = true, CloseOnEscapeKey = true };
 
         await DialogService.ShowAsync<PlusFlagsDialog>("Plus Flags Editor", parameters, options);
     }
@@ -175,10 +169,7 @@ public partial class MovesTab
     {
         var parameters = new DialogParameters<MoveShopDialog> { { x => x.Pokemon, Pokemon } };
 
-        var options = new DialogOptions
-        {
-            MaxWidth = MaxWidth.Small, FullWidth = true, CloseButton = true, CloseOnEscapeKey = true
-        };
+        var options = new DialogOptions { MaxWidth = MaxWidth.Small, FullWidth = true, CloseButton = true, CloseOnEscapeKey = true };
 
         await DialogService.ShowAsync<MoveShopDialog>("Move Shop Editor", parameters, options);
     }

--- a/Pkmds.Rcl/Components/EditForms/Tabs/OtMiscTab.razor.cs
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/OtMiscTab.razor.cs
@@ -58,8 +58,8 @@ public partial class OtMiscTab : IDisposable
     private List<ComboItem>? CachedGeoCountries { get; set; }
 
     /// <summary>
-    ///     Returns the memory generation (6 or 8) used for feeling/argument lookups.
-    ///     Gen 6/7 Pokémon use generation 6 memory sets; Gen 8+ use generation 8 memory sets.
+    /// Returns the memory generation (6 or 8) used for feeling/argument lookups.
+    /// Gen 6/7 Pokémon use generation 6 memory sets; Gen 8+ use generation 8 memory sets.
     /// </summary>
     private int MemoryGen => Pokemon?.Context switch
     {
@@ -96,7 +96,7 @@ public partial class OtMiscTab : IDisposable
         }
 
         var ctx = LegalityLocalizationContext.Create(la);
-        return ctx.Humanize(in r, false);
+        return ctx.Humanize(in r);
     }
 
     protected override void OnInitialized() =>
@@ -142,7 +142,7 @@ public partial class OtMiscTab : IDisposable
     };
 
     /// <summary>
-    ///     Builds the fully-formatted memory preview string, substituting all placeholders.
+    /// Builds the fully-formatted memory preview string, substituting all placeholders.
     /// </summary>
     private string FormatMemoryText(
         byte memoryId,
@@ -400,12 +400,12 @@ public partial class OtMiscTab : IDisposable
     }
 
     /// <summary>
-    ///     Builds the affixed ribbon combo items for the given Pokémon's format.
-    ///     Includes "None" (-1) and every ribbon/mark slot that can be affixed (i.e.
-    ///     any ribbon/mark whose name can be mapped to a <see cref="RibbonIndex" />),
-    ///     regardless of whether the Pokémon currently has each ribbon. This ensures
-    ///     the selector is always fully populated and does not go stale when ribbons
-    ///     are toggled on the Ribbons tab.
+    /// Builds the affixed ribbon combo items for the given Pokémon's format.
+    /// Includes "None" (-1) and every ribbon/mark slot that can be affixed (i.e.
+    /// any ribbon/mark whose name can be mapped to a <see cref="RibbonIndex" />),
+    /// regardless of whether the Pokémon currently has each ribbon. This ensures
+    /// the selector is always fully populated and does not go stale when ribbons
+    /// are toggled on the Ribbons tab.
     /// </summary>
     private List<ComboItem> BuildAffixedRibbonItems()
     {

--- a/Pkmds.Rcl/Components/EditForms/Tabs/RibbonsTab.razor.cs
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/RibbonsTab.razor.cs
@@ -13,11 +13,11 @@ public partial class RibbonsTab : IDisposable
         RefreshService.OnAppStateChanged -= StateHasChanged;
 
     /// <summary>
-    ///     Returns the worst-severity legality check result for a given mark property name,
-    ///     or null if the mark is valid or is a regular ribbon (not a mark).
-    ///     Only marks have per-entry <see cref="CheckResult" />s with <see cref="CheckResult.Argument" />
-    ///     set to the <see cref="RibbonIndex" />. Regular ribbon checks are grouped into a single result
-    ///     with Argument = count, so per-ribbon targeting is not possible for them.
+    /// Returns the worst-severity legality check result for a given mark property name,
+    /// or null if the mark is valid or is a regular ribbon (not a mark).
+    /// Only marks have per-entry <see cref="CheckResult" />s with <see cref="CheckResult.Argument" />
+    /// set to the <see cref="RibbonIndex" />. Regular ribbon checks are grouped into a single result
+    /// with Argument = count, so per-ribbon targeting is not possible for them.
     /// </summary>
     private CheckResult? GetRibbonCheckResult(string propertyName)
     {
@@ -108,12 +108,12 @@ public partial class RibbonsTab : IDisposable
         }
 
         var ctx = LegalityLocalizationContext.Create(la);
-        return ctx.Humanize(in result, false);
+        return ctx.Humanize(in result);
     }
 
     /// <summary>
-    ///     Returns the message portion of a humanized check result, stripping the leading "Severity: "
-    ///     prefix. Used in the Ribbon Issues list where the icon already communicates severity.
+    /// Returns the message portion of a humanized check result, stripping the leading "Severity: "
+    /// prefix. Used in the Ribbon Issues list where the icon already communicates severity.
     /// </summary>
     private string GetRibbonIssueMessage(CheckResult result)
     {

--- a/Pkmds.Rcl/Components/EditForms/Tabs/StatsTab.razor.cs
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/StatsTab.razor.cs
@@ -40,7 +40,7 @@ public partial class StatsTab : IDisposable
         }
 
         var ctx = LegalityLocalizationContext.Create(la);
-        return ctx.Humanize(in r, false);
+        return ctx.Humanize(in r);
     }
 
     protected override void OnInitialized() =>

--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor
@@ -39,7 +39,8 @@
             </MudChip>
         }
         <MudStack Row>
-            <MudButtonGroup Variant="@Variant.Outlined" Size="@Size.Small">
+            <MudButtonGroup Variant="@Variant.Outlined"
+                            Size="@Size.Small">
                 <MudIconButton Icon="@Icons.Material.Filled.LightMode"
                                Color="@Color.Inherit"
                                Style="@(themeMode == ThemeMode.Light

--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
@@ -63,7 +63,9 @@ public partial class MainLayout : IDisposable
         {
             isDarkMode = newValue;
             RefreshService.RefreshTheme(isDarkMode);
-            var themeStr = newValue ? "dark" : "light";
+            var themeStr = newValue
+                ? "dark"
+                : "light";
             await JSRuntime.InvokeVoidAsync("setAppTheme", themeStr);
             StateHasChanged();
         }
@@ -75,7 +77,9 @@ public partial class MainLayout : IDisposable
         isDarkMode = ComputeIsDarkMode();
         RefreshService.RefreshTheme(isDarkMode);
 
-        var themeStr = isDarkMode ? "dark" : "light";
+        var themeStr = isDarkMode
+            ? "dark"
+            : "light";
         await JSRuntime.InvokeVoidAsync("setAppTheme", themeStr);
 
         if (themeMode == ThemeMode.System)

--- a/Pkmds.Rcl/Components/MainTabPages/EncounterDatabaseTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/EncounterDatabaseTab.razor.cs
@@ -166,8 +166,8 @@ public partial class EncounterDatabaseTab : RefreshAwareComponent
     }
 
     /// <summary>
-    ///     Finds the first empty box slot in the save file and selects it via <see cref="IAppService" />.
-    ///     Returns <see langword="false" /> when no empty slot is found or no save is loaded.
+    /// Finds the first empty box slot in the save file and selects it via <see cref="IAppService" />.
+    /// Returns <see langword="false" /> when no empty slot is found or no save is loaded.
     /// </summary>
     private bool TrySelectFirstEmptyBoxSlot()
     {

--- a/Pkmds.Rcl/Components/MainTabPages/LegalityReportTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/LegalityReportTab.razor.cs
@@ -11,7 +11,7 @@ public partial class LegalityReportTab : RefreshAwareComponent
     private LegalityStatus? statusFilter;
 
     /// <summary>
-    ///     Callback invoked after a row is clicked to jump to the Party / Box tab.
+    /// Callback invoked after a row is clicked to jump to the Party / Box tab.
     /// </summary>
     [Parameter]
     public EventCallback OnJumpToPartyBox { get; set; }
@@ -124,7 +124,7 @@ public partial class LegalityReportTab : RefreshAwareComponent
         {
             if (!result.Valid)
             {
-                return ctx.Humanize(in result, false);
+                return ctx.Humanize(in result);
             }
         }
 

--- a/Pkmds.Rcl/Components/PokemonSlotComponent.razor.cs
+++ b/Pkmds.Rcl/Components/PokemonSlotComponent.razor.cs
@@ -82,8 +82,8 @@ public partial class PokemonSlotComponent : IDisposable
     };
 
     /// <returns>
-    ///     <see langword="true" /> = legal, <see langword="false" /> = illegal/fishy,
-    ///     <see langword="null" /> = no Pokémon in slot (skip indicator).
+    /// <see langword="true" /> = legal, <see langword="false" /> = illegal/fishy,
+    /// <see langword="null" /> = no Pokémon in slot (skip indicator).
     /// </returns>
     private bool? GetLegalityValid() => legalityValid;
 

--- a/Pkmds.Rcl/Components/RefreshAwareComponent.cs
+++ b/Pkmds.Rcl/Components/RefreshAwareComponent.cs
@@ -1,8 +1,8 @@
 namespace Pkmds.Rcl.Components;
 
 /// <summary>
-///     Base component that automatically subscribes to refresh events.
-///     Reduces boilerplate code for components that need to refresh on state changes.
+/// Base component that automatically subscribes to refresh events.
+/// Reduces boilerplate code for components that need to refresh on state changes.
 /// </summary>
 public abstract class RefreshAwareComponent : ComponentBase, IDisposable
 {
@@ -17,8 +17,8 @@ public abstract class RefreshAwareComponent : ComponentBase, IDisposable
     private IRefreshService RefreshServiceInternal => RefreshServiceField!;
 
     /// <summary>
-    ///     Override this property to control which refresh events trigger StateHasChanged.
-    ///     By default, only OnAppStateChanged is subscribed.
+    /// Override this property to control which refresh events trigger StateHasChanged.
+    /// By default, only OnAppStateChanged is subscribed.
     /// </summary>
     protected virtual RefreshEvents SubscribeTo => RefreshEvents.AppState;
 
@@ -68,7 +68,7 @@ public abstract class RefreshAwareComponent : ComponentBase, IDisposable
     }
 
     /// <summary>
-    ///     Override this method to add custom disposal logic.
+    /// Override this method to add custom disposal logic.
     /// </summary>
     protected virtual void Dispose(bool disposing)
     {
@@ -76,7 +76,7 @@ public abstract class RefreshAwareComponent : ComponentBase, IDisposable
 }
 
 /// <summary>
-///     Flags enum to control which refresh events a component subscribes to.
+/// Flags enum to control which refresh events a component subscribes to.
 /// </summary>
 [Flags]
 public enum RefreshEvents

--- a/Pkmds.Rcl/Components/SaveFileNameDisplay.cs
+++ b/Pkmds.Rcl/Components/SaveFileNameDisplay.cs
@@ -3,13 +3,13 @@
 namespace Pkmds.Rcl.Components;
 
 /// <summary>
-///     Utility class for generating display names for save files and game versions.
+/// Utility class for generating display names for save files and game versions.
 /// </summary>
 public static class SaveFileNameDisplay
 {
     /// <summary>
-    ///     Generates a formatted display string for the current save file.
-    ///     Includes trainer name, gender, TID, game version, and playtime.
+    /// Generates a formatted display string for the current save file.
+    /// Includes trainer name, gender, TID, game version, and playtime.
     /// </summary>
     /// <param name="appState">The application state containing the save file.</param>
     /// <param name="appService">The application service for formatting IDs.</param>
@@ -55,7 +55,7 @@ public static class SaveFileNameDisplay
     }
 
     /// <summary>
-    ///     Converts a GameVersion enum value to a user-friendly game name.
+    /// Converts a GameVersion enum value to a user-friendly game name.
     /// </summary>
     /// <param name="gameVersion">The game version to convert.</param>
     /// <returns>A human-readable game name.</returns>

--- a/Pkmds.Rcl/Constants.cs
+++ b/Pkmds.Rcl/Constants.cs
@@ -1,7 +1,7 @@
 ﻿namespace Pkmds.Rcl;
 
 /// <summary>
-///     Application-wide constants used throughout the PKMDS application.
+/// Application-wide constants used throughout the PKMDS application.
 /// </summary>
 public static class Constants
 {

--- a/Pkmds.Rcl/Extensions/VersionExtensions.cs
+++ b/Pkmds.Rcl/Extensions/VersionExtensions.cs
@@ -1,12 +1,12 @@
 ﻿namespace Pkmds.Rcl.Extensions;
 
 /// <summary>
-///     Extension methods for System.Version.
+/// Extension methods for System.Version.
 /// </summary>
 public static class VersionExtensions
 {
     /// <summary>
-    ///     Converts a Version to a formatted string in the format "YYYY.MM.DD.HHMM".
+    /// Converts a Version to a formatted string in the format "YYYY.MM.DD.HHMM".
     /// </summary>
     /// <param name="version">The version to format.</param>
     /// <returns>A formatted version string (e.g., "2026.01.27.0949").</returns>

--- a/Pkmds.Rcl/IAppState.cs
+++ b/Pkmds.Rcl/IAppState.cs
@@ -1,83 +1,83 @@
 ﻿namespace Pkmds.Rcl;
 
 /// <summary>
-///     Represents the global application state for the PKMDS application.
-///     This interface provides access to the currently loaded save file, selected Pokémon slots,
-///     clipboard data, and other application-wide state information.
+/// Represents the global application state for the PKMDS application.
+/// This interface provides access to the currently loaded save file, selected Pokémon slots,
+/// clipboard data, and other application-wide state information.
 /// </summary>
 public interface IAppState
 {
     /// <summary>
-    ///     Gets or sets the current language code used for displaying game data.
+    /// Gets or sets the current language code used for displaying game data.
     /// </summary>
     string CurrentLanguage { get; set; }
 
     /// <summary>
-    ///     Gets the numeric language ID corresponding to the <see cref="CurrentLanguage" />.
+    /// Gets the numeric language ID corresponding to the <see cref="CurrentLanguage" />.
     /// </summary>
     int CurrentLanguageId { get; }
 
     /// <summary>
-    ///     Gets or sets the currently loaded save file from a Pokémon game.
-    ///     This is null when no save file is loaded.
+    /// Gets or sets the currently loaded save file from a Pokémon game.
+    /// This is null when no save file is loaded.
     /// </summary>
     SaveFile? SaveFile { get; set; }
 
     /// <summary>
-    ///     Gets the box editor interface for the current save file.
-    ///     This provides access to box manipulation operations.
+    /// Gets the box editor interface for the current save file.
+    /// This provides access to box manipulation operations.
     /// </summary>
     BoxEdit? BoxEdit { get; }
 
     /// <summary>
-    ///     Gets or sets the Pokémon currently stored in the clipboard for copy/paste operations.
+    /// Gets or sets the Pokémon currently stored in the clipboard for copy/paste operations.
     /// </summary>
     PKM? CopiedPokemon { get; set; }
 
     /// <summary>
-    ///     Gets or sets the currently selected box number (0-based index).
-    ///     Null when no box is selected or when a party slot is selected.
+    /// Gets or sets the currently selected box number (0-based index).
+    /// Null when no box is selected or when a party slot is selected.
     /// </summary>
     int? SelectedBoxNumber { get; set; }
 
     /// <summary>
-    ///     Gets or sets the currently selected box slot number (0-based index within a box).
-    ///     Null when no box slot is selected or when a party slot is selected.
+    /// Gets or sets the currently selected box slot number (0-based index within a box).
+    /// Null when no box slot is selected or when a party slot is selected.
     /// </summary>
     int? SelectedBoxSlotNumber { get; set; }
 
     /// <summary>
-    ///     Gets or sets the currently selected party slot number (0-based index, 0-5 for party).
-    ///     Null when no party slot is selected or when a box slot is selected.
+    /// Gets or sets the currently selected party slot number (0-based index, 0-5 for party).
+    /// Null when no party slot is selected or when a box slot is selected.
     /// </summary>
     int? SelectedPartySlotNumber { get; set; }
 
     /// <summary>
-    ///     Gets or sets whether the progress indicator should be displayed.
-    ///     Used to show loading spinners during long-running operations.
+    /// Gets or sets whether the progress indicator should be displayed.
+    /// Used to show loading spinners during long-running operations.
     /// </summary>
     bool ShowProgressIndicator { get; set; }
 
     /// <summary>
-    ///     Gets the current application version string.
+    /// Gets the current application version string.
     /// </summary>
     string? AppVersion { get; }
 
     /// <summary>
-    ///     Gets the version of PKHeX.Core library being used.
+    /// Gets the version of PKHeX.Core library being used.
     /// </summary>
     static string? PkhexVersion => Assembly.GetAssembly(typeof(PKM))?.GetName().Version?.ToString();
 
     /// <summary>
-    ///     Gets whether the currently selected slots represent a valid selection.
-    ///     This is true when exactly one slot (either box or party) is selected.
+    /// Gets whether the currently selected slots represent a valid selection.
+    /// This is true when exactly one slot (either box or party) is selected.
     /// </summary>
     bool SelectedSlotsAreValid { get; }
 
     /// <summary>
-    ///     Gets or sets whether PKHaX (Illegal Mode) is enabled.
-    ///     When true, legality restrictions are suppressed and certain editing limits are lifted.
-    ///     Persisted across sessions via localStorage.
+    /// Gets or sets whether PKHaX (Illegal Mode) is enabled.
+    /// When true, legality restrictions are suppressed and certain editing limits are lifted.
+    /// Persisted across sessions via localStorage.
     /// </summary>
     bool IsHaXEnabled { get; set; }
 }

--- a/Pkmds.Rcl/ImageHelper.Accent.cs
+++ b/Pkmds.Rcl/ImageHelper.Accent.cs
@@ -1,7 +1,7 @@
 ﻿namespace Pkmds.Rcl;
 
 /// <summary>
-///     Partial class for accent icon sprite filename generation (gender, lock, party, legality indicators, etc.).
+/// Partial class for accent icon sprite filename generation (gender, lock, party, legality indicators, etc.).
 /// </summary>
 public static partial class ImageHelper
 {

--- a/Pkmds.Rcl/ImageHelper.Box.cs
+++ b/Pkmds.Rcl/ImageHelper.Box.cs
@@ -1,13 +1,13 @@
 ﻿namespace Pkmds.Rcl;
 
 /// <summary>
-///     Partial class for box wallpaper sprite filename generation.
+/// Partial class for box wallpaper sprite filename generation.
 /// </summary>
 public static partial class ImageHelper
 {
     /// <summary>
-    ///     Gets the sprite filename for a box wallpaper based on wallpaper ID and game version.
-    ///     The wallpaper ID is typically retrieved from the save file's box data.
+    /// Gets the sprite filename for a box wallpaper based on wallpaper ID and game version.
+    /// The wallpaper ID is typically retrieved from the save file's box data.
     /// </summary>
     /// <param name="wallpaperId">The wallpaper ID (typically 0-23 or similar depending on game).</param>
     /// <param name="gameVersion">The game version enum.</param>
@@ -18,13 +18,13 @@ public static partial class ImageHelper
     }
 
     /// <summary>
-    ///     Gets the sprite filename for a box wallpaper based on wallpaper ID and game version abbreviation.
-    ///     The wallpaper ID is typically retrieved from the save file's box data.
+    /// Gets the sprite filename for a box wallpaper based on wallpaper ID and game version abbreviation.
+    /// The wallpaper ID is typically retrieved from the save file's box data.
     /// </summary>
     /// <param name="wallpaperId">The wallpaper ID (typically 0-23 or similar depending on game).</param>
     /// <param name="gameAbbreviation">
-    ///     The game abbreviation (e.g., "ao" for Omega Ruby/Alpha Sapphire, "swsh" for
-    ///     Sword/Shield, etc.).
+    /// The game abbreviation (e.g., "ao" for Omega Ruby/Alpha Sapphire, "swsh" for
+    /// Sword/Shield, etc.).
     /// </param>
     private static string GetBoxWallpaperSpriteFileName(int wallpaperId, string? gameAbbreviation)
     {
@@ -38,7 +38,7 @@ public static partial class ImageHelper
     }
 
     /// <summary>
-    ///     Converts a GameVersion enum to its box wallpaper folder abbreviation.
+    /// Converts a GameVersion enum to its box wallpaper folder abbreviation.
     /// </summary>
     private static string GetGameVersionAbbreviation(GameVersion version) => version switch
     {

--- a/Pkmds.Rcl/ImageHelper.Marking.cs
+++ b/Pkmds.Rcl/ImageHelper.Marking.cs
@@ -1,7 +1,7 @@
 ﻿namespace Pkmds.Rcl;
 
 /// <summary>
-///     Partial class for marking sprite filename generation (box marks, generation origin, shiny, region indicators).
+/// Partial class for marking sprite filename generation (box marks, generation origin, shiny, region indicators).
 /// </summary>
 public static partial class ImageHelper
 {

--- a/Pkmds.Rcl/ImageHelper.Overlay.cs
+++ b/Pkmds.Rcl/ImageHelper.Overlay.cs
@@ -1,8 +1,8 @@
 ﻿namespace Pkmds.Rcl;
 
 /// <summary>
-///     Partial class for overlay icon sprite filename generation (alpha, dynamax, held item, party slot, rare, starter,
-///     team indicators).
+/// Partial class for overlay icon sprite filename generation (alpha, dynamax, held item, party slot, rare, starter,
+/// team indicators).
 /// </summary>
 public static partial class ImageHelper
 {

--- a/Pkmds.Rcl/ImageHelper.Ribbon.cs
+++ b/Pkmds.Rcl/ImageHelper.Ribbon.cs
@@ -1,7 +1,7 @@
 ﻿namespace Pkmds.Rcl;
 
 /// <summary>
-///     Partial class for ribbon icon sprite filename generation.
+/// Partial class for ribbon icon sprite filename generation.
 /// </summary>
 public static partial class ImageHelper
 {

--- a/Pkmds.Rcl/ImageHelper.Status.cs
+++ b/Pkmds.Rcl/ImageHelper.Status.cs
@@ -1,7 +1,7 @@
 ﻿namespace Pkmds.Rcl;
 
 /// <summary>
-///     Partial class for status condition icon sprite filename generation.
+/// Partial class for status condition icon sprite filename generation.
 /// </summary>
 public static partial class ImageHelper
 {

--- a/Pkmds.Rcl/ImageHelper.cs
+++ b/Pkmds.Rcl/ImageHelper.cs
@@ -1,8 +1,8 @@
 ﻿namespace Pkmds.Rcl;
 
 /// <summary>
-///     Helper class for generating file paths to Pokémon and item sprite images.
-///     Handles sprite selection based on species, form, gender, context, and other attributes.
+/// Helper class for generating file paths to Pokémon and item sprite images.
+/// Handles sprite selection based on species, form, gender, context, and other attributes.
 /// </summary>
 public static partial class ImageHelper
 {
@@ -22,14 +22,14 @@ public static partial class ImageHelper
     private static readonly int[] Gen45MailIds = [137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148];
 
     /// <summary>
-    ///     Gets the sprite filename for a Mystery Gift (either Pokémon or item).
+    /// Gets the sprite filename for a Mystery Gift (either Pokémon or item).
     /// </summary>
     public static string GetMysteryGiftSpriteFileName(MysteryGift gift) => gift.IsItem
         ? GetItemSpriteFilename(gift.ItemID, gift.Context)
         : GetPokemonSpriteFilename(gift.Species, gift.Context, gift.IsEgg, gift.Form, 0, gift.Gender);
 
     /// <summary>
-    ///     Gets the sprite filename for a Pokémon, handling all forms, genders, and special cases.
+    /// Gets the sprite filename for a Pokémon, handling all forms, genders, and special cases.
     /// </summary>
     public static string GetPokemonSpriteFilename(PKM? pokemon) => pokemon is null
         ? PokemonFallbackImageFileName
@@ -37,8 +37,8 @@ public static partial class ImageHelper
             pokemon.GetFormArgument(0), pokemon.Gender);
 
     /// <summary>
-    ///     Internal method to construct the Pokémon sprite filename based on various attributes.
-    ///     Handles special cases like starter Pikachu/Eevee, eggs, gender differences, Alcremie variations, etc.
+    /// Internal method to construct the Pokémon sprite filename based on various attributes.
+    /// Handles special cases like starter Pikachu/Eevee, eggs, gender differences, Alcremie variations, etc.
     /// </summary>
     private static string GetPokemonSpriteFilename(ushort species, EntityContext context, bool isEgg, byte form,
         uint? formArg1, byte gender) =>
@@ -77,14 +77,14 @@ public static partial class ImageHelper
             .ToString();
 
     /// <summary>
-    ///     Gets the sprite filename for a Poké Ball.
+    /// Gets the sprite filename for a Poké Ball.
     /// </summary>
     /// <param name="ball">The ball ID.</param>
     public static string GetBallSpriteFilename(int ball) =>
         $"{SpritesRoot}b/_ball{ball}.png";
 
     /// <summary>
-    ///     Gets the sprite filename for an item, selecting appropriate size/style based on generation.
+    /// Gets the sprite filename for an item, selecting appropriate size/style based on generation.
     /// </summary>
     public static string GetItemSpriteFilename(int item, EntityContext context) => context switch
     {
@@ -144,7 +144,7 @@ public static partial class ImageHelper
     };
 
     /// <summary>
-    ///     Gets the sprite filename for a move category icon (Physical/Special/Status).
+    /// Gets the sprite filename for a move category icon (Physical/Special/Status).
     /// </summary>
     /// <remarks>TODO: Not yet implemented.</remarks>
     // ReSharper disable once UnusedParameter.Global
@@ -152,7 +152,7 @@ public static partial class ImageHelper
         string.Empty;
 
     /// <summary>
-    ///     Gets the CSS class to apply to a Pokémon slot based on whether it contains a valid Pokémon.
+    /// Gets the CSS class to apply to a Pokémon slot based on whether it contains a valid Pokémon.
     /// </summary>
     public static string GetSpriteCssClass(PKM? pkm) => (pkm?.Species).IsValidSpecies()
         ? " slot-fill"
@@ -169,8 +169,8 @@ public static partial class ImageHelper
     };
 
     /// <summary>
-    ///     Converts an item ID to its string representation for sprite filenames.
-    ///     Handles lumped items (TMs, TRs) and mail items specially.
+    /// Converts an item ID to its string representation for sprite filenames.
+    /// Handles lumped items (TMs, TRs) and mail items specially.
     /// </summary>
     private static string GetItemIdString(int item, EntityContext context) =>
         HeldItemLumpUtil.GetIsLump(item, context) switch

--- a/Pkmds.Rcl/LegalityReportEntry.cs
+++ b/Pkmds.Rcl/LegalityReportEntry.cs
@@ -1,8 +1,8 @@
 namespace Pkmds.Rcl;
 
 /// <summary>
-///     Represents a single row in the batch legality report, describing the legality
-///     status of one Pokémon slot (party or box).
+/// Represents a single row in the batch legality report, describing the legality
+/// status of one Pokémon slot (party or box).
 /// </summary>
 public sealed record LegalityReportEntry
 {

--- a/Pkmds.Rcl/LegalityStatus.cs
+++ b/Pkmds.Rcl/LegalityStatus.cs
@@ -1,7 +1,7 @@
 namespace Pkmds.Rcl;
 
 /// <summary>
-///     Represents the legality status of a Pokémon as determined by the batch legality sweep.
+/// Represents the legality status of a Pokémon as determined by the batch legality sweep.
 /// </summary>
 public enum LegalityStatus
 {

--- a/Pkmds.Rcl/Models/AdvancedSearchFilter.cs
+++ b/Pkmds.Rcl/Models/AdvancedSearchFilter.cs
@@ -1,8 +1,8 @@
 namespace Pkmds.Rcl.Models;
 
 /// <summary>
-///     Holds all optional filter criteria for the Advanced Search feature.
-///     Every field is nullable or an empty collection — a missing value means "any".
+/// Holds all optional filter criteria for the Advanced Search feature.
+/// Every field is nullable or an empty collection — a missing value means "any".
 /// </summary>
 public sealed record AdvancedSearchFilter
 {
@@ -15,19 +15,19 @@ public sealed record AdvancedSearchFilter
     public byte? Form { get; init; }
 
     /// <summary>
-    ///     <see langword="true" /> = shiny only, <see langword="false" /> = non-shiny only,
-    ///     <see langword="null" /> = any.
+    /// <see langword="true" /> = shiny only, <see langword="false" /> = non-shiny only,
+    /// <see langword="null" /> = any.
     /// </summary>
     public bool? IsShiny { get; init; }
 
     /// <summary>
-    ///     <see langword="true" /> = eggs only, <see langword="false" /> = non-eggs only,
-    ///     <see langword="null" /> = any.
+    /// <see langword="true" /> = eggs only, <see langword="false" /> = non-eggs only,
+    /// <see langword="null" /> = any.
     /// </summary>
     public bool? IsEgg { get; init; }
 
     /// <summary>
-    ///     Gender filter: 0 = male, 1 = female, -1 = genderless, <see langword="null" /> = any.
+    /// Gender filter: 0 = male, 1 = female, -1 = genderless, <see langword="null" /> = any.
     /// </summary>
     public int? Gender { get; init; }
 
@@ -47,16 +47,16 @@ public sealed record AdvancedSearchFilter
     public GameVersion? OriginGame { get; init; }
 
     /// <summary>
-    ///     <see langword="true" /> = legal only (no Invalid checks), <see langword="false" /> = illegal only,
-    ///     <see langword="null" /> = any. Evaluated last due to cost.
+    /// <see langword="true" /> = legal only (no Invalid checks), <see langword="false" /> = illegal only,
+    /// <see langword="null" /> = any. Evaluated last due to cost.
     /// </summary>
     public bool? IsLegal { get; init; }
 
     // ── Trainer ───────────────────────────────────────────────────────────
 
     /// <summary>
-    ///     Substring filter for the OT name (case-insensitive),
-    ///     or <see langword="null" /> to skip.
+    /// Substring filter for the OT name (case-insensitive),
+    /// or <see langword="null" /> to skip.
     /// </summary>
     public string? OriginalTrainerName { get; init; }
 
@@ -95,14 +95,14 @@ public sealed record AdvancedSearchFilter
     // ── Moves ─────────────────────────────────────────────────────────────
 
     /// <summary>
-    ///     Pokémon must know <em>at least one</em> of these move IDs (OR logic).
-    ///     Empty list = skip check.
+    /// Pokémon must know <em>at least one</em> of these move IDs (OR logic).
+    /// Empty list = skip check.
     /// </summary>
     public IReadOnlyList<ushort> AnyMoves { get; init; } = [];
 
     /// <summary>
-    ///     Pokémon must know <em>all</em> of these move IDs (AND logic).
-    ///     Empty list = skip check.
+    /// Pokémon must know <em>all</em> of these move IDs (AND logic).
+    /// Empty list = skip check.
     /// </summary>
     public IReadOnlyList<ushort> AllMoves { get; init; } = [];
 
@@ -114,9 +114,9 @@ public sealed record AdvancedSearchFilter
     // ── Ribbons / Marks ───────────────────────────────────────────────────
 
     /// <summary>
-    ///     All named ribbon/mark properties must be <see langword="true" />.
-    ///     Uses the PKHeX property name (e.g., <c>"RibbonChampionG3Hoenn"</c>).
-    ///     Empty list = skip check.
+    /// All named ribbon/mark properties must be <see langword="true" />.
+    /// Uses the PKHeX property name (e.g., <c>"RibbonChampionG3Hoenn"</c>).
+    /// Empty list = skip check.
     /// </summary>
     public IReadOnlyList<string> RequiredRibbons { get; init; } = [];
 }

--- a/Pkmds.Rcl/Models/AdvancedSearchResult.cs
+++ b/Pkmds.Rcl/Models/AdvancedSearchResult.cs
@@ -1,7 +1,7 @@
 namespace Pkmds.Rcl.Models;
 
 /// <summary>
-///     Represents a single row in the Advanced Search results table.
+/// Represents a single row in the Advanced Search results table.
 /// </summary>
 public sealed record AdvancedSearchResult
 {

--- a/Pkmds.Rcl/Models/EncounterSearchFilter.cs
+++ b/Pkmds.Rcl/Models/EncounterSearchFilter.cs
@@ -1,8 +1,8 @@
 namespace Pkmds.Rcl.Models;
 
 /// <summary>
-///     Holds all optional filter criteria for the Encounter Database feature.
-///     Every field is nullable — a missing value means "any".
+/// Holds all optional filter criteria for the Encounter Database feature.
+/// Every field is nullable — a missing value means "any".
 /// </summary>
 public sealed record EncounterSearchFilter
 {
@@ -13,8 +13,8 @@ public sealed record EncounterSearchFilter
     public byte? Form { get; init; }
 
     /// <summary>
-    ///     Specific game version to search, or <see langword="null" /> to search all versions
-    ///     compatible with the current save file's format.
+    /// Specific game version to search, or <see langword="null" /> to search all versions
+    /// compatible with the current save file's format.
     /// </summary>
     public GameVersion? Version { get; init; }
 
@@ -25,10 +25,10 @@ public sealed record EncounterSearchFilter
     public byte? LevelMax { get; init; }
 
     /// <summary>
-    ///     Shiny lock filter:
-    ///     <see langword="true" /> = shiny-locked encounters only (Shiny.Never),
-    ///     <see langword="false" /> = encounters that can be shiny,
-    ///     <see langword="null" /> = any.
+    /// Shiny lock filter:
+    /// <see langword="true" /> = shiny-locked encounters only (Shiny.Never),
+    /// <see langword="false" /> = encounters that can be shiny,
+    /// <see langword="null" /> = any.
     /// </summary>
     public bool? IsShinyLocked { get; init; }
 

--- a/Pkmds.Rcl/Models/EncounterSearchResult.cs
+++ b/Pkmds.Rcl/Models/EncounterSearchResult.cs
@@ -1,7 +1,7 @@
 namespace Pkmds.Rcl.Models;
 
 /// <summary>
-///     Represents a single encounter result row in the Encounter Database.
+/// Represents a single encounter result row in the Encounter Database.
 /// </summary>
 public sealed record EncounterSearchResult
 {

--- a/Pkmds.Rcl/RibbonHelper.cs
+++ b/Pkmds.Rcl/RibbonHelper.cs
@@ -1,14 +1,14 @@
 namespace Pkmds.Rcl;
 
 /// <summary>
-///     Helper class for ribbon-related operations in the ribbon editor.
+/// Helper class for ribbon-related operations in the ribbon editor.
 /// </summary>
 public static class RibbonHelper
 {
     /// <summary>Gets a human-friendly display name for a ribbon property name.</summary>
     /// <remarks>
-    ///     Uses <see cref="RibbonStrings" /> from <see cref="GameInfo.Strings" /> when available, falling back to the
-    ///     property name itself.
+    /// Uses <see cref="RibbonStrings" /> from <see cref="GameInfo.Strings" /> when available, falling back to the
+    /// property name itself.
     /// </remarks>
     /// <param name="propertyName">The property name, e.g. "RibbonChampionKalos".</param>
     public static string GetRibbonDisplayName(string propertyName) =>
@@ -24,8 +24,8 @@ public static class RibbonHelper
                 : info.Name);
 
     /// <summary>
-    ///     Returns <see langword="true" /> when the ribbon name corresponds to a personality mark
-    ///     (Gen 8 encounter marks or Gen 9 alpha/mightiest/titan marks).
+    /// Returns <see langword="true" /> when the ribbon name corresponds to a personality mark
+    /// (Gen 8 encounter marks or Gen 9 alpha/mightiest/titan marks).
     /// </summary>
     public static bool IsMarkEntry(string name)
     {
@@ -43,8 +43,8 @@ public static class RibbonHelper
     }
 
     /// <summary>
-    ///     Gets all ribbon info entries for the given Pokémon, or an empty list if <paramref name="pokemon" /> is
-    ///     <see langword="null" />.
+    /// Gets all ribbon info entries for the given Pokémon, or an empty list if <paramref name="pokemon" /> is
+    /// <see langword="null" />.
     /// </summary>
     public static List<RibbonInfo> GetAllRibbonInfo(PKM? pokemon) =>
         pokemon is not null

--- a/Pkmds.Rcl/Services/AppService.cs
+++ b/Pkmds.Rcl/Services/AppService.cs
@@ -1004,9 +1004,9 @@ public class AppService(IAppState appState, IRefreshService refreshService) : IA
     }
 
     /// <summary>
-    ///     Returns <see langword="true" /> when <paramref name="pkm" /> satisfies every
-    ///     non-null/non-empty criterion in <paramref name="f" />.
-    ///     Cheap equality checks run first; expensive legality analysis runs last.
+    /// Returns <see langword="true" /> when <paramref name="pkm" /> satisfies every
+    /// non-null/non-empty criterion in <paramref name="f" />.
+    /// Cheap equality checks run first; expensive legality analysis runs last.
     /// </summary>
     private bool Matches(PKM pkm, AdvancedSearchFilter f)
     {
@@ -1260,8 +1260,8 @@ public class AppService(IAppState appState, IRefreshService refreshService) : IA
     }
 
     /// <summary>
-    ///     Compacts a box by shifting all Pokémon left to fill gaps (for Gen 1 and Gen 2 games).
-    ///     In these generations, boxes were lists, not grids, so they should have no gaps.
+    /// Compacts a box by shifting all Pokémon left to fill gaps (for Gen 1 and Gen 2 games).
+    /// In these generations, boxes were lists, not grids, so they should have no gaps.
     /// </summary>
     private static void CompactBox(SaveFile saveFile, int boxNumber)
     {
@@ -1321,8 +1321,8 @@ public class AppService(IAppState appState, IRefreshService refreshService) : IA
     }
 
     /// <summary>
-    ///     Returns the human-readable location name for an encounter, or <see langword="null" />
-    ///     when no location is associated (e.g., location ID is 0).
+    /// Returns the human-readable location name for an encounter, or <see langword="null" />
+    /// when no location is associated (e.g., location ID is 0).
     /// </summary>
     private static string? GetEncounterLocationName(IEncounterable enc)
     {
@@ -1339,8 +1339,8 @@ public class AppService(IAppState appState, IRefreshService refreshService) : IA
     }
 
     /// <summary>
-    ///     Classifies an <see cref="IEncounterable" /> into one of the five
-    ///     <see cref="EncounterTypeGroup" /> buckets.
+    /// Classifies an <see cref="IEncounterable" /> into one of the five
+    /// <see cref="EncounterTypeGroup" /> buckets.
     /// </summary>
     private static EncounterTypeGroup GetEncounterTypeGroup(IEncounterable enc)
     {

--- a/Pkmds.Rcl/Services/DragDropService.cs
+++ b/Pkmds.Rcl/Services/DragDropService.cs
@@ -1,8 +1,8 @@
 namespace Pkmds.Rcl.Services;
 
 /// <summary>
-///     Implementation of drag-and-drop service for managing Pokémon drag operations.
-///     Maintains state about the current drag operation including source location and Pokémon data.
+/// Implementation of drag-and-drop service for managing Pokémon drag operations.
+/// Maintains state about the current drag operation including source location and Pokémon data.
 /// </summary>
 public class DragDropService : IDragDropService
 {

--- a/Pkmds.Rcl/Services/IAppService.cs
+++ b/Pkmds.Rcl/Services/IAppService.cs
@@ -1,96 +1,96 @@
 ﻿namespace Pkmds.Rcl.Services;
 
 /// <summary>
-///     Provides core application services for managing Pokémon data, UI state, and game information.
-///     This is the main service for interacting with the save file and Pokémon data.
+/// Provides core application services for managing Pokémon data, UI state, and game information.
+/// This is the main service for interacting with the save file and Pokémon data.
 /// </summary>
 public interface IAppService
 {
     /// <summary>
-    ///     Gets or sets the Pokémon currently being edited in the edit form.
-    ///     This is a clone of the selected Pokémon to allow for canceling edits.
+    /// Gets or sets the Pokémon currently being edited in the edit form.
+    /// This is a clone of the selected Pokémon to allow for canceling edits.
     /// </summary>
     PKM? EditFormPokemon { get; set; }
 
     /// <summary>
-    ///     Gets or sets whether the navigation drawer is currently open.
+    /// Gets or sets whether the navigation drawer is currently open.
     /// </summary>
     bool IsDrawerOpen { get; set; }
 
     /// <summary>
-    ///     Toggles the navigation drawer between open and closed states.
+    /// Toggles the navigation drawer between open and closed states.
     /// </summary>
     void ToggleDrawer();
 
     /// <summary>
-    ///     Clears the current selection (both box and party slots) and resets the edit form.
+    /// Clears the current selection (both box and party slots) and resets the edit form.
     /// </summary>
     void ClearSelection();
 
     /// <summary>
-    ///     Deletes a Pokémon from the party at the specified slot.
-    ///     Ensures at least one battle-ready Pokémon remains in the party.
+    /// Deletes a Pokémon from the party at the specified slot.
+    /// Ensures at least one battle-ready Pokémon remains in the party.
     /// </summary>
     /// <param name="partySlotNumber">The 0-based party slot index (0-5).</param>
     void DeletePokemon(int partySlotNumber);
 
     /// <summary>
-    ///     Deletes a Pokémon from a box by replacing it with a blank Pokémon.
+    /// Deletes a Pokémon from a box by replacing it with a blank Pokémon.
     /// </summary>
     /// <param name="boxNumber">The 0-based box number.</param>
     /// <param name="boxSlotNumber">The 0-based slot number within the box.</param>
     void DeletePokemon(int boxNumber, int boxSlotNumber);
 
     /// <summary>
-    ///     Gets the display name for a Pokémon species in the current language.
+    /// Gets the display name for a Pokémon species in the current language.
     /// </summary>
     /// <param name="speciesId">The species ID to look up.</param>
     /// <returns>The localized species name.</returns>
     string? GetPokemonSpeciesName(ushort speciesId);
 
     /// <summary>
-    ///     Searches for Pokémon species names matching the search string.
+    /// Searches for Pokémon species names matching the search string.
     /// </summary>
     /// <param name="searchString">The search term to filter species names.</param>
     /// <returns>A collection of matching species as combo items.</returns>
     IEnumerable<ComboItem> SearchPokemonNames(string searchString);
 
     /// <summary>
-    ///     Gets the combo item representation for a specific species.
+    /// Gets the combo item representation for a specific species.
     /// </summary>
     /// <param name="speciesId">The species ID to look up.</param>
     /// <returns>A combo item containing the species name and ID.</returns>
     ComboItem GetSpeciesComboItem(ushort speciesId);
 
     /// <summary>
-    ///     Gets a human-readable string describing a nature's stat modifiers.
+    /// Gets a human-readable string describing a nature's stat modifiers.
     /// </summary>
     /// <param name="nature">The nature to describe.</param>
     /// <returns>A string like "(Atk ↑, Def ↓)" or "(neutral)" for neutral natures.</returns>
     string GetStatModifierString(Nature nature);
 
     /// <summary>
-    ///     Calculates and loads the stats for a Pokémon based on its species, form, IVs, EVs, and level.
+    /// Calculates and loads the stats for a Pokémon based on its species, form, IVs, EVs, and level.
     /// </summary>
     /// <param name="pokemon">The Pokémon to load stats for.</param>
     void LoadPokemonStats(PKM? pokemon);
 
     /// <summary>
-    ///     Searches for items matching the search string.
+    /// Searches for items matching the search string.
     /// </summary>
     /// <param name="searchString">The search term to filter item names.</param>
     /// <returns>A collection of matching items as combo items.</returns>
     IEnumerable<ComboItem> SearchItemNames(string searchString);
 
     /// <summary>
-    ///     Gets the combo item representation for a specific item.
+    /// Gets the combo item representation for a specific item.
     /// </summary>
     /// <param name="itemId">The item ID to look up.</param>
     /// <returns>A combo item containing the item name and ID.</returns>
     ComboItem GetItemComboItem(int itemId);
 
     /// <summary>
-    ///     Searches for met locations matching the search string for a specific game version and context.
+    /// Searches for met locations matching the search string for a specific game version and context.
     /// </summary>
     /// <param name="searchString">The search term to filter location names.</param>
     /// <param name="gameVersion">The game version to get locations for.</param>
@@ -101,7 +101,7 @@ public interface IAppService
         bool isEggLocation = false);
 
     /// <summary>
-    ///     Gets the combo item representation for a specific met location.
+    /// Gets the combo item representation for a specific met location.
     /// </summary>
     /// <param name="metLocationId">The location ID to look up.</param>
     /// <param name="gameVersion">The game version for the location.</param>
@@ -112,48 +112,48 @@ public interface IAppService
         bool isEggLocation = false);
 
     /// <summary>
-    ///     Searches for moves matching the search string.
+    /// Searches for moves matching the search string.
     /// </summary>
     /// <param name="searchString">The search term to filter move names.</param>
     /// <returns>A collection of matching moves as combo items.</returns>
     IEnumerable<ComboItem> SearchMoves(string searchString);
 
     /// <summary>
-    ///     Gets all available moves for the current game context.
+    /// Gets all available moves for the current game context.
     /// </summary>
     /// <returns>A collection of all moves as combo items.</returns>
     IEnumerable<ComboItem> GetMoves();
 
     /// <summary>
-    ///     Gets the combo item representation for a specific move.
+    /// Gets the combo item representation for a specific move.
     /// </summary>
     /// <param name="moveId">The move ID to look up.</param>
     /// <returns>A combo item containing the move name and ID.</returns>
     ComboItem GetMoveComboItem(int moveId);
 
     /// <summary>
-    ///     Saves the edited Pokémon back to its original slot in the save file.
+    /// Saves the edited Pokémon back to its original slot in the save file.
     /// </summary>
     /// <param name="selectedPokemon">The Pokémon to save.</param>
     void SavePokemon(PKM? selectedPokemon);
 
     /// <summary>
-    ///     Generates a clean, standardized filename for exporting a Pokémon.
-    ///     Format varies by generation: Gen 1/2 use DV values, Gen 3+ use PID.
+    /// Generates a clean, standardized filename for exporting a Pokémon.
+    /// Format varies by generation: Gen 1/2 use DV values, Gen 3+ use PID.
     /// </summary>
     /// <param name="pkm">The Pokémon to generate a filename for.</param>
     /// <returns>A clean filename suitable for file export.</returns>
     string GetCleanFileName(PKM pkm);
 
     /// <summary>
-    ///     Sets the selected Pokémon from Let's Go Pikachu/Eevee storage.
+    /// Sets the selected Pokémon from Let's Go Pikachu/Eevee storage.
     /// </summary>
     /// <param name="pkm">The Pokémon to select.</param>
     /// <param name="slotNumber">The slot number in Let's Go storage.</param>
     void SetSelectedLetsGoPokemon(PKM? pkm, int slotNumber);
 
     /// <summary>
-    ///     Sets the selected Pokémon from a box slot.
+    /// Sets the selected Pokémon from a box slot.
     /// </summary>
     /// <param name="pkm">The Pokémon to select.</param>
     /// <param name="boxNumber">The box number (0-based).</param>
@@ -161,34 +161,34 @@ public interface IAppService
     void SetSelectedBoxPokemon(PKM? pkm, int boxNumber, int slotNumber);
 
     /// <summary>
-    ///     Sets the selected Pokémon from a party slot.
+    /// Sets the selected Pokémon from a party slot.
     /// </summary>
     /// <param name="pkm">The Pokémon to select.</param>
     /// <param name="slotNumber">The party slot number (0-5).</param>
     void SetSelectedPartyPokemon(PKM? pkm, int slotNumber);
 
     /// <summary>
-    ///     Exports a Pokémon to Pokémon Showdown format text.
+    /// Exports a Pokémon to Pokémon Showdown format text.
     /// </summary>
     /// <param name="pkm">The Pokémon to export.</param>
     /// <returns>A Showdown-formatted text representation of the Pokémon.</returns>
     string ExportPokemonAsShowdown(PKM? pkm);
 
     /// <summary>
-    ///     Exports all Pokémon in the party to Pokémon Showdown format text.
+    /// Exports all Pokémon in the party to Pokémon Showdown format text.
     /// </summary>
     /// <returns>A Showdown-formatted text representation of the entire party.</returns>
     string ExportPartyAsShowdown();
 
     /// <summary>
-    ///     Gets the format string for displaying trainer IDs based on the current save file's format.
+    /// Gets the format string for displaying trainer IDs based on the current save file's format.
     /// </summary>
     /// <param name="isSid">Whether to get the format for SID instead of TID.</param>
     /// <returns>A format string for use with string formatting (e.g., "D5" for 5-digit format).</returns>
     string GetIdFormatString(bool isSid = false);
 
     /// <summary>
-    ///     Determines which type of slot is currently selected and retrieves the slot coordinates.
+    /// Determines which type of slot is currently selected and retrieves the slot coordinates.
     /// </summary>
     /// <param name="partySlot">The party slot number if a party slot is selected.</param>
     /// <param name="boxNumber">The box number if a box slot is selected.</param>
@@ -197,7 +197,7 @@ public interface IAppService
     SelectedPokemonType GetSelectedPokemonSlot(out int partySlot, out int boxNumber, out int boxSlot);
 
     /// <summary>
-    ///     Imports a Mystery Gift into the save file.
+    /// Imports a Mystery Gift into the save file.
     /// </summary>
     /// <param name="gift">The Mystery Gift data to import.</param>
     /// <param name="isSuccessful">Output parameter indicating whether the import was successful.</param>
@@ -206,7 +206,7 @@ public interface IAppService
     Task ImportMysteryGift(DataMysteryGift gift, out bool isSuccessful, out string resultsMessage);
 
     /// <summary>
-    ///     Imports a Mystery Gift from raw data and file extension.
+    /// Imports a Mystery Gift from raw data and file extension.
     /// </summary>
     /// <param name="data">The raw Mystery Gift file data.</param>
     /// <param name="fileExtension">The file extension (e.g., ".wc7", ".pgf").</param>
@@ -216,8 +216,8 @@ public interface IAppService
     Task ImportMysteryGift(byte[] data, string fileExtension, out bool isSuccessful, out string resultsMessage);
 
     /// <summary>
-    ///     Moves or swaps a Pokémon between slots (box-to-box, party-to-box, box-to-party, or party-to-party).
-    ///     Handles special cases like Gen 1/2 box compacting and party compacting.
+    /// Moves or swaps a Pokémon between slots (box-to-box, party-to-box, box-to-party, or party-to-party).
+    /// Handles special cases like Gen 1/2 box compacting and party compacting.
     /// </summary>
     /// <param name="sourceBoxNumber">The source box number (null for party or Let's Go storage).</param>
     /// <param name="sourceSlotNumber">The source slot number.</param>
@@ -229,13 +229,13 @@ public interface IAppService
         int? destBoxNumber, int destSlotNumber, bool isDestParty);
 
     /// <summary>
-    ///     Gets all available memory combo items for the memory ID dropdown.
+    /// Gets all available memory combo items for the memory ID dropdown.
     /// </summary>
     /// <returns>A collection of memories as combo items.</returns>
     IEnumerable<ComboItem> GetMemoryComboItems();
 
     /// <summary>
-    ///     Gets all available memory feeling combo items for the given memory generation.
+    /// Gets all available memory feeling combo items for the given memory generation.
     /// </summary>
     /// <param name="memoryGen">The memory generation (6 for Gen 6/7, 8 for Gen 8+).</param>
     /// <returns>A collection of feelings as combo items.</returns>
@@ -251,60 +251,60 @@ public interface IAppService
     IEnumerable<ComboItem> GetLanguageComboItems(int generation, EntityContext context);
 
     /// <summary>
-    ///     Gets all valid geo-location country combo items (ID → English name).
-    ///     Entry 0 is the "none/blank" country (—).
+    /// Gets all valid geo-location country combo items (ID → English name).
+    /// Entry 0 is the "none/blank" country (—).
     /// </summary>
     IEnumerable<ComboItem> GetGeoCountryComboItems();
 
     /// <summary>
-    ///     Gets all geo-location region combo items for a given country (ID → English name).
-    ///     Only valid when <paramref name="country" /> is non-zero.
+    /// Gets all geo-location region combo items for a given country (ID → English name).
+    /// Only valid when <paramref name="country" /> is non-zero.
     /// </summary>
     IEnumerable<ComboItem> GetGeoRegionComboItems(byte country);
 
     /// <summary>
-    ///     Gets combo items for 3DS console hardware regions (Japan, North America, Europe, etc.).
-    ///     Used for the <see cref="IRegionOrigin.ConsoleRegion" /> field (Gen 6–7 only).
+    /// Gets combo items for 3DS console hardware regions (Japan, North America, Europe, etc.).
+    /// Used for the <see cref="IRegionOrigin.ConsoleRegion" /> field (Gen 6–7 only).
     /// </summary>
     IReadOnlyList<ComboItem> GetConsoleRegionComboItems();
 
     /// <summary>
-    ///     Performs a full legality analysis on the given Pokémon using PKHeX.Core's
-    ///     <see cref="LegalityAnalysis" /> engine.
+    /// Performs a full legality analysis on the given Pokémon using PKHeX.Core's
+    /// <see cref="LegalityAnalysis" /> engine.
     /// </summary>
     /// <param name="pkm">The Pokémon to analyse.</param>
     /// <returns>A <see cref="LegalityAnalysis" /> result.</returns>
     LegalityAnalysis GetLegalityAnalysis(PKM pkm);
 
     /// <summary>
-    ///     Sweeps all party and box slots and returns every Pokémon that satisfies
-    ///     every non-null criterion in <paramref name="filter" />.
-    ///     Legality checks (if requested) are evaluated last due to their cost.
+    /// Sweeps all party and box slots and returns every Pokémon that satisfies
+    /// every non-null criterion in <paramref name="filter" />.
+    /// Legality checks (if requested) are evaluated last due to their cost.
     /// </summary>
     /// <param name="filter">The multi-criteria search filter.</param>
     /// <returns>A lazily-evaluated sequence of matching results.</returns>
     IEnumerable<AdvancedSearchResult> SearchPokemon(AdvancedSearchFilter filter);
 
     /// <summary>
-    ///     Queries PKHeX.Core encounter tables for the species specified in <paramref name="filter" />
-    ///     and returns all encounters that satisfy the given criteria.
+    /// Queries PKHeX.Core encounter tables for the species specified in <paramref name="filter" />
+    /// and returns all encounters that satisfy the given criteria.
     /// </summary>
     /// <param name="filter">
-    ///     Filter criteria. <see cref="EncounterSearchFilter.Species" /> must be non-null for any
-    ///     results to be returned.
+    /// Filter criteria. <see cref="EncounterSearchFilter.Species" /> must be non-null for any
+    /// results to be returned.
     /// </param>
     /// <returns>A lazily-evaluated sequence of matching encounter results.</returns>
     IEnumerable<EncounterSearchResult> SearchEncounters(EncounterSearchFilter filter);
 
     /// <summary>
-    ///     Generates a <see cref="PKM" /> from the given encounter template using the current
-    ///     save file as the trainer info source.
-    ///     Callers are responsible for performing any legality analysis on the generated Pokémon.
+    /// Generates a <see cref="PKM" /> from the given encounter template using the current
+    /// save file as the trainer info source.
+    /// Callers are responsible for performing any legality analysis on the generated Pokémon.
     /// </summary>
     /// <param name="encounter">The encounter template to generate from.</param>
     /// <returns>
-    ///     The generated <see cref="PKM" /> if the save file is loaded;
-    ///     <see langword="null" /> if the save file is not loaded.
+    /// The generated <see cref="PKM" /> if the save file is loaded;
+    /// <see langword="null" /> if the save file is not loaded.
     /// </returns>
     PKM? GeneratePokemonFromEncounter(IEncounterable encounter);
 }

--- a/Pkmds.Rcl/Services/IDragDropService.cs
+++ b/Pkmds.Rcl/Services/IDragDropService.cs
@@ -1,39 +1,39 @@
 namespace Pkmds.Rcl.Services;
 
 /// <summary>
-///     Service for managing drag-and-drop operations for Pokémon between slots.
-///     Tracks the source of a drag operation and provides state for drop targets.
+/// Service for managing drag-and-drop operations for Pokémon between slots.
+/// Tracks the source of a drag operation and provides state for drop targets.
 /// </summary>
 public interface IDragDropService
 {
     /// <summary>
-    ///     Gets or sets the Pokémon currently being dragged.
+    /// Gets or sets the Pokémon currently being dragged.
     /// </summary>
     PKM? DraggedPokemon { get; set; }
 
     /// <summary>
-    ///     Gets or sets the source box number where the drag started.
-    ///     Null for party slots or Let's Go storage.
+    /// Gets or sets the source box number where the drag started.
+    /// Null for party slots or Let's Go storage.
     /// </summary>
     int? DragSourceBoxNumber { get; set; }
 
     /// <summary>
-    ///     Gets or sets the source slot number where the drag started.
+    /// Gets or sets the source slot number where the drag started.
     /// </summary>
     int DragSourceSlotNumber { get; set; }
 
     /// <summary>
-    ///     Gets or sets whether the drag source is a party slot.
+    /// Gets or sets whether the drag source is a party slot.
     /// </summary>
     bool IsDragSourceParty { get; set; }
 
     /// <summary>
-    ///     Gets whether a drag operation is currently in progress.
+    /// Gets whether a drag operation is currently in progress.
     /// </summary>
     bool IsDragging { get; }
 
     /// <summary>
-    ///     Starts a drag operation with the specified Pokémon and source information.
+    /// Starts a drag operation with the specified Pokémon and source information.
     /// </summary>
     /// <param name="pokemon">The Pokémon being dragged.</param>
     /// <param name="boxNumber">The source box number (null for party or Let's Go storage).</param>
@@ -42,12 +42,12 @@ public interface IDragDropService
     void StartDrag(PKM? pokemon, int? boxNumber, int slotNumber, bool isParty);
 
     /// <summary>
-    ///     Ends the drag operation, indicating a successful drop.
+    /// Ends the drag operation, indicating a successful drop.
     /// </summary>
     void EndDrag();
 
     /// <summary>
-    ///     Cancels the drag operation without performing a drop.
+    /// Cancels the drag operation without performing a drop.
     /// </summary>
     void ClearDrag();
 }

--- a/Pkmds.Rcl/Services/ILoggingService.cs
+++ b/Pkmds.Rcl/Services/ILoggingService.cs
@@ -1,20 +1,20 @@
 namespace Pkmds.Rcl.Services;
 
 /// <summary>
-///     Service for controlling application logging levels.
-///     Allows users to toggle verbose logging for debugging purposes.
+/// Service for controlling application logging levels.
+/// Allows users to toggle verbose logging for debugging purposes.
 /// </summary>
 public interface ILoggingService
 {
     /// <summary>
-    ///     Gets or sets whether verbose logging is enabled.
-    ///     When true, sets log level to Verbose; when false, sets to Information.
+    /// Gets or sets whether verbose logging is enabled.
+    /// When true, sets log level to Verbose; when false, sets to Information.
     /// </summary>
     bool IsVerboseLoggingEnabled { get; set; }
 
     /// <summary>
-    ///     Event triggered when logging configuration changes.
-    ///     Provides the new log event level.
+    /// Event triggered when logging configuration changes.
+    /// Provides the new log event level.
     /// </summary>
     event Action<LogEventLevel>? OnLoggingConfigurationChanged;
 }

--- a/Pkmds.Rcl/Services/IRefreshService.cs
+++ b/Pkmds.Rcl/Services/IRefreshService.cs
@@ -1,65 +1,65 @@
 ﻿namespace Pkmds.Rcl.Services;
 
 /// <summary>
-///     Service for managing UI refresh events across the application.
-///     Components can subscribe to specific events to re-render when relevant state changes.
+/// Service for managing UI refresh events across the application.
+/// Components can subscribe to specific events to re-render when relevant state changes.
 /// </summary>
 public interface IRefreshService
 {
     /// <summary>
-    ///     Event triggered when general application state changes (e.g., save file loaded, language changed).
+    /// Event triggered when general application state changes (e.g., save file loaded, language changed).
     /// </summary>
     event Action? OnAppStateChanged;
 
     /// <summary>
-    ///     Event triggered when box data changes (e.g., Pokémon moved, edited, or deleted in boxes).
+    /// Event triggered when box data changes (e.g., Pokémon moved, edited, or deleted in boxes).
     /// </summary>
     event Action? OnBoxStateChanged;
 
     /// <summary>
-    ///     Event triggered when party data changes (e.g., Pokémon moved, edited, or deleted in party).
+    /// Event triggered when party data changes (e.g., Pokémon moved, edited, or deleted in party).
     /// </summary>
     event Action? OnPartyStateChanged;
 
     /// <summary>
-    ///     Event triggered when an application update is available.
+    /// Event triggered when an application update is available.
     /// </summary>
     event Action? OnUpdateAvailable;
 
     /// <summary>
-    ///     Event triggered when the UI theme changes between light and dark modes.
+    /// Event triggered when the UI theme changes between light and dark modes.
     /// </summary>
     event Action<bool>? OnThemeChanged;
 
     /// <summary>
-    ///     Triggers a general application state refresh.
+    /// Triggers a general application state refresh.
     /// </summary>
     void Refresh();
 
     /// <summary>
-    ///     Triggers a refresh for components displaying box data.
+    /// Triggers a refresh for components displaying box data.
     /// </summary>
     void RefreshBoxState();
 
     /// <summary>
-    ///     Triggers a refresh for components displaying party data.
+    /// Triggers a refresh for components displaying party data.
     /// </summary>
     void RefreshPartyState();
 
     /// <summary>
-    ///     Triggers a refresh for both box and party data simultaneously.
-    ///     Useful for operations that affect both (e.g., Let's Go Pikachu/Eevee).
+    /// Triggers a refresh for both box and party data simultaneously.
+    /// Useful for operations that affect both (e.g., Let's Go Pikachu/Eevee).
     /// </summary>
     void RefreshBoxAndPartyState();
 
     /// <summary>
-    ///     Triggers a theme change event.
+    /// Triggers a theme change event.
     /// </summary>
     /// <param name="isDarkMode">True for dark mode, false for light mode.</param>
     void RefreshTheme(bool isDarkMode);
 
     /// <summary>
-    ///     Displays a message notifying the user that an application update is available.
+    /// Displays a message notifying the user that an application update is available.
     /// </summary>
     // ReSharper disable once UnusedMember.Global
     void ShowUpdateMessage();

--- a/Pkmds.Rcl/Services/LoggingService.cs
+++ b/Pkmds.Rcl/Services/LoggingService.cs
@@ -1,8 +1,8 @@
 namespace Pkmds.Rcl.Services;
 
 /// <summary>
-///     Implementation of logging service for controlling application log levels.
-///     Allows runtime toggling between Information and Debug log levels.
+/// Implementation of logging service for controlling application log levels.
+/// Allows runtime toggling between Information and Debug log levels.
 /// </summary>
 public class LoggingService : ILoggingService
 {

--- a/Pkmds.Rcl/Services/SelectedPokemonType.cs
+++ b/Pkmds.Rcl/Services/SelectedPokemonType.cs
@@ -1,7 +1,7 @@
 ﻿namespace Pkmds.Rcl.Services;
 
 /// <summary>
-///     Enum representing the type of Pokémon slot currently selected.
+/// Enum representing the type of Pokémon slot currently selected.
 /// </summary>
 public enum SelectedPokemonType
 {

--- a/Pkmds.Tests/AdvancedSearchTests.cs
+++ b/Pkmds.Tests/AdvancedSearchTests.cs
@@ -3,7 +3,7 @@ using Pkmds.Rcl.Models;
 namespace Pkmds.Tests;
 
 /// <summary>
-///     Tests for <see cref="AppService.SearchPokemon" /> covering the main filter criteria.
+/// Tests for <see cref="AppService.SearchPokemon" /> covering the main filter criteria.
 /// </summary>
 public class AdvancedSearchTests
 {
@@ -22,7 +22,7 @@ public class AdvancedSearchTests
     }
 
     /// <summary>
-    ///     Counts all party + box Pokémon with Species > 0 directly from the save file.
+    /// Counts all party + box Pokémon with Species > 0 directly from the save file.
     /// </summary>
     private static int CountOccupiedSlots(SaveFile sav)
     {

--- a/Pkmds.Tests/AppServiceTests.cs
+++ b/Pkmds.Tests/AppServiceTests.cs
@@ -1,7 +1,7 @@
 namespace Pkmds.Tests;
 
 /// <summary>
-///     Tests for AppService functionality
+/// Tests for AppService functionality
 /// </summary>
 public class AppServiceTests
 {

--- a/Pkmds.Tests/CatchRateStatusConditionTests.cs
+++ b/Pkmds.Tests/CatchRateStatusConditionTests.cs
@@ -1,7 +1,7 @@
 namespace Pkmds.Tests;
 
 /// <summary>
-///     Tests for Gen 1-2 Catch Rate and Status Condition editing.
+/// Tests for Gen 1-2 Catch Rate and Status Condition editing.
 /// </summary>
 public class CatchRateStatusConditionTests
 {

--- a/Pkmds.Tests/ContestStatsTests.cs
+++ b/Pkmds.Tests/ContestStatsTests.cs
@@ -1,7 +1,7 @@
 namespace Pkmds.Tests;
 
 /// <summary>
-///     Tests for contest stat validation and Pokémon contest stat support.
+/// Tests for contest stat validation and Pokémon contest stat support.
 /// </summary>
 public class ContestStatsTests
 {

--- a/Pkmds.Tests/EncounterDatabaseTests.cs
+++ b/Pkmds.Tests/EncounterDatabaseTests.cs
@@ -3,7 +3,7 @@ using Pkmds.Rcl.Models;
 namespace Pkmds.Tests;
 
 /// <summary>
-///     Tests for <see cref="AppService.SearchEncounters" /> and <see cref="AppService.GeneratePokemonFromEncounter" />.
+/// Tests for <see cref="AppService.SearchEncounters" /> and <see cref="AppService.GeneratePokemonFromEncounter" />.
 /// </summary>
 public class EncounterDatabaseTests
 {
@@ -62,10 +62,7 @@ public class EncounterDatabaseTests
 
         // Act
         var results = service
-            .SearchEncounters(new EncounterSearchFilter
-            {
-                Species = (ushort)Species.Pikachu, LevelMin = minLevel, LevelMax = maxLevel
-            })
+            .SearchEncounters(new EncounterSearchFilter { Species = (ushort)Species.Pikachu, LevelMin = minLevel, LevelMax = maxLevel })
             .ToList();
 
         // Assert — every returned encounter must overlap [minLevel, maxLevel]
@@ -110,10 +107,7 @@ public class EncounterDatabaseTests
 
         // Act
         var wildOnly = service
-            .SearchEncounters(new EncounterSearchFilter
-            {
-                Species = (ushort)Species.Pidgey, EncounterGroup = EncounterTypeGroup.Slot
-            })
+            .SearchEncounters(new EncounterSearchFilter { Species = (ushort)Species.Pidgey, EncounterGroup = EncounterTypeGroup.Slot })
             .ToList();
 
         // Assert
@@ -145,10 +139,7 @@ public class EncounterDatabaseTests
         // Arrange — find a wild Pikachu encounter in Red
         var (service, _) = CreateServiceFromFile("POKEMON RED-0.sav");
         var wildEncounter = service
-            .SearchEncounters(new EncounterSearchFilter
-            {
-                Species = (ushort)Species.Pikachu, EncounterGroup = EncounterTypeGroup.Slot
-            })
+            .SearchEncounters(new EncounterSearchFilter { Species = (ushort)Species.Pikachu, EncounterGroup = EncounterTypeGroup.Slot })
             .FirstOrDefault();
 
         wildEncounter.Should().NotBeNull("there must be at least one wild Pikachu encounter in Gen 1");
@@ -167,10 +158,7 @@ public class EncounterDatabaseTests
         // Arrange — find a static encounter (e.g., starter or gift Pokémon) in a Gen 5 save
         var (service, _) = CreateServiceFromFile("Black - Full Completion.sav");
         var staticEncounter = service
-            .SearchEncounters(new EncounterSearchFilter
-            {
-                Species = (ushort)Species.Victini, EncounterGroup = EncounterTypeGroup.Static
-            })
+            .SearchEncounters(new EncounterSearchFilter { Species = (ushort)Species.Victini, EncounterGroup = EncounterTypeGroup.Static })
             .FirstOrDefault();
 
         staticEncounter.Should().NotBeNull("Victini has a static encounter in Gen 5 Black");

--- a/Pkmds.Tests/ExtensionTests.cs
+++ b/Pkmds.Tests/ExtensionTests.cs
@@ -1,7 +1,7 @@
 namespace Pkmds.Tests;
 
 /// <summary>
-///     Tests for extension methods in PkmExtensions
+/// Tests for extension methods in PkmExtensions
 /// </summary>
 public class ExtensionTests
 {

--- a/Pkmds.Tests/Gen2NicknameFallbackTests.cs
+++ b/Pkmds.Tests/Gen2NicknameFallbackTests.cs
@@ -1,7 +1,7 @@
 namespace Pkmds.Tests;
 
 /// <summary>
-///     Tests validating the fix for Gen II nickname encoding issues
+/// Tests validating the fix for Gen II nickname encoding issues
 /// </summary>
 public class Gen2NicknameFallbackTests
 {

--- a/Pkmds.Tests/Gen2SilverTest.cs
+++ b/Pkmds.Tests/Gen2SilverTest.cs
@@ -1,7 +1,7 @@
 namespace Pkmds.Tests;
 
 /// <summary>
-///     Test Gen II Silver save (English) for nickname handling
+/// Test Gen II Silver save (English) for nickname handling
 /// </summary>
 public class Gen2SilverTest
 {

--- a/Pkmds.Tests/HaXModeTests.cs
+++ b/Pkmds.Tests/HaXModeTests.cs
@@ -1,7 +1,7 @@
 namespace Pkmds.Tests;
 
 /// <summary>
-///     Tests for PKHaX (Illegal Mode) stat-editing behaviour.
+/// Tests for PKHaX (Illegal Mode) stat-editing behaviour.
 /// </summary>
 public class HaXModeTests
 {

--- a/Pkmds.Tests/MemoryEditorTests.cs
+++ b/Pkmds.Tests/MemoryEditorTests.cs
@@ -1,7 +1,7 @@
 namespace Pkmds.Tests;
 
 /// <summary>
-///     Tests for memory editing support (Gen 6+).
+/// Tests for memory editing support (Gen 6+).
 /// </summary>
 public class MemoryEditorTests
 {

--- a/Pkmds.Tests/PokemonEncryptionTests.cs
+++ b/Pkmds.Tests/PokemonEncryptionTests.cs
@@ -1,7 +1,7 @@
 namespace Pkmds.Tests;
 
 /// <summary>
-///     Tests for Pokémon encryption, decryption, and checksum validation
+/// Tests for Pokémon encryption, decryption, and checksum validation
 /// </summary>
 public class PokemonEncryptionTests
 {

--- a/Pkmds.Tests/RefreshAwareComponentTests.cs
+++ b/Pkmds.Tests/RefreshAwareComponentTests.cs
@@ -1,7 +1,7 @@
 namespace Pkmds.Tests;
 
 /// <summary>
-///     Tests for RefreshAwareComponent functionality
+/// Tests for RefreshAwareComponent functionality
 /// </summary>
 public class RefreshAwareComponentTests
 {

--- a/Pkmds.Tests/RibbonEditorTests.cs
+++ b/Pkmds.Tests/RibbonEditorTests.cs
@@ -1,7 +1,7 @@
 namespace Pkmds.Tests;
 
 /// <summary>
-///     Tests for the ribbon editor logic in RibbonHelper.
+/// Tests for the ribbon editor logic in RibbonHelper.
 /// </summary>
 public class RibbonEditorTests
 {

--- a/Pkmds.Tests/SaveFileLoadingTests.cs
+++ b/Pkmds.Tests/SaveFileLoadingTests.cs
@@ -1,7 +1,7 @@
 namespace Pkmds.Tests;
 
 /// <summary>
-///     Tests for loading various save file formats
+/// Tests for loading various save file formats
 /// </summary>
 public class SaveFileLoadingTests
 {

--- a/Pkmds.Tests/SaveFileSavingTests.cs
+++ b/Pkmds.Tests/SaveFileSavingTests.cs
@@ -1,7 +1,7 @@
 namespace Pkmds.Tests;
 
 /// <summary>
-///     Tests for saving save files and verifying data integrity
+/// Tests for saving save files and verifying data integrity
 /// </summary>
 public class SaveFileSavingTests
 {

--- a/Pkmds.Web/AppState.cs
+++ b/Pkmds.Web/AppState.cs
@@ -1,9 +1,9 @@
 ﻿namespace Pkmds.Web;
 
 /// <summary>
-///     Blazor WebAssembly implementation of the application state.
-///     This record holds the global state for the PKMDS application including the current save file,
-///     selected slots, clipboard data, and UI preferences.
+/// Blazor WebAssembly implementation of the application state.
+/// This record holds the global state for the PKMDS application including the current save file,
+/// selected slots, clipboard data, and UI preferences.
 /// </summary>
 public record AppState : IAppState
 {

--- a/Pkmds.Web/Services/BlazorAesProvider.cs
+++ b/Pkmds.Web/Services/BlazorAesProvider.cs
@@ -1,15 +1,15 @@
 ﻿namespace Pkmds.Web.Services;
 
 /// <summary>
-///     Blazor WebAssembly implementation of AES cryptography provider.
-///     Uses JavaScript interop (via crypto-js) to perform AES encryption/decryption
-///     because System.Security.Cryptography is not fully supported in WASM.
-///     This is required for PKHeX.Core's encryption/decryption of save files and Pokémon data.
+/// Blazor WebAssembly implementation of AES cryptography provider.
+/// Uses JavaScript interop (via crypto-js) to perform AES encryption/decryption
+/// because System.Security.Cryptography is not fully supported in WASM.
+/// This is required for PKHeX.Core's encryption/decryption of save files and Pokémon data.
 /// </summary>
 public class BlazorAesProvider(JsService jsService) : IAesCryptographyProvider
 {
     /// <summary>
-    ///     Creates an AES cryptography instance with the specified parameters.
+    /// Creates an AES cryptography instance with the specified parameters.
     /// </summary>
     /// <param name="key">The encryption key.</param>
     /// <param name="mode">The cipher mode (ECB or CBC).</param>
@@ -20,7 +20,7 @@ public class BlazorAesProvider(JsService jsService) : IAesCryptographyProvider
         new CryptoJsAes(jsService, key, mode, padding, iv);
 
     /// <summary>
-    ///     Internal class that implements AES encryption/decryption using JavaScript interop.
+    /// Internal class that implements AES encryption/decryption using JavaScript interop.
     /// </summary>
 #pragma warning disable CS9113 // Parameter is unread.
     private class CryptoJsAes(JsService jsService, byte[] key, CipherMode mode, PaddingMode padding, byte[]? iv = null)
@@ -28,31 +28,31 @@ public class BlazorAesProvider(JsService jsService) : IAesCryptographyProvider
         : IAesCryptographyProvider.IAes
     {
         /// <summary>
-        ///     Encrypts data using AES in ECB mode.
+        /// Encrypts data using AES in ECB mode.
         /// </summary>
         public void EncryptEcb(ReadOnlySpan<byte> plaintext, Span<byte> destination) =>
             jsService.EncryptAes(plaintext, destination, key, CipherMode.ECB);
 
         /// <summary>
-        ///     Decrypts data using AES in ECB mode.
+        /// Decrypts data using AES in ECB mode.
         /// </summary>
         public void DecryptEcb(ReadOnlySpan<byte> ciphertext, Span<byte> destination) =>
             jsService.DecryptAes(ciphertext, destination, key, CipherMode.ECB);
 
         /// <summary>
-        ///     Encrypts data using AES in CBC mode.
+        /// Encrypts data using AES in CBC mode.
         /// </summary>
         public void EncryptCbc(ReadOnlySpan<byte> plaintext, Span<byte> destination) =>
             jsService.EncryptAes(plaintext, destination, key, CipherMode.CBC);
 
         /// <summary>
-        ///     Decrypts data using AES in CBC mode.
+        /// Decrypts data using AES in CBC mode.
         /// </summary>
         public void DecryptCbc(ReadOnlySpan<byte> ciphertext, Span<byte> destination) =>
             jsService.DecryptAes(ciphertext, destination, key, CipherMode.CBC);
 
         /// <summary>
-        ///     Disposes the AES instance (no-op for JavaScript-based implementation).
+        /// Disposes the AES instance (no-op for JavaScript-based implementation).
         /// </summary>
         public void Dispose() { }
     }

--- a/Pkmds.Web/Services/BlazorMd5Provider.cs
+++ b/Pkmds.Web/Services/BlazorMd5Provider.cs
@@ -1,15 +1,15 @@
 ﻿namespace Pkmds.Web.Services;
 
 /// <summary>
-///     Blazor WebAssembly implementation of MD5 hashing provider.
-///     Uses JavaScript interop (via crypto-js) to perform MD5 hashing
-///     because System.Security.Cryptography is not fully supported in WASM.
-///     This is required for PKHeX.Core's checksum validation of save files.
+/// Blazor WebAssembly implementation of MD5 hashing provider.
+/// Uses JavaScript interop (via crypto-js) to perform MD5 hashing
+/// because System.Security.Cryptography is not fully supported in WASM.
+/// This is required for PKHeX.Core's checksum validation of save files.
 /// </summary>
 public class BlazorMd5Provider(JsService jsService) : IMd5Provider
 {
     /// <summary>
-    ///     Computes the MD5 hash of the input data.
+    /// Computes the MD5 hash of the input data.
     /// </summary>
     /// <param name="source">The data to hash.</param>
     /// <param name="destination">The span to write the hash to (must be at least 16 bytes).</param>

--- a/Pkmds.Web/Services/JsService.cs
+++ b/Pkmds.Web/Services/JsService.cs
@@ -1,14 +1,14 @@
 ﻿namespace Pkmds.Web.Services;
 
 /// <summary>
-///     Service for JavaScript interop, providing cryptographic operations via crypto-js library.
-///     This service bridges .NET code with JavaScript implementations of AES and MD5,
-///     which are necessary because these cryptographic APIs are not fully supported in Blazor WebAssembly.
+/// Service for JavaScript interop, providing cryptographic operations via crypto-js library.
+/// This service bridges .NET code with JavaScript implementations of AES and MD5,
+/// which are necessary because these cryptographic APIs are not fully supported in Blazor WebAssembly.
 /// </summary>
 public class JsService(IJSRuntime js)
 {
     /// <summary>
-    ///     Gets the synchronous JavaScript runtime, throwing if not available.
+    /// Gets the synchronous JavaScript runtime, throwing if not available.
     /// </summary>
     /// <exception cref="NotSupportedException">Thrown when IJSInProcessRuntime is not available.</exception>
     private IJSInProcessRuntime SyncJs =>
@@ -16,7 +16,7 @@ public class JsService(IJSRuntime js)
         ?? throw new NotSupportedException("Requested an in process javascript interop, but none was found");
 
     /// <summary>
-    ///     Encrypts data using AES with the specified key and cipher mode.
+    /// Encrypts data using AES with the specified key and cipher mode.
     /// </summary>
     /// <param name="origin">The plaintext data to encrypt.</param>
     /// <param name="destination">The span to write the encrypted data to.</param>
@@ -34,7 +34,7 @@ public class JsService(IJSRuntime js)
     }
 
     /// <summary>
-    ///     Decrypts data using AES with the specified key and cipher mode.
+    /// Decrypts data using AES with the specified key and cipher mode.
     /// </summary>
     /// <param name="origin">The ciphertext data to decrypt.</param>
     /// <param name="destination">The span to write the decrypted data to.</param>
@@ -52,7 +52,7 @@ public class JsService(IJSRuntime js)
     }
 
     /// <summary>
-    ///     Converts a hexadecimal string to a byte array.
+    /// Converts a hexadecimal string to a byte array.
     /// </summary>
     /// <param name="hex">The hexadecimal string (without separators).</param>
     /// <returns>The byte array representation.</returns>
@@ -68,7 +68,7 @@ public class JsService(IJSRuntime js)
     }
 
     /// <summary>
-    ///     Computes the MD5 hash of the input data using JavaScript interop.
+    /// Computes the MD5 hash of the input data using JavaScript interop.
     /// </summary>
     /// <param name="toArray">The data to hash.</param>
     /// <returns>The MD5 hash as a byte array (16 bytes).</returns>

--- a/Pkmds.Web/Services/RefreshService.cs
+++ b/Pkmds.Web/Services/RefreshService.cs
@@ -1,18 +1,18 @@
 ﻿namespace Pkmds.Web.Services;
 
 /// <summary>
-///     Blazor WebAssembly implementation of the refresh service.
-///     Manages UI refresh events and provides JavaScript interop for service worker update notifications.
+/// Blazor WebAssembly implementation of the refresh service.
+/// Manages UI refresh events and provides JavaScript interop for service worker update notifications.
 /// </summary>
 public class RefreshService : IRefreshService
 {
     /// <summary>
-    ///     Initializes a new instance and sets the singleton instance for JavaScript interop.
+    /// Initializes a new instance and sets the singleton instance for JavaScript interop.
     /// </summary>
     public RefreshService() => Instance = this; // Set the singleton instance for JS interop
 
     /// <summary>
-    ///     Static singleton instance used by JavaScript to invoke update notifications.
+    /// Static singleton instance used by JavaScript to invoke update notifications.
     /// </summary>
     private static RefreshService? Instance { get; set; }
 
@@ -66,7 +66,7 @@ public class RefreshService : IRefreshService
     public void RefreshTheme(bool isDarkMode) => OnThemeChanged?.Invoke(isDarkMode);
 
     /// <summary>
-    ///     JavaScript-invokable method called by the service worker when an app update is detected.
+    /// JavaScript-invokable method called by the service worker when an app update is detected.
     /// </summary>
     [JSInvokable(nameof(ShowUpdateMessage))]
     public static void ShowUpdateMessage() => Instance?.OnUpdateAvailable?.Invoke();

--- a/Pkmds.Web/wwwroot/js/theme-init.js
+++ b/Pkmds.Web/wwwroot/js/theme-init.js
@@ -1,6 +1,9 @@
 (function () {
     var stored = null;
-    try { stored = localStorage.getItem('pkmds_theme'); } catch (_) {}
+    try {
+        stored = localStorage.getItem('pkmds_theme');
+    } catch (_) {
+    }
     var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
     var theme = stored || (prefersDark ? 'dark' : 'light');
     document.documentElement.setAttribute('data-theme', theme);


### PR DESCRIPTION
Update package versions and perform small refactors across the RCL/Core/Web projects. Bumped Humanizer 3.0.1 -> 3.0.8 and MudBlazor 9.0.0 -> 9.1.0 in Directory.Packages.props. Remove explicit false argument from LegalityLocalizationContext.Humanize calls (use the parameterless/updated overload) and change Pokemon.SetMoveset(false) to the parameterless call. Also tidy up object initializers, theme string construction, and XML doc/comment formatting across many files; these are non-functional stylistic cleanups to align with updated APIs and improve code consistency.