### PR TITLE
Add report_type tag to Sentry scope

### DIFF
--- a/Pkmds.Web/Services/BugReportService.cs
+++ b/Pkmds.Web/Services/BugReportService.cs
@@ -35,6 +35,7 @@ public class BugReportService(IAppState appState) : IBugReportService
 
         SentrySdk.ConfigureScope(scope =>
         {
+            scope.SetTag("report_type", "user_bug_report");
             scope.SetTag("app_version", appState.AppVersion ?? "unknown");
             scope.SetTag("pkhex_version", IAppState.PkhexVersion ?? "unknown");
             scope.SetTag("hax_enabled", appState.IsHaXEnabled.ToString());


### PR DESCRIPTION
Set a "report_type" tag with value "user_bug_report" in BugReportService's Sentry scope to mark events as user-submitted bug reports, enabling easier filtering and analysis alongside existing app_version, pkhex_version, and hax_enabled tags.