### PR TITLE
feat: add UseLocalPKHeX flag and watch script for dev build testing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,11 @@ Local dev (Blazor WASM)
   - Equivalent from `Pkmds.Web`: `dotnet watch run -c Debug -v n --no-hot-reload`
   - Launch profiles expose: http `http://localhost:5283`, https `https://localhost:7267` (see `Pkmds.Web/Properties/launchSettings.json`).
 
+Local dev with a PKHeX.Core source checkout (manual UI testing)
+- From repo root (PowerShell): `./watch-local-pkhex.ps1`
+  - Optional custom path: `./watch-local-pkhex.ps1 -PKHeXSourcePath C:\Code\PKHeX-dev\PKHeX.Core\PKHeX.Core.csproj`
+  - See **Local dev override (`UseLocalPKHeX`)** under the PKHeX.Core section for full details.
+
 Restore and build
 - Restore: `dotnet restore`
 - Build Web (Debug/Release):
@@ -71,6 +76,43 @@ Runtime wiring (Web)
 This app depends heavily on [PKHeX.Core](https://github.com/kwsch/PKHeX). When implementing features, use the PKHeX WinForms app as a reference for how to leverage PKHeX.Core — both for UI/UX patterns and for understanding the correct API usage. The first place you should look when referencing PKHeX is `~/Code/codemonkey85/PKHeX` (macOS) or `C:\Code\PKHeX` (Windows), which contains the PKHeX WinForms app source code. The `PKHeX.Core` project within that solution is the library we consume here, and the WinForms app is a separate project that references it. The PKHeX WinForms app is a great reference for how to use PKHeX.Core effectively, as it demonstrates real-world usage of the library's APIs in a production application. If you can't find the source there, the PKHeX Wiki and source code are also valuable resources for understanding how to work with PKHeX.Core.
 
 If you encounter bugs or limitations in PKHeX.Core while working on an issue or PR, note them in a code comment at the relevant site and report them on the GitHub issue or PR you are working on.
+
+### Local dev override (`UseLocalPKHeX`)
+
+`Directory.Build.targets` at the repo root supports a `UseLocalPKHeX` MSBuild flag that swaps the NuGet `PKHeX.Core` package for a `ProjectReference` to a local source checkout. Use this when you want to:
+
+- Manually test the UI against a PKHeX dev build
+- Verify whether a PKHeX bug/regression affects this app
+- Test a PKHeX fix before it is released on NuGet
+
+**Manual UI testing (watch)**
+
+```powershell
+# Default paths: C:\Code\PKHeX (Windows), ~/Code/codemonkey85/PKHeX (macOS/Linux)
+./watch-local-pkhex.ps1
+
+# Custom path (e.g. a specific branch checkout)
+./watch-local-pkhex.ps1 -PKHeXSourcePath C:\Code\PKHeX-dev\PKHeX.Core\PKHeX.Core.csproj
+```
+
+**Build / automated tests**
+
+```sh
+# Build
+dotnet build Pkmds.Web/Pkmds.Web.csproj -c Debug -p:UseLocalPKHeX=true
+
+# Test
+dotnet test -c Release -p:UseLocalPKHeX=true
+
+# Custom path
+dotnet build Pkmds.Web/Pkmds.Web.csproj -c Debug -p:UseLocalPKHeX=true -p:PKHeXSourcePath=/path/to/PKHeX.Core.csproj
+```
+
+Default `PKHeXSourcePath` values (set in `Directory.Build.targets`):
+- **Windows**: `C:\Code\PKHeX\PKHeX.Core\PKHeX.Core.csproj`
+- **macOS/Linux**: `~/Code/codemonkey85/PKHeX/PKHeX.Core/PKHeX.Core.csproj`
+
+The default build (no flag) is completely unaffected.
 
 ### PKHeX.Core API notes
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,17 @@
+<Project>
+
+    <PropertyGroup>
+        <!-- Default PKHeX source paths per OS; override with -p:PKHeXSourcePath=... -->
+        <PKHeXSourcePath Condition="'$(PKHeXSourcePath)' == '' And $([MSBuild]::IsOsPlatform('Windows'))">C:\Code\PKHeX\PKHeX.Core\PKHeX.Core.csproj</PKHeXSourcePath>
+        <PKHeXSourcePath Condition="'$(PKHeXSourcePath)' == ''">$(HOME)/Code/codemonkey85/PKHeX/PKHeX.Core/PKHeX.Core.csproj</PKHeXSourcePath>
+    </PropertyGroup>
+
+    <!-- Swap NuGet PKHeX.Core for a local project reference.
+         Usage: dotnet build ... -p:UseLocalPKHeX=true
+         Override path: -p:PKHeXSourcePath=/path/to/PKHeX.Core.csproj -->
+    <ItemGroup Condition="'$(UseLocalPKHeX)' == 'true'">
+        <PackageReference Remove="PKHeX.Core" />
+        <ProjectReference Include="$(PKHeXSourcePath)" />
+    </ItemGroup>
+
+</Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -6,10 +6,19 @@
         <PKHeXSourcePath Condition="'$(PKHeXSourcePath)' == ''">$(HOME)/Code/codemonkey85/PKHeX/PKHeX.Core/PKHeX.Core.csproj</PKHeXSourcePath>
     </PropertyGroup>
 
+    <!-- Detect whether this project directly references PKHeX.Core so we only swap
+         projects that actually consume it. Without this guard the ItemGroup below
+         runs for every project that imports Directory.Build.targets (Pkmds.Functions,
+         Pkmds.Web, etc.), unnecessarily coupling them to the local PKHeX checkout. -->
+    <PropertyGroup>
+        <_HasPKHeXCorePackageReference>false</_HasPKHeXCorePackageReference>
+        <_HasPKHeXCorePackageReference Condition="'@(PackageReference-&gt;WithMetadataValue('Identity', 'PKHeX.Core'))' != ''">true</_HasPKHeXCorePackageReference>
+    </PropertyGroup>
+
     <!-- Swap NuGet PKHeX.Core for a local project reference.
          Usage: dotnet build ... -p:UseLocalPKHeX=true
          Override path: -p:PKHeXSourcePath=/path/to/PKHeX.Core.csproj -->
-    <ItemGroup Condition="'$(UseLocalPKHeX)' == 'true'">
+    <ItemGroup Condition="'$(UseLocalPKHeX)' == 'true' And '$(_HasPKHeXCorePackageReference)' == 'true'">
         <PackageReference Remove="PKHeX.Core" />
         <ProjectReference Include="$(PKHeXSourcePath)" />
     </ItemGroup>

--- a/watch-local-pkhex.ps1
+++ b/watch-local-pkhex.ps1
@@ -1,0 +1,39 @@
+<#
+.SYNOPSIS
+    Runs the Blazor WASM dev server pointing at a local PKHeX.Core source checkout.
+
+.DESCRIPTION
+    Use this instead of watch.ps1 when you need to manually test the UI against a
+    local PKHeX dev build. Passes -p:UseLocalPKHeX=true to dotnet watch run, which
+    swaps the NuGet package for a ProjectReference (see Directory.Build.targets).
+
+.PARAMETER PKHeXSourcePath
+    Optional path to PKHeX.Core.csproj. Defaults to the OS-appropriate path
+    defined in Directory.Build.targets (C:\Code\PKHeX on Windows,
+    ~/Code/codemonkey85/PKHeX on macOS/Linux).
+
+.EXAMPLE
+    # Use default path
+    ./watch-local-pkhex.ps1
+
+.EXAMPLE
+    # Use a custom path (e.g. a different branch checkout)
+    ./watch-local-pkhex.ps1 -PKHeXSourcePath C:\Code\PKHeX-dev\PKHeX.Core\PKHeX.Core.csproj
+#>
+param(
+    [string]$PKHeXSourcePath = ""
+)
+
+$extraArgs = @("-p:UseLocalPKHeX=true")
+if ($PKHeXSourcePath -ne "") {
+    $extraArgs += "-p:PKHeXSourcePath=$PKHeXSourcePath"
+}
+
+try {
+    Push-Location .\Pkmds.Web
+    $env:DOTNET_CLI_TELEMETRY_OPTOUT = 1
+    dotnet watch run -c Debug -v n --no-hot-reload @extraArgs
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
## Summary

- `Directory.Build.targets`: swaps the `PKHeX.Core` NuGet package for a `ProjectReference` to a local checkout when `-p:UseLocalPKHeX=true` is passed. Works for both automated tests and manual UI runs via `dotnet watch`. Default path is `~/Code/codemonkey85/PKHeX/PKHeX.Core/PKHeX.Core.csproj` (macOS) or `C:\Code\PKHeX\PKHeX.Core\PKHeX.Core.csproj` (Windows); overridable with `-p:PKHeXSourcePath=...`.
- `watch-local-pkhex.ps1`: mirrors `watch.ps1` but adds `UseLocalPKHeX=true`, with an optional `-PKHeXSourcePath` parameter for custom checkout locations.
- `AGENTS.md`: documents the new flag, the watch script, and the default source paths.

Closes codemonkey85/pkmds-blazor#678.

## Test plan

- [ ] `dotnet build Pkmds.Web/Pkmds.Web.csproj -c Debug` (default) still builds against the NuGet `PKHeX.Core`.
- [ ] `dotnet build Pkmds.Web/Pkmds.Web.csproj -c Debug -p:UseLocalPKHeX=true` builds against the local PKHeX checkout at the default path.
- [ ] `dotnet build ... -p:UseLocalPKHeX=true -p:PKHeXSourcePath=<custom>` honors the override.
- [ ] `./watch-local-pkhex.ps1` launches the Blazor WASM app against the local PKHeX source.
- [ ] `dotnet test -c Release` still passes in CI (no UseLocalPKHeX flag set).

https://claude.ai/code/session_01U4KQtHm3ma4zNDNQt3ezJH