### PR TITLE
Remove lazy pouch rendering and adjust layout

### DIFF
--- a/Pkmds.Rcl/Components/MainTabPages/BagTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/BagTab.razor
@@ -5,9 +5,8 @@
     <MudTabs Outlined
              Rounded
              Border
-             ActivePanelIndexChanged="@OnActivePanelChanged"
              @ref="@PouchTabs">
-        @foreach (var (pouch, pouchIndex) in Inventory.Pouches.Select((p, i) => (p, i)))
+        @foreach (var pouch in Inventory.Pouches)
         {
             <MudTabPanel ID="@pouch.Type.ToString()">
                 <TabContent>
@@ -25,11 +24,9 @@
                     </MudStack>
                 </TabContent>
                 <ChildContent>
-                    @if (RenderedPouches.Contains(pouchIndex))
-                    {
-                        <MudStack>
-                            <MudStack Row
-                                      Wrap="@Wrap.Wrap">
+                    <MudStack>
+                        <MudStack Row
+                                  Wrap="@Wrap.Wrap">
                                 <MudButton OnClick="@SaveChanges"
                                            Color="@Color.Primary"
                                            Variant="@Variant.Filled"
@@ -71,7 +68,6 @@
                                          RowsPerPage="50"
                                          RowClassFunc="@((_, i) => i % 2 != 0 ? "row-alt" : string.Empty)"
                                          EditTrigger="@DataGridEditTrigger.OnRowClick"
-                                         Height="calc(100vh - 300px)"
                                          Class="bag-data-grid">
                                 <PagerContent>
                                     <MudDataGridPager T="@InventoryItem"
@@ -207,12 +203,7 @@
                                     </TemplateColumn>
                                 </Columns>
                             </MudDataGrid>
-                        </MudStack>
-                    }
-                    else
-                    {
-                        <MudProgressLinear Indeterminate/>
-                    }
+                    </MudStack>
                 </ChildContent>
             </MudTabPanel>
         }

--- a/Pkmds.Rcl/Components/MainTabPages/BagTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/BagTab.razor.cs
@@ -32,11 +32,9 @@ public partial class BagTab
 
     private bool IsSortedByIndex { get; set; } = true; // Set as true so first sort is ascending
 
-    private int ActivePouchIndex { get; set; }
-
-    private HashSet<int> RenderedPouches { get; } = [];
-
     private bool ShowEmptySlots { get; set; }
+
+    private PlayerBag? PreviousInventory { get; set; }
 
     protected override void OnParametersSet()
     {
@@ -47,10 +45,12 @@ public partial class BagTab
             return;
         }
 
-        // Reset lazy rendering state for new inventory
-        RenderedPouches.Clear();
-        RenderedPouches.Add(0);
-        ActivePouchIndex = 0;
+        if (ReferenceEquals(Inventory, PreviousInventory))
+        {
+            return;
+        }
+
+        PreviousInventory = Inventory;
 
         ItemList = [.. GameInfo.Strings.GetItemStrings(saveFile.Context, saveFile.Version)];
 
@@ -72,12 +72,6 @@ public partial class BagTab
         // Build caches for improved performance
         BuildItemComboCache();
         BuildPouchValidItemsCache();
-    }
-
-    private void OnActivePanelChanged(int index)
-    {
-        ActivePouchIndex = index;
-        RenderedPouches.Add(index);
     }
 
     private void BuildItemComboCache()

--- a/Pkmds.Rcl/wwwroot/css/app.css
+++ b/Pkmds.Rcl/wwwroot/css/app.css
@@ -122,6 +122,7 @@ body, html {
 }
 
 .bag-data-grid .mud-table-container {
+    max-height: calc(100vh - 380px);
     overflow-y: auto;
 }
 


### PR DESCRIPTION
Drop the lazy-rendering logic for pouch panels: remove ActivePanelIndexChanged binding, ActivePouchIndex, RenderedPouches and OnActivePanelChanged; iterate pouches directly and always render their content. Add a reference check (PreviousInventory) to avoid redundant rebuilds when the same Inventory is passed. Remove the inline DataGrid Height and instead constrain the grid with a new CSS max-height (.bag-data-grid .mud-table-container). Misc: minor refactor of item list initialization and pouch markup simplification.