### PR TITLE
Bump deps and apply minor code cleanup

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,14 +6,14 @@
         <PackageVersion Include="bUnit" Version="2.6.2"/>
         <PackageVersion Include="coverlet.collector" Version="8.0.0"/>
         <PackageVersion Include="FluentAssertions" Version="8.8.0"/>
-        <PackageVersion Include="Humanizer" Version="3.0.8"/>
+        <PackageVersion Include="Humanizer" Version="3.0.10"/>
         <PackageVersion Include="KristofferStrube.Blazor.FileSystemAccess" Version="3.3.0"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.3"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.3"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.4"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.4"/>
         <PackageVersion Include="Microsoft.JSInterop" Version="10.0.3"/>
         <PackageVersion Include="Microsoft.JSInterop.WebAssembly" Version="10.0.3"/>
         <PackageVersion Include="MudBlazor" Version="9.1.0"/>
-        <PackageVersion Include="PKHeX.Core" Version="26.1.31"/>
+        <PackageVersion Include="PKHeX.Core" Version="26.3.6"/>
         <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0"/>
         <PackageVersion Include="Serilog.Sinks.BrowserConsole" Version="8.0.0"/>
         <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5"/>

--- a/Pkmds.Core/Utilities/MoveCategoryData.cs
+++ b/Pkmds.Core/Utilities/MoveCategoryData.cs
@@ -3,26 +3,12 @@ namespace Pkmds.Core.Utilities;
 /// <summary>
 /// Move category (Physical / Special / Status) lookup table for Gen 4+ moves.
 /// Data sourced from Pokémon Showdown (smogon/pokemon-showdown data/moves.ts).
-/// Indexed by move ID; value encodes <see cref="GameInfoUtilities.MoveCategory"/>.
+/// Indexed by move ID; value encodes <see cref="GameInfoUtilities.MoveCategory" />.
 /// Odd Z-move IDs (623–657) are the Special variants of their Physical counterparts.
 /// IDs 921–999 are reserved/unused slots; they default to Status (0).
 /// </summary>
 internal static class MoveCategoryData
 {
-    /// <summary>
-    /// Gets the <see cref="GameInfoUtilities.MoveCategory"/> for a Gen 4+ move.
-    /// </summary>
-    /// <param name="moveId">Move ID (PKHeX <see cref="PKHeX.Core.Move"/> cast to ushort).</param>
-    /// <returns>The move's damage category, or <see cref="GameInfoUtilities.MoveCategory.Status"/> for unknown IDs.</returns>
-    internal static GameInfoUtilities.MoveCategory GetMoveCategory(ushort moveId)
-    {
-        // caching in a local within GetMoveCategory to ensure it’s created once
-        var table = CategoryTable;
-        return moveId >= table.Length
-            ? GameInfoUtilities.MoveCategory.Status
-            : (GameInfoUtilities.MoveCategory)table[moveId];
-    }
-
     /// <summary>
     /// Category table indexed by move ID. Values: 0 = Status, 1 = Physical, 2 = Special.
     /// </summary>
@@ -78,6 +64,20 @@ internal static class MoveCategoryData
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        1,
+        1
     ];
+
+    /// <summary>
+    /// Gets the <see cref="GameInfoUtilities.MoveCategory" /> for a Gen 4+ move.
+    /// </summary>
+    /// <param name="moveId">Move ID (PKHeX <see cref="PKHeX.Core.Move" /> cast to ushort).</param>
+    /// <returns>The move's damage category, or <see cref="GameInfoUtilities.MoveCategory.Status" /> for unknown IDs.</returns>
+    internal static GameInfoUtilities.MoveCategory GetMoveCategory(ushort moveId)
+    {
+        // caching in a local within GetMoveCategory to ensure it’s created once
+        var table = CategoryTable;
+        return moveId >= table.Length
+            ? GameInfoUtilities.MoveCategory.Status
+            : (GameInfoUtilities.MoveCategory)table[moveId];
+    }
 }

