### PR TITLE
Set BlazorWebAssemblyEnvironment=Staging in UAT publish

### DIFF
--- a/.github/workflows/uat.yml
+++ b/.github/workflows/uat.yml
@@ -34,7 +34,7 @@ jobs:
         run: dotnet restore Pkmds.Web/Pkmds.Web.csproj
 
       - name: Publish
-        run: dotnet publish Pkmds.Web/Pkmds.Web.csproj -c Release -o release --nologo
+        run: dotnet publish Pkmds.Web/Pkmds.Web.csproj -c Release -o release --nologo -p:BlazorWebAssemblyEnvironment=Staging
 
       - name: Copy index.html to 404.html
         run: cp release/wwwroot/index.html release/wwwroot/404.html


### PR DESCRIPTION
Bakes the Staging environment name into the WASM boot manifest so HostEnvironment.IsStaging() returns true at runtime in UAT, enabling future debug features to be gated on Development || Staging without affecting prod.