### PR TITLE
Fix trainer gender change: player appearance and Pokémon OT legality

### DIFF
--- a/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor.cs
@@ -137,16 +137,20 @@ public partial class TrainerInfoTab : IDisposable
         // Several games store gender-specific fashion/appearance data.
         // Changing gender without resetting it causes the player model to become
         // invisible in-game because clothing items don't exist for the new gender's model.
+        // Skin color slots are gender-paired (even = male, odd = female).
+        // Aligning the skin color's LSB to the new gender is required to avoid
+        // a corrupted appearance (invisible player model) in games that tie
+        // skin/appearance data to gender.
         switch (saveFile)
         {
             case SAV7 sav7:
-                // SM/USUM: fashion data is gender-specific; incompatible clothing causes an invisible player model.
-                sav7.Fashion.Reset();
+                // SM/USUM: DressUpSkinColor must match the gender's parity or the
+                // player model becomes invisible. Mirrors PKHeX WinForms UpdateSkinColor.
+                sav7.MyStatus.DressUpSkinColor = (sav7.MyStatus.DressUpSkinColor & ~1) | genderByte;
                 break;
             case SAV8SWSH sav8:
-                // SWSH: GenderAppearance is a separate byte from Gender, and all appearance data
-                // (skin, hair, clothing, etc.) is gender-specific. Skin color slots are paired:
-                // even = male, odd = female — keep the same "shade" but flip to the new gender.
+                // SWSH: GenderAppearance is a separate byte from Gender, and a full
+                // appearance reset is needed to keep skin/clothing compatible.
                 var currentSkin = PlayerSkinColor8Extensions.GetSkinColorFromSkin(sav8.MyStatus.Skin);
                 var skinIndex = ((int)currentSkin & ~1) | genderByte;
                 sav8.MyStatus.GenderAppearance = genderByte;


### PR DESCRIPTION
## Summary

- **SM/USUM**: changing trainer gender now aligns `DressUpSkinColor` parity to the new gender (even = male, odd = female), preventing the invisible player model bug caused by a skin/gender mismatch
- **SWSH**: changing trainer gender now sets `GenderAppearance` and calls `MyStatus8.ResetAppearance()` with a gender-aligned skin color
- Investigated Gen 6, Gen 7b, Gen 8 PLA/BDSP, and Gen 9 SV — none require additional handling on gender change per PKHeX WinForms reference
- When trainer gender changes, `OT_Gender` is now synced on all party and box Pokémon whose OT name + ID32 + old gender match the trainer, preventing false *"Invalid Current handler value"* legality errors

Closes #565
Closes #573

## Test plan

- [ ] Load the USUM save files from the issue, toggle gender, save, and verify the player model is visible in-game
- [ ] Load a SWSH save, toggle gender, save, and verify appearance loads correctly in-game
- [ ] After toggling gender on any Gen 4+ save, verify Pokémon caught by this trainer no longer show *"Invalid Current handler value"* in the Legality tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)