--- a/Pkmds.Rcl/Components/BasePkmdsComponent.razor.cs
+++ b/Pkmds.Rcl/Components/BasePkmdsComponent.razor.cs
@@ -10,33 +10,43 @@ public partial class BasePkmdsComponent
     {
         var (up, dn) = nature.GetNatureModification();
         if (up == dn)
+        {
             return NatureModifier.Neutral;
+        }
+
         if (up == (int)stat)
+        {
             return NatureModifier.Boosted;
-        return dn == (int)stat ? NatureModifier.Hindered : NatureModifier.Neutral;
+        }
+
+        return dn == (int)stat
+            ? NatureModifier.Hindered
+            : NatureModifier.Neutral;
     }
 
     protected static string GetNatureAdornmentIcon(NatureModifier modifier) => modifier switch
     {
         NatureModifier.Boosted => Icons.Material.Filled.ArrowUpward,
         NatureModifier.Hindered => Icons.Material.Filled.ArrowDownward,
-        _ => string.Empty,
+        _ => string.Empty
     };
 
     protected static Color GetNatureAdornmentColor(NatureModifier modifier) => modifier switch
     {
         NatureModifier.Boosted => Color.Error,
         NatureModifier.Hindered => Color.Info,
-        _ => Color.Default,
+        _ => Color.Default
     };
 
     protected static Adornment GetNatureAdornment(NatureModifier modifier) =>
-        modifier is NatureModifier.Neutral ? Adornment.None : Adornment.End;
+        modifier is NatureModifier.Neutral
+            ? Adornment.None
+            : Adornment.End;
 
     protected static string GetNatureTooltip(NatureModifier modifier) => modifier switch
     {
         NatureModifier.Boosted => "Boosted by nature (+10%)",
         NatureModifier.Hindered => "Hindered by nature (-10%)",
-        _ => string.Empty,
+        _ => string.Empty
     };
 }

--- a/Pkmds.Rcl/Components/EditForms/Tabs/MovesTab.razor.cs
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/MovesTab.razor.cs
@@ -19,7 +19,7 @@ public partial class MovesTab
         }
 
         var ctx = LegalityLocalizationContext.Create(la);
-        return ctx.FormatMove(result, index + 1, (byte)AppState.SaveFile!.Context);
+        return ctx.FormatMove(result, index + 1, AppState.SaveFile!.Context);
     }
 
     private Task<IEnumerable<ComboItem>> SearchMoves(string searchString, CancellationToken token) =>

--- a/Pkmds.Rcl/Components/EditForms/Tabs/StatsTab.razor.cs
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/StatsTab.razor.cs
@@ -182,7 +182,7 @@ public partial class StatsTab : IDisposable
 
     private void OnSetDv(Stats stat, int newValue)
     {
-        if (Pokemon is not PK1 or PK2)
+        if (Pokemon is not (PK1 or PK2))
         {
             return;
         }

--- a/Pkmds.Rcl/Models/NatureModifier.cs
+++ b/Pkmds.Rcl/Models/NatureModifier.cs
@@ -4,5 +4,5 @@ public enum NatureModifier
 {
     Neutral,
     Boosted,
-    Hindered,
+    Hindered
 }

--- a/Pkmds.Rcl/Models/Stats.cs
+++ b/Pkmds.Rcl/Models/Stats.cs
@@ -2,7 +2,7 @@ namespace Pkmds.Rcl.Models;
 
 /// <summary>
 /// Stat indices used for nature modifier calculations and display.
-/// Values 0–4 correspond to the indices returned by <see cref="PKHeX.Core.NatureAmp.GetNatureModification"/>.
+/// Values 0–4 correspond to the indices returned by <see cref="PKHeX.Core.NatureAmp.GetNatureModification" />.
 /// </summary>
 public enum Stats
 {
@@ -12,5 +12,5 @@ public enum Stats
     Speed,
     SpecialAttack,
     SpecialDefense,
-    Special = 99,
+    Special = 99
 }

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "allowPrerelease": false,
     "rollForward": "latestMinor",
-    "version": "10.0.102"
+    "version": "10.0.104"
   }
 }


### PR DESCRIPTION
Update package and SDK versions and apply small code/style refactors. Bumped Humanizer, Microsoft.AspNetCore.Components.WebAssembly (+DevServer), PKHeX.Core in Directory.Packages.props and updated global.json SDK to 10.0.104. MoveCategoryData: moved GetMoveCategory below the category table and normalized XML cref formatting. Miscellaneous C# formatting and minor fixes across components: added/normalized braces and expression formatting in BasePkmdsComponent, removed an unnecessary cast in MovesTab, adjusted pattern matching parentheses in StatsTab, and cleaned up trailing commas and doc comments in models.