### PR TITLE
Add GH_TOKEN env to Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -131,3 +131,4 @@ jobs:
             Post the discussion URL as a final output message.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Expose GH_TOKEN in .github/workflows/claude.yml by mapping it to secrets.GITHUB_TOKEN. This provides compatibility for actions or tools that expect GH_TOKEN in addition to GITHUB_TOKEN, without changing existing token usage.