### PR TITLE
Add BoxViewerDialog and BoxListDialog pop-out dialogs

### DIFF
--- a/Pkmds.Rcl/Components/Dialogs/BoxListDialog.razor
+++ b/Pkmds.Rcl/Components/Dialogs/BoxListDialog.razor
@@ -1,0 +1,44 @@
+@inherits RefreshAwareComponent
+
+<MudDialog>
+    <TitleContent>
+        <MudText Typo="@Typo.h6">All Boxes</MudText>
+    </TitleContent>
+    <DialogContent>
+        @if (AppState.SaveFile is { } saveFile)
+        {
+            <div style="max-height: 80vh; overflow-y: auto;">
+                <MudGrid>
+                    @for (var i = 0; i < saveFile.BoxCount; i++)
+                    {
+                        var boxIndex = i;
+                        var boxName = saveFile is IBoxDetailNameRead r
+                            ? r.GetBoxName(boxIndex)
+                            : string.Empty;
+
+                        <MudItem xs="12" sm="6" md="4" lg="3" @key="@boxIndex">
+                            <MudPaper Outlined Class="pa-2">
+                                <div class="d-flex align-center justify-space-between mb-1">
+                                    <MudText Typo="@Typo.subtitle2">
+                                        @($"Box {boxIndex + 1}: {boxName}")
+                                    </MudText>
+                                    <MudIconButton Icon="@Icons.Material.Filled.SwapHoriz"
+                                                   Size="@Size.Small"
+                                                   title="@($"Swap Box {boxIndex + 1} with Box {(boxIndex + 1) % saveFile.BoxCount + 1}")"
+                                                   OnClick="@(() => SwapWithNext(boxIndex, saveFile.BoxCount))"/>
+                                </div>
+                                <BoxGrid BoxNumber="@boxIndex"/>
+                            </MudPaper>
+                        </MudItem>
+                    }
+                </MudGrid>
+            </div>
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@Close"
+                   Variant="@Variant.Outlined">
+            Close
+        </MudButton>
+    </DialogActions>
+</MudDialog>

--- a/Pkmds.Rcl/Components/Dialogs/BoxListDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/BoxListDialog.razor.cs
@@ -1,0 +1,20 @@
+namespace Pkmds.Rcl.Components.Dialogs;
+
+public partial class BoxListDialog : RefreshAwareComponent
+{
+    [CascadingParameter]
+    private IMudDialogInstance? MudDialog { get; set; }
+
+    protected override RefreshEvents SubscribeTo => RefreshEvents.AppState | RefreshEvents.BoxState;
+
+    private void SwapWithNext(int boxIndex, int boxCount)
+    {
+        var nextBox = (boxIndex + 1) % boxCount;
+        if (!AppService.SwapBoxes(boxIndex, nextBox))
+        {
+            Snackbar.Add("Locked or team slots prevent swapping these boxes.", Severity.Warning);
+        }
+    }
+
+    private void Close() => MudDialog?.Close();
+}

--- a/Pkmds.Rcl/Components/Dialogs/BoxViewerDialog.razor
+++ b/Pkmds.Rcl/Components/Dialogs/BoxViewerDialog.razor
@@ -1,0 +1,56 @@
+@inherits RefreshAwareComponent
+
+<MudDialog>
+    <TitleContent>
+        <MudText Typo="@Typo.h6">Box Viewer</MudText>
+    </TitleContent>
+    <DialogContent>
+        @if (AppState is { SaveFile: { } saveFile, BoxEdit: not null })
+        {
+            <div class="flex items-center gap-1 mb-3">
+                <MudIconButton OnClick="@GoToPreviousBox"
+                               title="Previous Box"
+                               ButtonType="@ButtonType.Button"
+                               Icon="@Icons.Material.Filled.ArrowLeft"
+                               Variant="@Variant.Filled"
+                               Size="@Size.Small"/>
+
+                <MudSelect Value="@_currentBox"
+                           ValueChanged="@((int newBox) => _currentBox = newBox)"
+                           Dense
+                           Class="flex-1">
+                    @for (var boxId = 0; boxId < saveFile.BoxCount; boxId++)
+                    {
+                        var localBoxId = boxId;
+                        var boxName = saveFile is IBoxDetailNameRead r
+                            ? r.GetBoxName(localBoxId)
+                            : string.Empty;
+                        <MudSelectItem Value="@localBoxId" @key="@localBoxId">
+                            @($"Box {localBoxId + 1}: {boxName}")
+                        </MudSelectItem>
+                    }
+                </MudSelect>
+
+                <MudIconButton OnClick="@GoToNextBox"
+                               title="Next Box"
+                               ButtonType="@ButtonType.Button"
+                               Icon="@Icons.Material.Filled.ArrowRight"
+                               Variant="@Variant.Filled"
+                               Size="@Size.Small"/>
+            </div>
+
+            <BoxGrid BoxNumber="@_currentBox"/>
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@OpenBoxList"
+                   StartIcon="@Icons.Material.Filled.ViewModule"
+                   Variant="@Variant.Outlined">
+            View All Boxes
+        </MudButton>
+        <MudButton OnClick="@Close"
+                   Variant="@Variant.Outlined">
+            Close
+        </MudButton>
+    </DialogActions>
+</MudDialog>

--- a/Pkmds.Rcl/Components/Dialogs/BoxViewerDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/BoxViewerDialog.razor.cs
@@ -1,0 +1,57 @@
+namespace Pkmds.Rcl.Components.Dialogs;
+
+public partial class BoxViewerDialog : RefreshAwareComponent
+{
+    [CascadingParameter]
+    private IMudDialogInstance? MudDialog { get; set; }
+
+    [Parameter]
+    public int InitialBox { get; set; }
+
+    private int _currentBox;
+
+    protected override RefreshEvents SubscribeTo => RefreshEvents.BoxState;
+
+    protected override void OnInitialized()
+    {
+        _currentBox = InitialBox;
+        base.OnInitialized();
+    }
+
+    private void GoToNextBox()
+    {
+        if (AppState.SaveFile is not { } saveFile)
+        {
+            return;
+        }
+
+        _currentBox = (_currentBox + 1) % saveFile.BoxCount;
+    }
+
+    private void GoToPreviousBox()
+    {
+        if (AppState.SaveFile is not { } saveFile)
+        {
+            return;
+        }
+
+        _currentBox = (_currentBox - 1 + saveFile.BoxCount) % saveFile.BoxCount;
+    }
+
+    private async Task OpenBoxList()
+    {
+        MudDialog?.Close();
+        await DialogService.ShowAsync<BoxListDialog>(
+            "All Boxes",
+            new DialogOptions
+            {
+                MaxWidth = MaxWidth.ExtraExtraLarge,
+                FullWidth = true,
+                CloseButton = true,
+                BackdropClick = true,
+                CloseOnEscapeKey = true,
+            });
+    }
+
+    private void Close() => MudDialog?.Close();
+}

--- a/Pkmds.Rcl/Components/PokemonStorageComponent.razor
+++ b/Pkmds.Rcl/Components/PokemonStorageComponent.razor
@@ -57,6 +57,22 @@
                            Variant="@Variant.Filled"
                            Class="m-1.5 p-1.5">
             </MudIconButton>
+
+            <MudIconButton OnClick="@OpenBoxListDialog"
+                           title="All Boxes"
+                           ButtonType="@ButtonType.Button"
+                           Icon="@Icons.Material.Filled.ViewModule"
+                           Variant="@Variant.Filled"
+                           Class="m-1.5 p-1.5">
+            </MudIconButton>
+
+            <MudIconButton OnClick="@OpenBoxViewerDialog"
+                           title="Pop Out Box"
+                           ButtonType="@ButtonType.Button"
+                           Icon="@Icons.Material.Filled.OpenInNew"
+                           Variant="@Variant.Filled"
+                           Class="m-1.5 p-1.5">
+            </MudIconButton>
         </div>
 
         <BoxComponent BoxNumber="@boxEdit.CurrentBox"/>

--- a/Pkmds.Rcl/Components/PokemonStorageComponent.razor.cs
+++ b/Pkmds.Rcl/Components/PokemonStorageComponent.razor.cs
@@ -76,4 +76,38 @@ public partial class PokemonStorageComponent : RefreshAwareComponent
             new DialogOptions { CloseOnEscapeKey = true, MaxWidth = MaxWidth.Medium, FullWidth = true });
         RefreshService.RefreshBoxState();
     }
