### PR TITLE
feat: warn users when running inside an in-app browser

### DIFF
--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
@@ -95,6 +95,20 @@ public partial class MainLayout : IDisposable
         systemIsDarkMode = await mudThemeProvider.GetSystemDarkModeAsync();
         await mudThemeProvider.WatchSystemDarkModeAsync(OnSystemPreferenceChanged);
 
+        // Warn users who are running inside a known in-app browser (e.g. Google Search App,
+        // Facebook) whose WebView typically blocks file downloads.
+        var isInAppBrowser = await JSRuntime.InvokeAsync<bool>("isInAppBrowser");
+        if (isInAppBrowser)
+        {
+            Snackbar.Add(
+                new MarkupString(
+                    "You appear to be using an in-app browser, which may not support file exports. " +
+                    "For the best experience, please open this app in <strong>Safari</strong> (iOS) or " +
+                    "<strong>Chrome</strong> (Android)."),
+                Severity.Warning,
+                options => options.RequireInteraction = true);
+        }
+
         // Load all persisted settings (theme, PKHaX, verbose logging, trainer defaults)
         await SettingsService.LoadAsync();
 

--- a/Pkmds.Rcl/wwwroot/js/fileSave.js
+++ b/Pkmds.Rcl/wwwroot/js/fileSave.js
@@ -92,6 +92,21 @@ window.readDroppedFile = async function (index) {
     });
 };
 
+// Returns true if the page is running inside a known in-app browser (e.g. Google Search App,
+// Facebook, Instagram) whose WebView may block file downloads or the File System Access API.
+window.isInAppBrowser = function () {
+    const ua = navigator.userAgent || '';
+    return (
+        /GSA\//.test(ua) ||          // Google Search App (iOS)
+        /FBAN\/|FBAV\//.test(ua) ||  // Facebook
+        /Instagram/.test(ua) ||       // Instagram
+        /Twitter\//.test(ua) ||       // Twitter / X
+        /Line\//.test(ua) ||          // Line messenger
+        /LinkedInApp/.test(ua) ||     // LinkedIn
+        /Snapchat/.test(ua)           // Snapchat
+    );
+};
+
 window.showFilePickerAndWrite = async function (fileName, byteArray, extension, description) {
     // byteArray is expected to be a JS array of numbers coming from a Blazor byte[]
     try {

--- a/Pkmds.Rcl/wwwroot/js/fileSave.js
+++ b/Pkmds.Rcl/wwwroot/js/fileSave.js
@@ -105,7 +105,7 @@ window.isInAppBrowser = function () {
         /LinkedInApp/.test(ua) ||               // LinkedIn
         /Snapchat/.test(ua) ||                  // Snapchat
         /WhatsApp/.test(ua) ||                  // WhatsApp
-        /TelegramBot/.test(ua) ||               // Telegram
+        /Telegram(Bot)?/.test(ua) ||             // Telegram
         /MicroMessenger/.test(ua) ||            // WeChat
         /Discord\//.test(ua) ||                 // Discord
         /Pinterest\//.test(ua) ||               // Pinterest

--- a/Pkmds.Rcl/wwwroot/js/fileSave.js
+++ b/Pkmds.Rcl/wwwroot/js/fileSave.js
@@ -97,13 +97,21 @@ window.readDroppedFile = async function (index) {
 window.isInAppBrowser = function () {
     const ua = navigator.userAgent || '';
     return (
-        /GSA\//.test(ua) ||          // Google Search App (iOS)
-        /FBAN\/|FBAV\//.test(ua) ||  // Facebook
-        /Instagram/.test(ua) ||       // Instagram
-        /Twitter\//.test(ua) ||       // Twitter / X
-        /Line\//.test(ua) ||          // Line messenger
-        /LinkedInApp/.test(ua) ||     // LinkedIn
-        /Snapchat/.test(ua)           // Snapchat
+        /GSA\//.test(ua) ||                    // Google Search App (iOS)
+        /FBAN\/|FBAV\//.test(ua) ||            // Facebook
+        /Instagram/.test(ua) ||                 // Instagram
+        /Twitter\//.test(ua) ||                 // Twitter / X
+        /Line\//.test(ua) ||                    // Line messenger
+        /LinkedInApp/.test(ua) ||               // LinkedIn
+        /Snapchat/.test(ua) ||                  // Snapchat
+        /WhatsApp/.test(ua) ||                  // WhatsApp
+        /TelegramBot/.test(ua) ||               // Telegram
+        /MicroMessenger/.test(ua) ||            // WeChat
+        /Discord\//.test(ua) ||                 // Discord
+        /Pinterest\//.test(ua) ||               // Pinterest
+        /BytedanceWebview|musical_ly/.test(ua) || // TikTok
+        /Reddit\//.test(ua) ||                  // Reddit
+        !!window.TelegramWebviewProxy           // Telegram (fallback — UA not always branded)
     );
 };
 


### PR DESCRIPTION
Adds `isInAppBrowser()` in fileSave.js to detect common in-app browsers (Google Search App, Facebook, Instagram, Twitter/X, Line, LinkedIn, Snapchat) via the user-agent string.

On first render MainLayout calls this and shows a persistent MudBlazor warning snackbar if detected, directing the user to open the app in Safari (iOS) or Chrome (Android) for reliable file export support.

Closes #663