### PR TITLE
Fix blank Trainer tab for Emerald saves

### DIFF
--- a/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor
@@ -261,7 +261,7 @@
             </div>
         }
 
-        if (saveFile is SAV3E sav3)
+        @if (saveFile is SAV3E sav3)
         {
             <div class="form-field">
                 <MudNumericField Label="BP"


### PR DESCRIPTION
## Summary

- `TrainerInfoTab.razor` had a bare `if (saveFile is SAV3E sav3)` instead of `@if` on line 264
- In Razor markup mode, the `{` after an unescaped `if` is parsed as a Razor code block delimiter rather than the C# block body, crashing the component and producing a blank gray screen
- Only affected Emerald (SAV3E) saves since that's the only code path hitting this block

Closes #582 (duplicate: #583)

## Test plan

- [ ] Load a Pokémon Emerald save file
- [ ] Click the Trainer tab — should display trainer info fields, not a blank screen
- [ ] Verify other save types (Gen 1–4, non-Emerald) still render the Trainer tab correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)