### PR TITLE
fix: detect non-exportable save files at load time

### DIFF
--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
@@ -368,6 +368,7 @@ public partial class MainLayout : IDisposable
         AppService.ClearSelection();
         ParseSettings.ClearActiveTrainer();
         AppState.SaveFile = null;
+        manicEmuSaveContext = null;
         AppState.ShowProgressIndicator = true;
 
         var data = Array.Empty<byte>();
@@ -391,7 +392,6 @@ public partial class MainLayout : IDisposable
                     return;
                 }
 
-                manicEmuSaveContext = null;
                 FinishLoadingSaveFile(saveFile, selectedFile.Name);
             }
             // If that fails, check whether this is a Manic EMU .3ds.sav ZIP archive.

--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
@@ -382,6 +382,15 @@ public partial class MainLayout : IDisposable
             // Try to load the file directly as a raw save.
             if (SaveUtil.TryGetSaveFile(data, out var saveFile, selectedFile.Name))
             {
+                if (!saveFile.State.Exportable)
+                {
+                    Logger.LogWarning("Save file is not exportable (unsupported format/ROM hack): {FileName}", selectedFile.Name);
+                    await DialogService.ShowMessageBoxAsync("Unsupported save file",
+                        "This save file cannot be loaded — it may be from an unsupported ROM hack or format.");
+                    AppState.ShowProgressIndicator = false;
+                    return;
+                }
+
                 manicEmuSaveContext = null;
                 FinishLoadingSaveFile(saveFile, selectedFile.Name);
             }
@@ -389,6 +398,15 @@ public partial class MainLayout : IDisposable
             // Manic EMU packages 3DS saves as a ZIP containing sdmc/… directory paths.
             else if (ManicEmuSaveHelper.TryExtractSaveFromZip(data, selectedFile.Name, out saveFile, out var manicContext))
             {
+                if (!saveFile.State.Exportable)
+                {
+                    Logger.LogWarning("Manic EMU save file is not exportable (unsupported format/ROM hack): {FileName}", selectedFile.Name);
+                    await DialogService.ShowMessageBoxAsync("Unsupported save file",
+                        "This save file cannot be loaded — it may be from an unsupported ROM hack or format.");
+                    AppState.ShowProgressIndicator = false;
+                    return;
+                }
+
                 manicEmuSaveContext = manicContext;
                 Logger.LogInformation("Loaded save from Manic EMU .3ds.sav/.3ds.save archive; entry: {EntryPath}", manicContext.SaveEntryPath);
                 FinishLoadingSaveFile(saveFile, selectedFile.Name);


### PR DESCRIPTION
## Summary

- Check `SaveFile.State.Exportable` immediately after PKHeX parses the save in `MainLayout.LoadSaveFileAsync`. If `false` (e.g. ROM hack or unsupported format), show a clear error dialog and abort loading rather than silently letting the user edit a save that can never be exported.
- Applied to both the direct `SaveUtil.TryGetSaveFile` path and the Manic EMU `.zip` extraction path.

Refs codemonkey85/pkmds-blazor#675 (issue already closed — opening this PR per request).

## Test plan

- [ ] Load a normal, exportable save file — loads as before, no dialog shown.
- [ ] Load a ROM hack / unsupported save that PKHeX parses but marks `State.Exportable = false` — error dialog appears, progress indicator clears, and no tabs open.
- [ ] Load a Manic EMU `.zip` containing a non-exportable save — same error dialog path triggers.
- [ ] `dotnet format` + `dotnet build -c Debug` succeed (warnings-as-errors clean).

https://claude.ai/code/session_01U4KQtHm3ma4zNDNQt3ezJH