### PR TITLE
chore: update NuGet packages and fix Azure.Storage.Blobs 12.27.0 breaking change

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,29 +1,29 @@
 <Project>
-    <PropertyGroup>
-        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    </PropertyGroup>
-    <ItemGroup>
-        <PackageVersion Include="Azure.Storage.Blobs" Version="12.24.0"/>
-        <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.51.0"/>
-        <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0"/>
-        <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7"/>
-        <PackageVersion Include="Octokit" Version="14.0.0"/>
-    </ItemGroup>
-    <ItemGroup>
-        <PackageVersion Include="bUnit" Version="2.6.2"/>
-        <PackageVersion Include="coverlet.collector" Version="8.0.1"/>
-        <PackageVersion Include="FluentAssertions" Version="8.9.0"/>
-        <PackageVersion Include="Humanizer" Version="3.0.10"/>
-        <PackageVersion Include="KristofferStrube.Blazor.FileSystemAccess" Version="3.3.0"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.5"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.5"/>
-        <PackageVersion Include="Microsoft.JSInterop" Version="10.0.3"/>
-        <PackageVersion Include="Microsoft.JSInterop.WebAssembly" Version="10.0.3"/>
-        <PackageVersion Include="MudBlazor" Version="9.2.0"/>
-        <PackageVersion Include="PKHeX.Core" Version="26.3.20"/>
-        <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0"/>
-        <PackageVersion Include="Serilog.Sinks.BrowserConsole" Version="8.0.0"/>
-        <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5"/>
-        <PackageVersion Include="xunit.v3" Version="3.2.2"/>
-    </ItemGroup>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Azure.Storage.Blobs" Version="12.27.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
+    <PackageVersion Include="Octokit" Version="14.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageVersion Include="bUnit" Version="2.7.2" />
+    <PackageVersion Include="coverlet.collector" Version="8.0.1" />
+    <PackageVersion Include="FluentAssertions" Version="8.9.0" />
+    <PackageVersion Include="Humanizer" Version="3.0.10" />
+    <PackageVersion Include="KristofferStrube.Blazor.FileSystemAccess" Version="3.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.JSInterop" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.JSInterop.WebAssembly" Version="10.0.3" />
+    <PackageVersion Include="MudBlazor" Version="9.2.0" />
+    <PackageVersion Include="PKHeX.Core" Version="26.3.20" />
+    <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />
+    <PackageVersion Include="Serilog.Sinks.BrowserConsole" Version="8.0.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+  </ItemGroup>
 </Project>

--- a/Pkmds.Functions/GlobalUsings.cs
+++ b/Pkmds.Functions/GlobalUsings.cs
@@ -2,6 +2,7 @@
 global using System.Text;
 global using System.Text.Json;
 global using Azure.Storage.Blobs;
+global using Azure.Storage.Blobs.Models;
 global using Azure.Storage.Sas;
 global using Microsoft.AspNetCore.Http;
 global using Microsoft.AspNetCore.Mvc;

--- a/Pkmds.Functions/Services/BlobService.cs
+++ b/Pkmds.Functions/Services/BlobService.cs
@@ -12,7 +12,7 @@ public class BlobService(IConfiguration configuration, ILogger<BlobService> logg
     {
         var blobName = $"{issueNumber}/{fileName}";
         var blobClient = containerClient.GetBlobClient(blobName);
-        await blobClient.UploadAsync(data, overwrite: true, cancellationToken: cancellationToken);
+        await blobClient.UploadAsync(data, true, cancellationToken);
         logger.LogInformation("Uploaded blob {BlobName} for issue #{IssueNumber}", blobName, issueNumber);
     }
 
@@ -25,7 +25,13 @@ public class BlobService(IConfiguration configuration, ILogger<BlobService> logg
             return null;
         }
 
-        var sasBuilder = new BlobSasBuilder { BlobContainerName = containerClient.Name, BlobName = blobName, Resource = "b", ExpiresOn = DateTimeOffset.UtcNow.Add(expiry) };
+        var sasBuilder = new BlobSasBuilder
+        {
+            BlobContainerName = containerClient.Name,
+            BlobName = blobName,
+            Resource = "b",
+            ExpiresOn = DateTimeOffset.UtcNow.Add(expiry)
+        };
         sasBuilder.SetPermissions(BlobSasPermissions.Read);
         // Use AbsoluteUri (percent-encoded) — ToString() leaves spaces unencoded, breaking Markdown links
         return blobClient.GenerateSasUri(sasBuilder).AbsoluteUri;
@@ -38,7 +44,8 @@ public class BlobService(IConfiguration configuration, ILogger<BlobService> logg
         var prefix = $"{issueNumber}/";
         var deleted = 0;
 
-        await foreach (var blob in containerClient.GetBlobsAsync(prefix: prefix, cancellationToken: cancellationToken))
+        await foreach (var blob in containerClient.GetBlobsAsync(BlobTraits.None, BlobStates.None, prefix,
+                           cancellationToken))
         {
             var blobClient = containerClient.GetBlobClient(blob.Name);
             await blobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken);
@@ -51,7 +58,8 @@ public class BlobService(IConfiguration configuration, ILogger<BlobService> logg
     private static BlobContainerClient CreateContainerClient(IConfiguration configuration)
     {
         var connectionString = configuration["AzureStorageConnectionString"]
-                               ?? throw new InvalidOperationException("AzureStorageConnectionString configuration is required.");
+                               ?? throw new InvalidOperationException(
+                                   "AzureStorageConnectionString configuration is required.");
         var containerName = configuration["BlobContainerName"] ?? "bug-reports";
         var containerClient = new BlobServiceClient(connectionString).GetBlobContainerClient(containerName);
         containerClient.CreateIfNotExists();


### PR DESCRIPTION
## Summary

- Bumps `Azure.Storage.Blobs` from 12.24.0 → 12.27.0 and `bUnit` from 2.6.2 → 2.7.2
- Fixes build error caused by `GetBlobsAsync` no longer having default values for `traits`/`states` parameters in 12.27.0 — now passes `BlobTraits.None, BlobStates.None` explicitly
- Adds `global using Azure.Storage.Blobs.Models;` to `Pkmds.Functions/GlobalUsings.cs` so `BlobTraits`/`BlobStates` resolve

## Test plan

- [ ] CI build passes on all projects
- [ ] `Pkmds.Functions` builds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)