### PR TITLE
fix: suppress iOS Safari selection on draggable slots (#684)

### DIFF
--- a/Pkmds.Rcl/wwwroot/css/app.css
+++ b/Pkmds.Rcl/wwwroot/css/app.css
@@ -565,6 +565,11 @@ body, html {
 
 .square-slot[draggable="true"] {
     cursor: grab !important;
+    -webkit-user-select: none;
+    user-select: none;
+    -webkit-touch-callout: none;
+    -webkit-user-drag: element;
+    touch-action: manipulation;
 }
 
 .square-slot[draggable="true"]:active {


### PR DESCRIPTION
## Summary
- Adds `-webkit-user-select`, `user-select`, `-webkit-touch-callout`, `-webkit-user-drag`, and `touch-action: manipulation` to `.square-slot[draggable="true"]` in `Pkmds.Rcl/wwwroot/css/app.css`.
- Stops iOS Safari's native text-selection rectangle and long-press image preview from interfering with the drag gesture when sorting Pokémon in a box (the behavior shown in the screenshots on #684).

## Notes
- Box-internal drag/drop already worked on iOS Safari via standard HTML5 drag events — only the Safari selection chrome was getting in the way.
- Drag-out to the iOS Files app is **not** addressed in this PR; that's intentionally deferred. The plan there is to add a Web Share API export path later (no long-press / context menu work for now).
- Desktop drag-out via the Chrome/Edge `DownloadURL` convention is unchanged.

Refs #684

## Test plan
- [ ] On iPhone Safari, sort Pokémon within a box and confirm no blue selection rectangle appears mid-drag.
- [ ] Long-press a slot on iPhone Safari and confirm the native image preview / share menu no longer pops up.
- [ ] On desktop Chrome/Edge, confirm box drag/drop and drag-out-to-Files still work.
- [ ] On desktop Safari, confirm box drag/drop still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)