### PR TITLE
Remove show_full_output from Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -85,7 +85,6 @@ jobs:
       - uses: anthropics/claude-code-action@v1.0.82
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          show_full_output: true
           settings: |
             {
               "permissions": {


### PR DESCRIPTION
Remove the show_full_output: true input from the anthropics/claude-code-action step in .github/workflows/claude.yml. This reduces workflow log verbosity by preventing the action from emitting full output during runs.