### PR TITLE
fix: unbreak dotnet restore after PKHeX.Core detection regression

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -9,16 +9,17 @@
     <!-- Detect whether this project directly references PKHeX.Core so we only swap
          projects that actually consume it. Without this guard the ItemGroup below
          runs for every project that imports Directory.Build.targets (Pkmds.Functions,
-         Pkmds.Web, etc.), unnecessarily coupling them to the local PKHeX checkout. -->
-    <PropertyGroup>
-        <_HasPKHeXCorePackageReference>false</_HasPKHeXCorePackageReference>
-        <_HasPKHeXCorePackageReference Condition="'@(PackageReference-&gt;WithMetadataValue('Identity', 'PKHeX.Core'))' != ''">true</_HasPKHeXCorePackageReference>
-    </PropertyGroup>
+         Pkmds.Web, etc.), unnecessarily coupling them to the local PKHeX checkout.
+         We use item batching on %(Identity) to avoid nested single quotes in the
+         condition (which break MSBuild's condition parser). -->
+    <ItemGroup>
+        <_PKHeXCorePackageRef Include="@(PackageReference)" Condition="'%(Identity)' == 'PKHeX.Core'" />
+    </ItemGroup>
 
     <!-- Swap NuGet PKHeX.Core for a local project reference.
          Usage: dotnet build ... -p:UseLocalPKHeX=true
          Override path: -p:PKHeXSourcePath=/path/to/PKHeX.Core.csproj -->
-    <ItemGroup Condition="'$(UseLocalPKHeX)' == 'true' And '$(_HasPKHeXCorePackageReference)' == 'true'">
+    <ItemGroup Condition="'$(UseLocalPKHeX)' == 'true' And '@(_PKHeXCorePackageRef)' != ''">
         <PackageReference Remove="PKHeX.Core" />
         <ProjectReference Include="$(PKHeXSourcePath)" />
     </ItemGroup>


### PR DESCRIPTION
## Summary

PR #680 added a `Directory.Build.targets` property to detect whether a project directly references `PKHeX.Core` before swapping in the local source reference. The detection used nested single quotes inside the outer MSBuild condition string literal:

```xml
Condition="'@(PackageReference->WithMetadataValue('Identity', 'PKHeX.Core'))' != ''"
```

MSBuild's condition parser terminates the outer `'...'` string literal at the first inner `'` (before `Identity`), so the expression fails to parse and **`dotnet restore` exits 1 on every project that imports `Directory.Build.targets`**. That's why PR codemonkey85/pkmds-blazor#681 (`dev` → `main`) broke: `Build and Test`, `Deploy Azure Functions`, and `Build and Deploy UAT` all die in the "Restore dependencies" step in ~20 seconds before any build happens.

This PR swaps the broken condition for the classic MSBuild item-batching pattern:

- Filter `@(PackageReference)` by `%(Identity)` into a helper item `_PKHeXCorePackageRef`.
- Gate the swap `ItemGroup` on `'@(_PKHeXCorePackageRef)' != ''`.

Same semantics as before (only swap projects that directly reference `PKHeX.Core` — today that's just `Pkmds.Core`), zero nested single quotes, so the condition parses cleanly.

## Test plan

- [ ] `Build and Test` step "Restore dependencies" succeeds on this branch.
- [ ] `Build and Test` full run goes green.
- [ ] `Deploy Azure Functions` step "Publish Functions" succeeds.
- [ ] After merge to `dev`, rerun PR codemonkey85/pkmds-blazor#681 checks.
- [ ] Local (spot check): `dotnet build Pkmds.Web/Pkmds.Web.csproj -c Debug` still works with no `UseLocalPKHeX` flag.
- [ ] Local (spot check): `dotnet build Pkmds.Web/Pkmds.Web.csproj -c Debug -p:UseLocalPKHeX=true` still swaps `PKHeX.Core` only in `Pkmds.Core`.

https://claude.ai/code/session_013rWcbLq2VHyWkojLY5U8Pz