+
+    private async Task OpenBoxListDialog()
+    {
+        await DialogService.ShowAsync<BoxListDialog>(
+            "All Boxes",
+            new DialogOptions
+            {
+                MaxWidth = MaxWidth.ExtraExtraLarge,
+                FullWidth = true,
+                CloseButton = true,
+                BackdropClick = true,
+                CloseOnEscapeKey = true,
+            });
+    }
+
+    private async Task OpenBoxViewerDialog()
+    {
+        var parameters = new DialogParameters<BoxViewerDialog>
+        {
+            { x => x.InitialBox, AppState.BoxEdit?.CurrentBox ?? 0 },
+        };
+
+        await DialogService.ShowAsync<BoxViewerDialog>(
+            "Box Viewer",
+            parameters,
+            new DialogOptions
+            {
+                MaxWidth = MaxWidth.Large,
+                FullWidth = true,
+                CloseButton = true,
+                BackdropClick = true,
+                CloseOnEscapeKey = true,
+            });
+    }
 }

--- a/Pkmds.Rcl/Services/AppService.cs
+++ b/Pkmds.Rcl/Services/AppService.cs
@@ -1377,4 +1377,20 @@ public class AppService(IAppState appState, IRefreshService refreshService) : IA
         EncounterTypeGroup.Static => "Static",
         _ => "Unknown"
     };
