### PR TITLE
Make Held Item autocomplete clearable and null-safe

### DIFF
--- a/Pkmds.Rcl/Components/EditForms/Tabs/MainTab.razor
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/MainTab.razor
@@ -352,10 +352,11 @@
             <MudAutocomplete T="@ComboItem"
                              Label="Held Item"
                              Variant="@Variant.Outlined"
+                             Clearable
                              @bind-Value:get="@(AppService.GetItemComboItem(Pokemon.HeldItem))"
                              @bind-Value:set="@(item =>
                                               {
-                                                  Pokemon.HeldItem = item.Value;
+                                                  Pokemon.HeldItem = item?.Value ?? 0;
                                                   AppService.LoadPokemonStats(Pokemon);
                                                   RefreshService.Refresh();
                                               })"


### PR DESCRIPTION
Add Clearable to the Held Item MudAutocomplete and guard the setter against null selections by using item?.Value ?? 0. This prevents null reference errors when the user clears the selection and ensures Pokemon.HeldItem is set to 0 in that case; existing stat reload and UI refresh behavior is preserved.