### PR TITLE
Attach save file bytes to Sentry on errors

### DIFF
--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
@@ -272,8 +272,11 @@ public partial class MainLayout : IDisposable
             }
             else
             {
-                BugReportService.AttachRawFileToScope(data, selectedFile.Name);
-                Logger.LogError("Failed to load save file: {FileName} - Invalid save file format", selectedFile.Name);
+                using (BugReportService.AttachRawFileToScope(data, selectedFile.Name))
+                {
+                    Logger.LogError("Failed to load save file: {FileName} - Invalid save file format", selectedFile.Name);
+                }
+
                 const string message =
                     "The selected save file is invalid. If this save file came from a ROM hack, it is not supported. Otherwise, try saving in-game and re-exporting / re-uploading the save file.";
                 await DialogService.ShowMessageBoxAsync("Error", message);
@@ -282,12 +285,11 @@ public partial class MainLayout : IDisposable
         }
         catch (Exception ex)
         {
-            if (data.Length > 0)
+            using (BugReportService.AttachRawFileToScope(data, selectedFile.Name))
             {
-                BugReportService.AttachRawFileToScope(data, selectedFile.Name);
+                Logger.LogError(ex, "Error loading save file: {FileName}", selectedFile.Name);
             }
 
-            Logger.LogError(ex, "Error loading save file: {FileName}", selectedFile.Name);
             await DialogService.ShowMessageBoxAsync("Error", $"{ex.Message}{Environment.NewLine}{ex.StackTrace}");
         }
         finally

--- a/Pkmds.Rcl/Services/IBugReportService.cs
+++ b/Pkmds.Rcl/Services/IBugReportService.cs
@@ -5,8 +5,10 @@ public interface IBugReportService
     Task SubmitBugReportAsync(string description, string? email = null, string? name = null, bool attachSaveFile = false);
 
     /// <summary>
-    /// Attaches raw file bytes to the current Sentry scope so they are included
-    /// with any error events captured during save file loading failures.
+    /// Pushes a new Sentry scope with the raw file bytes attached. The attachment is
+    /// automatically removed when the returned <see cref="IDisposable"/> is disposed,
+    /// preventing it from leaking into unrelated events.
     /// </summary>
-    void AttachRawFileToScope(byte[] data, string fileName);
+    /// <returns>A disposable scope that should wrap the error logging call.</returns>
+    IDisposable AttachRawFileToScope(byte[] data, string fileName);
 }

--- a/Pkmds.Web/Services/BugReportService.cs
+++ b/Pkmds.Web/Services/BugReportService.cs
@@ -1,10 +1,32 @@
 namespace Pkmds.Web.Services;
 
+file sealed class NoOpDisposable : IDisposable
+{
+    public static readonly NoOpDisposable Instance = new();
+    public void Dispose() { }
+}
+
 public class BugReportService(IAppState appState) : IBugReportService
 {
-    public void AttachRawFileToScope(byte[] data, string fileName)
+    private const int MaxAttachmentBytes = 10 * 1024 * 1024; // 10 MiB, matches Program.cs
+
+    public IDisposable AttachRawFileToScope(byte[] data, string fileName)
     {
-        SentrySdk.ConfigureScope(scope => scope.AddAttachment(data, fileName));
+        if (data.Length == 0 || data.Length > MaxAttachmentBytes)
+        {
+            return NoOpDisposable.Instance;
+        }
+
+        // Sanitize filename: keep only the last segment and replace problematic characters.
+        var sanitized = Path.GetFileName(fileName);
+        if (string.IsNullOrWhiteSpace(sanitized))
+        {
+            sanitized = "unknown-save-file";
+        }
+
+        var scope = SentrySdk.PushScope();
+        SentrySdk.ConfigureScope(s => s.AddAttachment(data, sanitized));
+        return scope;
     }
 
     public async Task SubmitBugReportAsync(string description, string? email = null, string? name = null, bool attachSaveFile = false)


### PR DESCRIPTION
When a save file fails to load or an exception occurs, attach the raw save file bytes to the current Sentry scope for improved diagnostics. MainLayout now reads the uploaded file into a byte[] (initialized with Array.Empty<byte>()), and calls IBugReportService.AttachRawFileToScope in both invalid-format and exception paths. The IBugReportService interface was extended with AttachRawFileToScope, and BugReportService implements it by adding the bytes as a Sentry attachment via SentrySdk.ConfigureScope. This change helps include the problematic save file with error events to aid debugging.