### PR TITLE
Fix crash when clearing a move in Legends: ZA saves

### DIFF
--- a/Pkmds.Rcl/Components/EditForms/Tabs/MovesTab.razor.cs
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/MovesTab.razor.cs
@@ -134,12 +134,19 @@ public partial class MovesTab
     private void SetPokemonPPUps(int moveIndex, int ppUps) =>
         Pokemon?.SetPPUps(moveIndex, ppUps);
 
-    private bool GetPokemonMoveIsPlus(int moveIndex) =>
-        Pokemon is PA9 pa9 && pa9.GetMovePlusFlag(moveIndex);
+    private bool GetPokemonMoveIsPlus(int moveIndex)
+    {
+        if (moveIndex < 0 || Pokemon is not PA9 pa9)
+        {
+            return false;
+        }
+
+        return pa9.GetMovePlusFlag(moveIndex);
+    }
 
     private void SetPokemonMoveIsPlus(int moveIndex, bool isPlus)
     {
-        if (Pokemon is not PA9 pa9)
+        if (moveIndex < 0 || Pokemon is not PA9 pa9)
         {
             return;
         }


### PR DESCRIPTION
## Summary
- `GetPokemonMoveIsPlus` and `SetPokemonMoveIsPlus` lacked a `moveIndex < 0` guard
- When clicking X to clear a move in a ZA save, `PersonalInfo9ZA.PlusMoves.IndexOf(0)` returns `-1`, which was passed directly to `pa9.GetMovePlusFlag(-1)` causing a crash
- Added the same `moveIndex < 0` early-return guard already present in `GetPokemonMoveIsMastered`

Closes #576

## Test plan
- [ ] Load a Legends: ZA save file
- [ ] Open a Pokémon for editing and go to the Moves tab
- [ ] With text search enabled, click the X button on a move to clear it — should no longer crash
- [ ] Verify the move clears to empty and PP/PP Ups reset to 0
- [ ] Confirm the Plus Move checkbox renders correctly (unchecked) after clearing

🤖 Generated with [Claude Code](https://claude.com/claude-code)