### PR TITLE
fix: suppress iOS Safari selection on draggable slots (#684)

### DIFF
--- a/Pkmds.Rcl/wwwroot/css/app.css
+++ b/Pkmds.Rcl/wwwroot/css/app.css
@@ -563,16 +563,24 @@ body, html {
     background-color: rgba(76, 175, 80, 0.1);
 }
 
-.square-slot[draggable="true"] {
-    cursor: grab !important;
+/* Suppress iOS Safari's native text selection / long-press callout on Pokémon slots
+   so they don't interfere with drag-to-sort. The wrapper carries .square-slot but
+   draggable="true" lives on the inner div, so target both — and apply user-select
+   to descendants because Safari otherwise selects the inner sprite nodes. */
+.square-slot,
+.square-slot * {
     -webkit-user-select: none;
     user-select: none;
     -webkit-touch-callout: none;
+}
+
+.square-slot > div[draggable="true"] {
+    cursor: grab !important;
     -webkit-user-drag: element;
     touch-action: manipulation;
 }
 
-.square-slot[draggable="true"]:active {
+.square-slot > div[draggable="true"]:active {
     cursor: grabbing !important;
 }
 

--- a/Pkmds.Rcl/wwwroot/css/app.css
+++ b/Pkmds.Rcl/wwwroot/css/app.css
@@ -565,6 +565,11 @@ body, html {
 
 .square-slot[draggable="true"] {
     cursor: grab !important;
+    -webkit-user-select: none;
+    user-select: none;
+    -webkit-touch-callout: none;
+    -webkit-user-drag: element;
+    touch-action: manipulation;
 }
 
 .square-slot[draggable="true"]:active {


### PR DESCRIPTION
## Summary
- Adds `-webkit-user-select`, `user-select`, `-webkit-touch-callout`, `-webkit-user-drag`, and `touch-action: manipulation` to `.square-slot[draggable="true"]` in `Pkmds.Rcl/wwwroot/css/app.css`.
- Stops iOS Safari's native text-selection rectangle and long-press image preview from interfering with the drag gesture when sorting Pokémon in a box (the behavior shown in the screenshots on #684).

## Notes
- Box-internal drag/drop already worked on iOS Safari via standard HTML5 drag events — only the Safari selection chrome was getting in the way.
- Drag-out to the iOS Files app is **not** addressed in this PR; that's intentionally deferred. The plan is to add a Web Share API export path later.
- Desktop drag-out via the Chrome/Edge `DownloadURL` convention is unchanged.

Refs #684

## Test plan
- [ ] On iPhone Safari, sort Pokémon within a box and confirm no blue selection rectangle appears mid-drag.
- [ ] Long-press a slot on iPhone Safari and confirm the native image preview / share menu no longer pops up.
- [ ] On desktop Chrome/Edge, confirm box drag/drop and drag-out-to-Files still work.
- [ ] On desktop Safari, confirm box drag/drop still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)