### PR TITLE
Limit Claude code action to Bash

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -85,6 +85,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1.0.82
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_tools: "Bash"
           prompt: |
             You are generating a weekly changelog for PKMDS, a Pokémon save file editor at https://github.com/codemonkey85/PKMDS-Blazor.
 


### PR DESCRIPTION
Add allowed_tools: "Bash" to .github/workflows/claude.yml for the anthropics/claude-code-action step. This restricts the action's allowed tools to Bash when generating the weekly changelog for PKMDS, reducing the tool surface and improving consistency/security.