### PR TITLE
Display origin mark sprite in Met tab

### DIFF
--- a/Pkmds.Rcl/Components/EditForms/Tabs/MetTab.razor
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/MetTab.razor
@@ -32,6 +32,15 @@
                 }
             </MudSelect>
         </MudStack>
+        @if (OriginMarkSpriteFileName is { } originSrc)
+        {
+            <MudImage Src="@originSrc"
+                      Alt="Origin Mark"
+                      title="Origin Mark"
+                      Width="24"
+                      ObjectFit="@ObjectFit.Contain"
+                      ObjectPosition="@ObjectPosition.Center"/>
+        }
         <LegalityIndicator
             Severity="@(GetCheckResult(CheckIdentifier.GameOrigin)?.Judgement ?? PKHeX.Core.Severity.Valid)"
             Message="@HumanizeCheckResult(GetCheckResult(CheckIdentifier.GameOrigin))"/>

--- a/Pkmds.Rcl/Components/EditForms/Tabs/MetTab.razor.cs
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/MetTab.razor.cs
@@ -54,6 +54,10 @@ public partial class MetTab : IDisposable
         }
     }
 
+    private string? OriginMarkSpriteFileName => Pokemon is { Format: >= 6 }
+        ? ImageHelper.GetOriginMarkSpriteFileName(OriginMarkUtil.GetOriginMark(Pokemon))
+        : null;
+
     private bool ShowGroundTile => Pokemon is IGroundTile && Pokemon.Gen4 && Pokemon.Format < 7;
 
     public void Dispose() =>


### PR DESCRIPTION
Add a computed OriginMarkSpriteFileName property and render a MudImage for the origin mark in MetTab when available. The property returns an image filename for Pokemon with Format >= 6 via OriginMarkUtil/ImageHelper, and the Razor markup conditionally shows the 24px origin mark (with alt/title and object-fit/position) next to the existing legality indicator.