### PR TITLE
Fix UAT environment cleanup

### DIFF
--- a/.github/workflows/uat-close.yml
+++ b/.github/workflows/uat-close.yml
@@ -26,7 +26,7 @@ jobs:
       contents: read
     steps:
       - name: Azure Login
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.UAT_CLEANUP_CLIENT_ID }}
           tenant-id: ${{ secrets.UAT_CLEANUP_TENANT_ID }}
@@ -51,7 +51,7 @@ jobs:
       contents: read
     steps:
       - name: Azure Login
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.UAT_CLEANUP_CLIENT_ID }}
           tenant-id: ${{ secrets.UAT_CLEANUP_TENANT_ID }}


### PR DESCRIPTION
## Summary

- Rewrites `uat-close.yml` to use `az staticwebapp environment delete` for actual Azure environment deletion — the previous `action: close` approach only marked GitHub deployments inactive and left Azure environments alive, causing the staging-environment limit to be hit
- Creates a dedicated `pkmds-blazor-uat-cleanup` service principal with OIDC federated credentials scoped to `pull_request`, `refs/heads/main`, and `refs/heads/dev` events — the old `AZUREAPPSERVICE_CLIENTID_*` credentials lacked federated identity for these contexts and failed with `AADSTS700016`
- Adds `--repo` flag to `gh pr list` in the sweep job (no checkout step means no git context)
- Bumps `azure/login` v2 → v3 (Node.js 24; resolves deprecation warning)

## Test plan

- [x] Manual `workflow_dispatch` sweep ran successfully and deleted stale environment `528`
- [x] Azure Login step passes with new `UAT_CLEANUP_*` secrets
- [x] `az staticwebapp environment list` confirms only `default` remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)