### PR TITLE
Scale Gen I/II game sprites to 100%; align displayed version with tag format

### DIFF
--- a/Pkmds.Rcl/Components/PokemonSlotComponent.razor.cs
+++ b/Pkmds.Rcl/Components/PokemonSlotComponent.razor.cs
@@ -95,13 +95,23 @@ public partial class PokemonSlotComponent : IDisposable
         }
     }
 
-    // X/Y and OR/AS sprites are tightly cropped 60×60 px images that visually fill the slot more
-    // than other generations — scale them down slightly.
-    private string GetHiResSizeClass() =>
-        AppState.SpriteStyle == SpriteStyle.Game
-        && AppState.SaveFile?.Version is GameVersion.X or GameVersion.Y or GameVersion.OR or GameVersion.AS
-            ? "pkm-sprite-hires--sm"
-            : string.Empty;
+    // Gen I/II transparent sprites are 40×40 px — scale up to fill the slot.
+    // X/Y and OR/AS sprites are tightly cropped 60×60 px — scale down slightly.
+    private string GetHiResSizeClass()
+    {
+        if (AppState.SpriteStyle != SpriteStyle.Game)
+            return string.Empty;
+        return AppState.SaveFile?.Version switch
+        {
+            GameVersion.RD or GameVersion.GN or GameVersion.BU
+                or GameVersion.RB or GameVersion.RBY or GameVersion.YW
+                or GameVersion.GD or GameVersion.GS or GameVersion.SI or GameVersion.C
+                => "pkm-sprite-hires--lg",
+            GameVersion.X or GameVersion.Y or GameVersion.OR or GameVersion.AS
+                => "pkm-sprite-hires--sm",
+            _ => string.Empty
+        };
+    }
 
     private void OnHighResSpriteLoaded()
     {

--- a/Pkmds.Rcl/Extensions/VersionExtensions.cs
+++ b/Pkmds.Rcl/Extensions/VersionExtensions.cs
@@ -9,11 +9,11 @@ public static class VersionExtensions
     extension(Version? version)
     {
         /// <summary>
-        /// Converts a Version to a formatted string in the format "YYYY.MM.DD.HHMMSS".
+        /// Converts a Version to a formatted string matching the GitHub tag format "YYYY.MM.DDHH.mmss".
         /// The assembly version packs day+hour into the Build component (DDHH) and
-        /// minute+second into the Revision component (MMSS) to stay within the 0–65535 limit.
+        /// minute+second into the Revision component (mmss) to stay within the 0–65535 limit.
         /// </summary>
-        /// <returns>A formatted version string (e.g., "2026.01.27.094912").</returns>
+        /// <returns>A formatted version string (e.g., "2026.01.2709.4912").</returns>
         /// <exception cref="ArgumentNullException">Thrown if version is null.</exception>
         public string ToVersionString()
         {
@@ -22,11 +22,7 @@ public static class VersionExtensions
                 throw new ArgumentNullException(nameof(version));
             }
 
-            var day = version.Build / 100;
-            var hour = version.Build % 100;
-            var minute = version.Revision / 100;
-            var second = version.Revision % 100;
-            return $"{version.Major:D4}.{version.Minor:D2}.{day:D2}.{hour:D2}{minute:D2}{second:D2}";
+            return $"{version.Major}.{version.Minor:D2}.{version.Build:D4}.{version.Revision:D4}";
         }
 
         /// <summary>

--- a/Pkmds.Rcl/wwwroot/css/app.css
+++ b/Pkmds.Rcl/wwwroot/css/app.css
@@ -33,6 +33,10 @@ body, html {
     width: 50%;
 }
 
+.pkm-sprite-hires--lg {
+    width: 100%;
+}
+
 @keyframes sprite-fade-in {
     from { opacity: 0; }
     to { opacity: 1; }

--- a/Pkmds.Tests/VersionExtensionsTests.cs
+++ b/Pkmds.Tests/VersionExtensionsTests.cs
@@ -6,9 +6,9 @@ public class VersionExtensionsTests
 {
     // Build = DDHH (day * 100 + hour), Revision = MMSS (minute * 100 + second)
     [Theory]
-    [InlineData(2026, 3, 1109, 4912, "2026.03.11.094912", 2026, 3, 11, 9, 49, 12)]
-    [InlineData(2026, 3, 100, 500, "2026.03.01.000500", 2026, 3, 1, 0, 5, 0)]
-    [InlineData(2026, 3, 3123, 5959, "2026.03.31.235959", 2026, 3, 31, 23, 59, 59)]
+    [InlineData(2026, 3, 1109, 4912, "2026.03.1109.4912", 2026, 3, 11, 9, 49, 12)]
+    [InlineData(2026, 3, 100, 500, "2026.03.0100.0500", 2026, 3, 1, 0, 5, 0)]
+    [InlineData(2026, 3, 3123, 5959, "2026.03.3123.5959", 2026, 3, 31, 23, 59, 59)]
     public void ToDateTime_ValidVersion_ParsesUtcDateTime(
         int year, int month, int build, int revision,
         string expectedVersionString,


### PR DESCRIPTION
## Summary

- **Gen I/II sprite size**: The transparent 40×40 px sprites were rendering too small at the default 80% slot width. Added `.pkm-sprite-hires--lg` (100% width) applied for Gen I and Gen II in Game sprite mode.
- **Version string**: `ToVersionString()` now returns the raw packed format (e.g. `2026.03.1518.0443`) to match the GitHub tag, instead of the previously unpacked `2026.03.15.180443` form.

## Size classes summary

| Generation | Class | Width |
|---|---|---|
| Gen I, Gen II | `--lg` | 100% |
| Gen III–V, VII–IX | (default) | 80% |
| Gen VI (X/Y, OR/AS) | `--sm` | 50% |

## Test plan

- [ ] Load a Gen I or Gen II save in Game sprite mode — sprites fill the slot at 100% width
- [ ] Verify the version string in the app footer matches the GitHub tag exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)