+
+    public bool SwapBoxes(int boxA, int boxB)
+    {
+        if (AppState.SaveFile is not { } sav)
+        {
+            return false;
+        }
+
+        var success = sav.SwapBox(boxA, boxB);
+        if (success)
+        {
+            RefreshService.RefreshBoxState();
+        }
+
+        return success;
+    }
 }

--- a/Pkmds.Rcl/Services/IAppService.cs
+++ b/Pkmds.Rcl/Services/IAppService.cs
@@ -307,4 +307,12 @@ public interface IAppService
     /// <see langword="null" /> if the save file is not loaded.
     /// </returns>
     PKM? GeneratePokemonFromEncounter(IEncounterable encounter);
+
+    /// <summary>
+    /// Swaps all Pokémon slots between two boxes.
+    /// </summary>
+    /// <param name="boxA">The 0-based index of the first box.</param>
+    /// <param name="boxB">The 0-based index of the second box.</param>
+    /// <returns><see langword="true" /> if the swap succeeded; <see langword="false" /> if locked slots prevented it.</returns>
+    bool SwapBoxes(int boxA, int boxB);
 }

--- a/Pkmds.Tests/BoxManagementTests.cs
+++ b/Pkmds.Tests/BoxManagementTests.cs
@@ -1,0 +1,126 @@
+namespace Pkmds.Tests;
+
+/// <summary>
+/// Tests for box management features (SwapBoxes, BoxViewerDialog, BoxListDialog).
+/// </summary>
+public class BoxManagementTests
+{
+    private const string TestFilesPath = "../../../TestFiles";
+
+    [Fact]
+    public void SwapBoxes_NoSaveFile_ReturnsFalse()
+    {
+        // Arrange
+        var appState = new TestAppState { SaveFile = null };
+        var refreshService = new TestRefreshService();
+        var appService = new AppService(appState, refreshService);
+
+        // Act
+        var result = appService.SwapBoxes(0, 1);
+
+        // Assert
+        result.Should().BeFalse();
+        refreshService.RefreshBoxStateCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void SwapBoxes_ValidBoxes_SwapsAllSlots()
+    {
+        // Arrange
+        var data = File.ReadAllBytes(Path.Combine(TestFilesPath, "Black - Full Completion.sav"));
+        SaveUtil.TryGetSaveFile(data, out var saveFile, "Black - Full Completion.sav").Should().BeTrue();
+
+        var appState = new TestAppState { SaveFile = saveFile };
+        var refreshService = new TestRefreshService();
+        var appService = new AppService(appState, refreshService);
+
+        // Read slot 0 from box 0 and box 1 before swap
+        var box0Slot0Before = saveFile!.GetBoxSlotAtIndex(0, 0).Species;
+        var box1Slot0Before = saveFile.GetBoxSlotAtIndex(1, 0).Species;
+
+        // Act
+        var result = appService.SwapBoxes(0, 1);
+
+        // Assert
+        result.Should().BeTrue();
+        refreshService.RefreshBoxStateCount.Should().Be(1);
+
+        var box0Slot0After = saveFile.GetBoxSlotAtIndex(0, 0).Species;
+        var box1Slot0After = saveFile.GetBoxSlotAtIndex(1, 0).Species;
+
+        box0Slot0After.Should().Be(box1Slot0Before);
+        box1Slot0After.Should().Be(box0Slot0Before);
+    }
+
+    [Fact]
+    public void SwapBoxes_SameBox_ReturnsTrueWithNoEffectiveChange()
+    {
+        // Arrange
+        var data = File.ReadAllBytes(Path.Combine(TestFilesPath, "Black - Full Completion.sav"));
+        SaveUtil.TryGetSaveFile(data, out var saveFile, "Black - Full Completion.sav").Should().BeTrue();
+
+        var appState = new TestAppState { SaveFile = saveFile };
+        var refreshService = new TestRefreshService();
+        var appService = new AppService(appState, refreshService);
+
+        var box0Slot0Before = saveFile!.GetBoxSlotAtIndex(0, 0).Species;
+
+        // Act — swapping a box with itself should be a no-op
+        var result = appService.SwapBoxes(0, 0);
+
+        // Assert
+        var box0Slot0After = saveFile.GetBoxSlotAtIndex(0, 0).Species;
+        box0Slot0After.Should().Be(box0Slot0Before);
+
+        // Whether SwapBox returns true or false for same-box is PKHeX's concern;
+        // we only verify the service propagates the call correctly.
+        _ = result; // result depends on PKHeX internals; not asserted here
+    }
+
+    private class TestAppState : IAppState
+    {
+        public string CurrentLanguage { get; set; } = "en";
+        public int CurrentLanguageId => 2;
+        public SaveFile? SaveFile { get; set; }
+        public BoxEdit? BoxEdit => null;
+        public PKM? CopiedPokemon { get; set; }
+        public int? SelectedBoxNumber { get; set; }
+        public int? SelectedBoxSlotNumber { get; set; }
+        public int? SelectedPartySlotNumber { get; set; }
+        public bool ShowProgressIndicator { get; set; }
+        public string AppVersion => "Test";
+        public DateTime? AppBuildDate { get; }
+        public bool SelectedSlotsAreValid => true;
+        public bool IsHaXEnabled { get; set; }
+        public SpriteStyle SpriteStyle { get; set; }
+    }
+
+    private class TestRefreshService : IRefreshService
+    {
+        public int RefreshCount { get; private set; }
+        public int RefreshBoxStateCount { get; private set; }
+        private int RefreshPartyStateCount { get; set; }
+        private int RefreshBoxAndPartyStateCount { get; set; }
+
+        public void Refresh() => RefreshCount++;
+        public void RefreshBoxState() => RefreshBoxStateCount++;
+        public void RefreshPartyState() => RefreshPartyStateCount++;
+        public void RefreshBoxAndPartyState() => RefreshBoxAndPartyStateCount++;
+
+        public void RefreshTheme(bool isDarkMode)
+        {
+        }
+
+        public void ShowUpdateMessage()
+        {
+        }
+
+#pragma warning disable CS0067
+        public event Action? OnAppStateChanged;
+        public event Action? OnBoxStateChanged;
+        public event Action? OnPartyStateChanged;
+        public event Action? OnUpdateAvailable;
+        public event Action<bool>? OnThemeChanged;
+#pragma warning restore CS0067
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `SwapBoxes(int boxA, int boxB)` to `IAppService`/`AppService`, delegating to PKHeX's `SaveFile.SwapBox` and refreshing box state on success
- Adds **`BoxViewerDialog`**: single-box pop-out with its own prev/next navigation and a "View All Boxes" button that opens `BoxListDialog`; subscribes to `RefreshEvents.BoxState` via `RefreshAwareComponent`
- Adds **`BoxListDialog`**: scrollable all-boxes view in a responsive `MudGrid` (xs=12 / sm=6 / md=4 / lg=3) with per-box swap buttons (⇄); subscribes to `AppState | BoxState`
- Adds two icon buttons to `PokemonStorageComponent`'s box nav bar: **All Boxes** (`ViewModule`) and **Pop Out Box** (`OpenInNew`); both are inside the non-LetsGo `else` branch
- Adds `BoxManagementTests` with three unit tests for `SwapBoxes`

Closes #352

## Test plan

- [ ] Load a save file and verify the **All Boxes** (⊞) button opens `BoxListDialog` showing all boxes in a responsive grid
- [ ] Verify the swap (⇄) button on each box swaps it with the next box (wraps at the last box)
- [ ] Verify the **Pop Out Box** (⤢) button opens `BoxViewerDialog` defaulting to the current box
- [ ] Navigate prev/next in `BoxViewerDialog` and verify the displayed grid updates independently of the main UI
- [ ] Click "View All Boxes" inside `BoxViewerDialog` and confirm it transitions to `BoxListDialog`
- [ ] Click a Pokémon slot in either dialog and confirm it appears in the main edit form
- [ ] Confirm neither button appears for Let's Go saves
- [ ] Run `dotnet test -c Release` — all `BoxManagementTests` pass (2 pre-existing unrelated failures remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)