### PR TITLE
Fix box grid spacing and layout for Gen I/II and Let's Go

### DIFF
--- a/Pkmds.Rcl/Components/BoxGrid.razor.cs
+++ b/Pkmds.Rcl/Components/BoxGrid.razor.cs
@@ -8,7 +8,7 @@ public partial class BoxGrid : RefreshAwareComponent
 
     private string BoxGridClass =>
         AppState.SaveFile?.BoxSlotCount == 20
-            ? "w-80 h-[400px] grid grid-cols-4 grid-rows-5"
+            ? "w-80 h-[400px] grid grid-cols-4 grid-rows-5 gap-1"
             : "grid grid-cols-6 gap-1 w-full aspect-[6/5] mx-auto";
 
     private void SetSelectedPokemon(PKM? pokemon, int boxNumber, int slotNumber) =>

--- a/Pkmds.Rcl/Components/LetsGoBoxGrid.razor
+++ b/Pkmds.Rcl/Components/LetsGoBoxGrid.razor
@@ -6,7 +6,7 @@
         Note: The box grid is scrollable.
     </MudText>
     <div
-        class="overflow-x-hidden overflow-y-auto w-[420px] h-[398px] xl:h-[calc(100vh-319px)] xl:h-[calc(100dvh-319px)] grid grid-cols-5 grid-rows-[repeat(200,80px)]">
+        class="overflow-x-hidden overflow-y-auto w-[504px] h-[398px] xl:h-[calc(100vh-319px)] xl:h-[calc(100dvh-319px)] grid grid-cols-6 grid-rows-[repeat(167,80px)] gap-1">
         @{
             var count = 0;
         }

--- a/Pkmds.Rcl/Components/PokemonSlotComponent.razor.cs
+++ b/Pkmds.Rcl/Components/PokemonSlotComponent.razor.cs
@@ -214,6 +214,12 @@ public partial class PokemonSlotComponent : IDisposable
             return false;
         }
 
+        // Drag and drop is not supported for Let's Go games
+        if (AppState.SaveFile is SAV7b)
+        {
+            return false;
+        }
+
         // Don't allow dragging the last battle-ready Pokémon in the party
         // ReSharper disable once ConvertIfStatementToReturnStatement
         if (IsPartySlot && IsLastBattleReadyPokemon())
@@ -314,19 +320,12 @@ public partial class PokemonSlotComponent : IDisposable
                 return;
             }
 
-            // For Let's Go games, disable all party dragging (party-to-party, party-to-box, box-to-party)
-            // This is because SetPartySlotAtIndex moves actual box data instead of just reordering party pointers
+            // Drag and drop is not supported for Let's Go games
             if (AppState.SaveFile is SAV7b)
             {
-                var isAnyPartyDrag = DragDropService.IsDragSourceParty || IsPartySlot;
-
-                if (isAnyPartyDrag)
-                {
-                    // Silently prevent all party dragging for Let's Go games
-                    DragDropService.ClearDrag();
-                    StateHasChanged();
-                    return;
-                }
+                DragDropService.ClearDrag();
+                StateHasChanged();
+                return;
             }
 
             // Move the Pokémon


### PR DESCRIPTION
## Summary

- Add `gap-1` to Gen I/II (4-col) box grid to match spacing of other games
- Fix Let's Go box grid: switch from 5 to 6 columns (matching the in-game layout), correct row count to 167, add `gap-1`, and widen container to 504px
- Disable drag and drop entirely for Let's Go saves (previously only party drags were blocked)

## Test plan

- [ ] Load a Gen I or Gen II save and verify box slots have consistent spacing
- [ ] Load a Let's Go Pikachu/Eevee save and verify 6-column layout with gap
- [ ] Verify dragging a Pokémon in a Let's Go save is not possible (box-to-box and party)

🤖 Generated with [Claude Code](https://claude.com/claude-code)