### PR TITLE
Fix blank Trainer tab for Japanese Pokémon Emerald saves

### DIFF
--- a/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor
@@ -40,7 +40,7 @@
                     <MudNumericField Label="ID"
                                      Variant="@Variant.Outlined"
                                      @bind-Value:get="@saveFile.TID16"
-                                     @bind-Value:set="@(async (uint value) => await OnTID16ChangedAsync(saveFile, (ushort)value))"
+                                     @bind-Value:set="@(async (ushort value) => await OnTID16ChangedAsync(saveFile, value))"
                                      Format="@AppService.GetIdFormatString()"
                                      For="@(() => saveFile.TID16)"/>
                 </div>
@@ -51,7 +51,7 @@
                         <MudNumericField Label="SID"
                                          Variant="@Variant.Outlined"
                                          @bind-Value:get="@saveFile.SID16"
-                                         @bind-Value:set="@(async (uint value) => await OnSID16ChangedAsync(saveFile, (ushort)value))"
+                                         @bind-Value:set="@(async (ushort value) => await OnSID16ChangedAsync(saveFile, value))"
                                          Format="@AppService.GetIdFormatString(true)"
                                          For="@(() => saveFile.SID16)"/>
                     </div>


### PR DESCRIPTION
## Summary

- Fixes `System.InvalidCastException` in `MudFormComponent<UInt32, String>.OnParametersSet()` that blanked the Trainer tab when a Japanese Pokémon Emerald save was loaded
- Root cause: setter lambdas on the TID/SID `MudNumericField` components used `uint` while the getter and `For` expression used `ushort`, causing MudBlazor to infer `T = uint` and then fail at runtime when reconciling the `Expression<Func<ushort>>` `For` expression
- Fix: changed both setter lambdas from `(uint value)` to `(ushort value)` for type consistency

Closes #586
Related: #582, #584

## Test plan

- [ ] Load a Japanese Pokémon Emerald save file and click the Trainer tab — should display normally without a blank screen or console errors
- [ ] Load a non-Japanese Pokémon Emerald save file and verify Trainer tab still works
- [ ] Verify TID/SID fields on Gen 1–6 saves (SixteenBit format) can still be edited and changes sync to matching Pokémon

🤖 Generated with [Claude Code](https://claude.com/claude-code)