### PR TITLE
Add id-token: write permission to Claude workflow jobs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,6 +21,7 @@ jobs:
         || github.event.comment.author_association == 'COLLABORATOR')
     permissions:
       contents: read
+      id-token: write
       issues: write
       pull-requests: write
     runs-on: ubuntu-latest
@@ -33,6 +34,7 @@ jobs:
     if: github.event_name == 'issues' && github.event.action == 'opened'
     permissions:
       contents: read
+      id-token: write
       issues: write
     runs-on: ubuntu-latest
     steps:
@@ -72,8 +74,9 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
-      discussions: write
       contents: read
+      discussions: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

- Adds `id-token: write` permission to all three jobs in the Claude workflow (`claude`, `triage`, `changelog`)
- This permission is required by `anthropics/claude-code-action@v1` to fetch an OIDC token for authentication

## Test plan

- [ ] Trigger the `claude` job by commenting `@claude` on an issue or PR
- [ ] Verify the `triage` job runs successfully on a new issue
- [ ] Verify the `changelog` job runs via workflow dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)