### PR TITLE
Require name and email on bug report dialog - in response to #543

### DIFF
--- a/Pkmds.Rcl/Components/Dialogs/BugReportDialog.razor
+++ b/Pkmds.Rcl/Components/Dialogs/BugReportDialog.razor
@@ -18,11 +18,13 @@
                           Required
                           Variant="@Variant.Outlined"/>
             <MudTextField @bind-Value="@email"
-                          Label="Email (optional, for follow-up)"
+                          Label="Email"
                           InputType="@InputType.Email"
+                          Required
                           Variant="@Variant.Outlined"/>
             <MudTextField @bind-Value="@name"
-                          Label="Name (optional)"
+                          Label="Name"
+                          Required
                           Variant="@Variant.Outlined"/>
             <MudSwitch @bind-Value="@attachSaveFile"
                        Label="Attach current save file"
@@ -46,7 +48,7 @@
         <MudButton OnClick="@Submit"
                    Color="@Color.Primary"
                    Variant="@Variant.Filled"
-                   Disabled="@(string.IsNullOrWhiteSpace(description))">
+                   Disabled="@(string.IsNullOrWhiteSpace(description) || string.IsNullOrWhiteSpace(email) || string.IsNullOrWhiteSpace(name))">
             Submit Report
         </MudButton>
     </DialogActions>

--- a/Pkmds.Rcl/Components/Dialogs/BugReportDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/BugReportDialog.razor.cs
@@ -1,12 +1,12 @@
 namespace Pkmds.Rcl.Components.Dialogs;
 
-public record BugReportData(string Description, string? Email, string? Name, bool AttachSaveFile);
+public record BugReportData(string Description, string Email, string Name, bool AttachSaveFile);
 
 public partial class BugReportDialog
 {
     private string description = string.Empty;
-    private string? email;
-    private string? name;
+    private string email = string.Empty;
+    private string name = string.Empty;
     private bool attachSaveFile;
 
     [CascadingParameter]
@@ -22,4 +22,5 @@ public partial class BugReportDialog
 
     private void Submit() =>
         MudDialog.Close(DialogResult.Ok(new BugReportData(description, email, name, attachSaveFile)));
+
 }

--- a/Pkmds.Rcl/Services/IBugReportService.cs
+++ b/Pkmds.Rcl/Services/IBugReportService.cs
@@ -2,7 +2,7 @@ namespace Pkmds.Rcl.Services;
 
 public interface IBugReportService
 {
-    Task SubmitBugReportAsync(string description, string? email = null, string? name = null, bool attachSaveFile = false);
+    Task SubmitBugReportAsync(string description, string email, string name, bool attachSaveFile = false);
 
     /// <summary>
     /// Pushes a new Sentry scope with the raw file bytes attached. The attachment is

--- a/Pkmds.Web/Services/BugReportService.cs
+++ b/Pkmds.Web/Services/BugReportService.cs
@@ -29,7 +29,7 @@ public class BugReportService(IAppState appState) : IBugReportService
         return scope;
     }
 
-    public async Task SubmitBugReportAsync(string description, string? email = null, string? name = null, bool attachSaveFile = false)
+    public async Task SubmitBugReportAsync(string description, string email, string name, bool attachSaveFile = false)
     {
         using var _ = SentrySdk.PushScope();
 


### PR DESCRIPTION
Make reporter name and email required across the bug report flow. UI: mark Email and Name fields Required and disable Submit unless description, email, and name are non-empty. Data/API: change BugReportData fields and dialog backing fields to non-nullable strings (initialized to empty), and update IBugReportService and BugReportService signatures to accept non-nullable email and name. Note: this is a breaking API change for any IBugReportService implementations which must be updated.

This is in direct response to #543. For some reason I didn't consider people would be abusive.