### PR TITLE
ALM: improve Mystery Gift / event encounter support (#695)

### DIFF
--- a/Pkmds.Rcl/Components/Dialogs/AppSettingsDialog.razor
+++ b/Pkmds.Rcl/Components/Dialogs/AppSettingsDialog.razor
@@ -87,6 +87,29 @@
 
                     <MudText Typo="@Typo.subtitle1"
                              Color="@Color.Primary">
+                        Legality Indicators
+                    </MudText>
+                    <MudText Typo="@Typo.caption"
+                             Color="@Color.Secondary">
+                        Choose which overlay icons appear on box and party slots.
+                    </MudText>
+                    <MudSwitch @bind-Value="@showLegalIndicator"
+                               Color="@Color.Success"
+                               Label="Show Legal (green)"
+                               title="Show a green check on slots whose Pokémon are fully legal"/>
+                    <MudSwitch @bind-Value="@showFishyIndicator"
+                               Color="@Color.Warning"
+                               Label="Show Fishy (yellow)"
+                               title="Show a yellow warning on slots whose Pokémon pass legality but have suspicious checks"/>
+                    <MudSwitch @bind-Value="@showIllegalIndicator"
+                               Color="@Color.Error"
+                               Label="Show Illegal (red)"
+                               title="Show a red indicator on slots whose Pokémon fail legality"/>
+
+                    <MudDivider/>
+
+                    <MudText Typo="@Typo.subtitle1"
+                             Color="@Color.Primary">
                         Developer Options
                     </MudText>
                     <MudSwitch T="@bool"

--- a/Pkmds.Rcl/Components/Dialogs/AppSettingsDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/AppSettingsDialog.razor.cs
@@ -24,6 +24,9 @@ public partial class AppSettingsDialog
     private bool isHaXEnabled;
     private bool isVerboseLogging;
     private int maxBackupCount = 10;
+    private bool showFishyIndicator = true;
+    private bool showIllegalIndicator = true;
+    private bool showLegalIndicator = true;
     private SpriteStyle spriteStyle;
 
     // Working copy — only committed on Save
@@ -52,6 +55,9 @@ public partial class AppSettingsDialog
         defaultLanguageId = InitialSettings.DefaultLanguageId;
         isAutoBackupEnabled = InitialSettings.IsAutoBackupEnabled;
         maxBackupCount = InitialSettings.MaxBackupCount;
+        showLegalIndicator = InitialSettings.ShowLegalIndicator;
+        showFishyIndicator = InitialSettings.ShowFishyIndicator;
+        showIllegalIndicator = InitialSettings.ShowIllegalIndicator;
     }
 
     private async Task OnHaXEnabledChanged(bool newValue)
@@ -98,6 +104,9 @@ public partial class AppSettingsDialog
         defaultLanguageId = defaults.DefaultLanguageId;
         isAutoBackupEnabled = defaults.IsAutoBackupEnabled;
         maxBackupCount = defaults.MaxBackupCount;
+        showLegalIndicator = defaults.ShowLegalIndicator;
+        showFishyIndicator = defaults.ShowFishyIndicator;
+        showIllegalIndicator = defaults.ShowIllegalIndicator;
         StateHasChanged();
     }
 
@@ -123,7 +132,10 @@ public partial class AppSettingsDialog
             DefaultSecretId = defaultSecretId,
             DefaultLanguageId = defaultLanguageId,
             IsAutoBackupEnabled = isAutoBackupEnabled,
-            MaxBackupCount = maxBackupCount
+            MaxBackupCount = maxBackupCount,
+            ShowLegalIndicator = showLegalIndicator,
+            ShowFishyIndicator = showFishyIndicator,
+            ShowIllegalIndicator = showIllegalIndicator
         };
 
         MudDialog.Close(DialogResult.Ok(updated));

--- a/Pkmds.Rcl/Components/EditForms/Tabs/LegalityTab.razor
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/LegalityTab.razor
@@ -8,20 +8,26 @@
     {
         <MudStack Class="pa-2">
 
-            <MudAlert Severity="@(IsLegal
-                                    ? Severity.Success
-                                    : Severity.Error)"
-                      Icon="@(IsLegal
-                                ? Icons.Material.Filled.CheckCircle
-                                : Icons.Material.Filled.Cancel)">
-                @(IsLegal
-                    ? "This Pokémon is legal."
-                    : "This Pokémon has legality issues.")
+            <MudAlert Severity="@(IsFishy
+                                    ? Severity.Warning
+                                    : IsLegal
+                                        ? Severity.Success
+                                        : Severity.Error)"
+                      Icon="@(IsFishy
+                                ? Icons.Material.Filled.Warning
+                                : IsLegal
+                                    ? Icons.Material.Filled.CheckCircle
+                                    : Icons.Material.Filled.Cancel)">
+                @(IsFishy
+                    ? "This Pokémon is valid but has fishy details."
+                    : IsLegal
+                        ? "This Pokémon is legal."
+                        : "This Pokémon has legality issues.")
             </MudAlert>
 
             @{
                 var issues = analysis.Results
-                    .Where(r => !r.Valid)
+                    .Where(r => r.Judgement is PKHeX.Core.Severity.Invalid or PKHeX.Core.Severity.Fishy)
                     .ToList();
                 var invalidMoves = GetInvalidMoves();
                 var invalidRelearns = GetInvalidRelearnMoves();

--- a/Pkmds.Rcl/Components/EditForms/Tabs/LegalityTab.razor.cs
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/LegalityTab.razor.cs
@@ -31,6 +31,14 @@ public partial class LegalityTab : IDisposable
                             && MoveResult.AllValid(la.Info.Moves)
                             && MoveResult.AllValid(la.Info.Relearn);
 
+    // Fishy = passes LegalityAnalysis.Valid but at least one CheckResult has a Fishy
+    // judgement. CheckResult.Valid is true for Fishy, so plain IsLegal collapses it
+    // into Legal — distinguish it here so the alert can show a warning severity
+    // matching what the Legality Report tab reports.
+    private bool IsFishy => IsLegal
+                            && Analysis is { } la
+                            && la.Results.Any(r => r.Judgement == PKHeX.Core.Severity.Fishy);
+
     private bool HasRibbonIssues => Analysis is { } la &&
                                     la.Results.Any(r => r is
                                     {

--- a/Pkmds.Rcl/Components/MainTabPages/LegalityReportTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/LegalityReportTab.razor
@@ -100,33 +100,32 @@
 
             </MudStack>
 
-            <MudButtonGroup Variant="@Variant.Outlined"
-                            Size="@Size.Small">
+            <MudButtonGroup Size="@Size.Small">
 
-                <MudButton Color="@(statusFilter is null
-                                      ? Color.Primary
-                                      : Color.Default)"
+                <MudButton Variant="@(statusFilter is null ? Variant.Filled : Variant.Outlined)"
+                           Color="@Color.Primary"
+                           StartIcon="@(statusFilter is null ? Icons.Material.Filled.Check : null)"
                            OnClick="@(() => SetFilter(null))">
                     All
                 </MudButton>
 
-                <MudButton Color="@(statusFilter == LegalityStatus.Legal
-                                      ? Color.Success
-                                      : Color.Default)"
+                <MudButton Variant="@(statusFilter == LegalityStatus.Legal ? Variant.Filled : Variant.Outlined)"
+                           Color="@Color.Success"
+                           StartIcon="@(statusFilter == LegalityStatus.Legal ? Icons.Material.Filled.Check : null)"
                            OnClick="@(() => SetFilter(LegalityStatus.Legal))">
                     Legal Only
                 </MudButton>
 
-                <MudButton Color="@(statusFilter == LegalityStatus.Fishy
-                                      ? Color.Warning
-                                      : Color.Default)"
+                <MudButton Variant="@(statusFilter == LegalityStatus.Fishy ? Variant.Filled : Variant.Outlined)"
+                           Color="@Color.Warning"
+                           StartIcon="@(statusFilter == LegalityStatus.Fishy ? Icons.Material.Filled.Check : null)"
                            OnClick="@(() => SetFilter(LegalityStatus.Fishy))">
                     Fishy Only
                 </MudButton>
 
-                <MudButton Color="@(statusFilter == LegalityStatus.Illegal
-                                      ? Color.Error
-                                      : Color.Default)"
+                <MudButton Variant="@(statusFilter == LegalityStatus.Illegal ? Variant.Filled : Variant.Outlined)"
+                           Color="@Color.Error"
+                           StartIcon="@(statusFilter == LegalityStatus.Illegal ? Icons.Material.Filled.Check : null)"
                            OnClick="@(() => SetFilter(LegalityStatus.Illegal))">
                     Illegal Only
                 </MudButton>

--- a/Pkmds.Rcl/Components/MainTabPages/LegalityReportTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/LegalityReportTab.razor
@@ -100,37 +100,31 @@
 
             </MudStack>
 
-            <MudButtonGroup Size="@Size.Small">
+            <MudToggleGroup T="LegalityStatus?"
+                            Value="@statusFilter"
+                            ValueChanged="@SetFilter"
+                            SelectionMode="@SelectionMode.SingleSelection"
+                            Color="@Color.Primary"
+                            CheckMark
+                            Size="@Size.Small">
 
-                <MudButton Variant="@(statusFilter is null ? Variant.Filled : Variant.Outlined)"
-                           Color="@Color.Primary"
-                           StartIcon="@(statusFilter is null ? Icons.Material.Filled.Check : null)"
-                           OnClick="@(() => SetFilter(null))">
-                    All
-                </MudButton>
+                <MudToggleItem T="LegalityStatus?"
+                               Value="@((LegalityStatus?)null)"
+                               Text="All"/>
 
-                <MudButton Variant="@(statusFilter == LegalityStatus.Legal ? Variant.Filled : Variant.Outlined)"
-                           Color="@Color.Success"
-                           StartIcon="@(statusFilter == LegalityStatus.Legal ? Icons.Material.Filled.Check : null)"
-                           OnClick="@(() => SetFilter(LegalityStatus.Legal))">
-                    Legal Only
-                </MudButton>
+                <MudToggleItem T="LegalityStatus?"
+                               Value="@((LegalityStatus?)LegalityStatus.Legal)"
+                               Text="Legal Only"/>
 
-                <MudButton Variant="@(statusFilter == LegalityStatus.Fishy ? Variant.Filled : Variant.Outlined)"
-                           Color="@Color.Warning"
-                           StartIcon="@(statusFilter == LegalityStatus.Fishy ? Icons.Material.Filled.Check : null)"
-                           OnClick="@(() => SetFilter(LegalityStatus.Fishy))">
-                    Fishy Only
-                </MudButton>
+                <MudToggleItem T="LegalityStatus?"
+                               Value="@((LegalityStatus?)LegalityStatus.Fishy)"
+                               Text="Fishy Only"/>
 
-                <MudButton Variant="@(statusFilter == LegalityStatus.Illegal ? Variant.Filled : Variant.Outlined)"
-                           Color="@Color.Error"
-                           StartIcon="@(statusFilter == LegalityStatus.Illegal ? Icons.Material.Filled.Check : null)"
-                           OnClick="@(() => SetFilter(LegalityStatus.Illegal))">
-                    Illegal Only
-                </MudButton>
+                <MudToggleItem T="LegalityStatus?"
+                               Value="@((LegalityStatus?)LegalityStatus.Illegal)"
+                               Text="Illegal Only"/>
 
-            </MudButtonGroup>
+            </MudToggleGroup>
 
             <MudTable T="@LegalityReportEntry"
                       Items="@legalityReportEntries"

--- a/Pkmds.Rcl/Components/MainTabPages/LegalityReportTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/LegalityReportTab.razor.cs
@@ -337,9 +337,12 @@ public partial class LegalityReportTab : RefreshAwareComponent
     {
         var ctx = LegalityLocalizationContext.Create(la);
 
+        // Prefer Invalid results over Fishy ones so the more severe issue is shown
+        // when both are present. CheckResult.Valid is true for Fishy judgements,
+        // so we have to match on Judgement directly to surface Fishy reasons at all.
         foreach (var result in la.Results)
         {
-            if (!result.Valid)
+            if (result.Judgement == PKHexSeverity.Invalid)
             {
                 return ctx.Humanize(in result);
             }
@@ -353,6 +356,14 @@ public partial class LegalityReportTab : RefreshAwareComponent
         if (!MoveResult.AllValid(la.Info.Relearn))
         {
             return "Invalid relearn move detected.";
+        }
+
+        foreach (var result in la.Results)
+        {
+            if (result.Judgement == PKHexSeverity.Fishy)
+            {
+                return ctx.Humanize(in result);
+            }
         }
 
         return string.Empty;

--- a/Pkmds.Rcl/Components/MainTabPages/LegalityReportTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/LegalityReportTab.razor.cs
@@ -141,7 +141,7 @@ public partial class LegalityReportTab : RefreshAwareComponent
             // Re-read the stored bytes and re-analyse so the table reflects exactly what
             // the save now contains — if the round trip mutated the PKM, we'll see the
             // real status here rather than an optimistic pre-write one.
-            var storedLa = AppService.GetLegalityAnalysis(storedPk);
+            var storedLa = AppService.GetLegalityAnalysis(storedPk, isParty: entry.IsParty);
             var newStatus = GetStatus(storedLa);
             var updated = entry with
             {
@@ -266,7 +266,7 @@ public partial class LegalityReportTab : RefreshAwareComponent
                 continue;
             }
 
-            var la = AppService.GetLegalityAnalysis(pkm);
+            var la = AppService.GetLegalityAnalysis(pkm, isParty: true);
             entries.Add(BuildEntry(pkm, la, true, 0, i));
         }
 

--- a/Pkmds.Rcl/Components/PokemonSlotComponent.razor
+++ b/Pkmds.Rcl/Components/PokemonSlotComponent.razor
@@ -84,7 +84,8 @@
                                           LegalityStatus.Fishy => Color.Warning,
                                           _ => Color.Error
                                       })"
-                             Size="@Size.Small"/>
+                             Class="w-full h-full"
+                             Style="font-size: 16px;"/>
                 </div>
             }
 

--- a/Pkmds.Rcl/Components/PokemonSlotComponent.razor
+++ b/Pkmds.Rcl/Components/PokemonSlotComponent.razor
@@ -63,20 +63,28 @@
                 </div>
             }
 
-            @if (!AppState.IsHaXEnabled && GetLegalityValid() is { } isLegal)
+            @if (!AppState.IsHaXEnabled && GetLegalityStatus() is { } status)
             {
                 <div class="legality-indicator-icon"
-                     title="@(isLegal
-                                ? "Legal"
-                                : "Illegal")">
-                    <img src="@(isLegal
-                                  ? ImageHelper.GetLegalityValidSpriteFileName()
-                                  : ImageHelper.GetLegalityWarnSpriteFileName())"
-                         alt="@(isLegal
-                                  ? "Legal"
-                                  : "Illegal")"
-                         class="w-full h-full object-contain"
-                         draggable="false">
+                     title="@(status switch
+                              {
+                                  LegalityStatus.Legal => "Legal",
+                                  LegalityStatus.Fishy => "Fishy",
+                                  _ => "Illegal"
+                              })">
+                    <MudIcon Icon="@(status switch
+                                     {
+                                         LegalityStatus.Legal => Icons.Material.Filled.CheckCircle,
+                                         LegalityStatus.Fishy => Icons.Material.Filled.Warning,
+                                         _ => Icons.Material.Filled.Cancel
+                                     })"
+                             Color="@(status switch
+                                      {
+                                          LegalityStatus.Legal => Color.Success,
+                                          LegalityStatus.Fishy => Color.Warning,
+                                          _ => Color.Error
+                                      })"
+                             Size="@Size.Small"/>
                 </div>
             }
 

--- a/Pkmds.Rcl/Components/PokemonSlotComponent.razor.cs
+++ b/Pkmds.Rcl/Components/PokemonSlotComponent.razor.cs
@@ -156,7 +156,7 @@ public partial class PokemonSlotComponent : IDisposable
             return;
         }
 
-        var la = AppService.GetLegalityAnalysis(Pokemon);
+        var la = AppService.GetLegalityAnalysis(Pokemon, isParty: IsPartySlot);
         var hasInvalid = la.Results.Any(r => r.Judgement == PKHeX.Core.Severity.Invalid)
                          || !MoveResult.AllValid(la.Info.Moves)
                          || !MoveResult.AllValid(la.Info.Relearn);

--- a/Pkmds.Rcl/Components/PokemonSlotComponent.razor.cs
+++ b/Pkmds.Rcl/Components/PokemonSlotComponent.razor.cs
@@ -18,7 +18,7 @@ public partial class PokemonSlotComponent : IDisposable
     private ushort lastLoadedSpecies;
     private SpriteStyle lastLoadedSpriteStyle;
 
-    private bool? legalityValid;
+    private LegalityStatus? legalityStatus;
 
     [Parameter]
     [EditorRequired]
@@ -152,14 +152,22 @@ public partial class PokemonSlotComponent : IDisposable
     {
         if (Pokemon is not { Species: > 0 } || AppState.IsHaXEnabled)
         {
-            legalityValid = null;
+            legalityStatus = null;
             return;
         }
 
         var la = AppService.GetLegalityAnalysis(Pokemon);
-        legalityValid = la.Results.All(r => r.Valid)
-                        && MoveResult.AllValid(la.Info.Moves)
-                        && MoveResult.AllValid(la.Info.Relearn);
+        var hasInvalid = la.Results.Any(r => r.Judgement == PKHeX.Core.Severity.Invalid)
+                         || !MoveResult.AllValid(la.Info.Moves)
+                         || !MoveResult.AllValid(la.Info.Relearn);
+        if (hasInvalid)
+        {
+            legalityStatus = LegalityStatus.Illegal;
+            return;
+        }
+
+        var hasFishy = la.Results.Any(r => r.Judgement == PKHeX.Core.Severity.Fishy);
+        legalityStatus = hasFishy ? LegalityStatus.Fishy : LegalityStatus.Legal;
     }
 
     private string GetPokemonTitle() => Pokemon is { Species: > 0 }
@@ -178,10 +186,20 @@ public partial class PokemonSlotComponent : IDisposable
     };
 
     /// <returns>
-    /// <see langword="true" /> = legal, <see langword="false" /> = illegal/fishy,
-    /// <see langword="null" /> = no Pokémon in slot (skip indicator).
+    /// The tri-state legality status, or <see langword="null" /> when no Pokémon is in
+    /// the slot, HaX mode is on, or the user has disabled the indicator for this status
+    /// via settings.
     /// </returns>
-    private bool? GetLegalityValid() => legalityValid;
+    private LegalityStatus? GetLegalityStatus()
+    {
+        return legalityStatus switch
+        {
+            LegalityStatus.Legal when AppState.ShowLegalIndicator => LegalityStatus.Legal,
+            LegalityStatus.Fishy when AppState.ShowFishyIndicator => LegalityStatus.Fishy,
+            LegalityStatus.Illegal when AppState.ShowIllegalIndicator => LegalityStatus.Illegal,
+            _ => null
+        };
+    }
 
     private string? GetStatusOverlaySpriteFileName() =>
         ImageHelper.GetStatusOverlaySpriteFileName(Pokemon);

--- a/Pkmds.Rcl/IAppState.cs
+++ b/Pkmds.Rcl/IAppState.cs
@@ -103,4 +103,13 @@ public interface IAppState
     /// Null when no box is pinned. Pinning a box replaces the Pokémon editor in the right column.
     /// </summary>
     int? PinnedBoxNumber { get; set; }
+
+    /// <summary>Whether to render the green "legal" indicator on slots.</summary>
+    bool ShowLegalIndicator { get => true; set { } }
+
+    /// <summary>Whether to render the yellow "fishy" indicator on slots.</summary>
+    bool ShowFishyIndicator { get => true; set { } }
+
+    /// <summary>Whether to render the red "illegal" indicator on slots.</summary>
+    bool ShowIllegalIndicator { get => true; set { } }
 }

--- a/Pkmds.Rcl/IAppState.cs
+++ b/Pkmds.Rcl/IAppState.cs
@@ -105,11 +105,11 @@ public interface IAppState
     int? PinnedBoxNumber { get; set; }
 
     /// <summary>Whether to render the green "legal" indicator on slots.</summary>
-    bool ShowLegalIndicator { get => true; set { } }
+    bool ShowLegalIndicator { get; set; }
 
     /// <summary>Whether to render the yellow "fishy" indicator on slots.</summary>
-    bool ShowFishyIndicator { get => true; set { } }
+    bool ShowFishyIndicator { get; set; }
 
     /// <summary>Whether to render the red "illegal" indicator on slots.</summary>
-    bool ShowIllegalIndicator { get => true; set { } }
+    bool ShowIllegalIndicator { get; set; }
 }

--- a/Pkmds.Rcl/Models/AppSettings.cs
+++ b/Pkmds.Rcl/Models/AppSettings.cs
@@ -57,4 +57,19 @@ public record AppSettings
     /// Maximum number of save file backups to retain. Oldest backups are pruned when this limit is exceeded.
     /// </summary>
     public int MaxBackupCount { get; init; } = 10;
+
+    /// <summary>
+    /// Whether to show the green "legal" indicator on box/party slots.
+    /// </summary>
+    public bool ShowLegalIndicator { get; init; } = true;
+
+    /// <summary>
+    /// Whether to show the yellow "fishy" indicator on box/party slots.
+    /// </summary>
+    public bool ShowFishyIndicator { get; init; } = true;
+
+    /// <summary>
+    /// Whether to show the red "illegal" indicator on box/party slots.
+    /// </summary>
+    public bool ShowIllegalIndicator { get; init; } = true;
 }

--- a/Pkmds.Rcl/Services/AppService.cs
+++ b/Pkmds.Rcl/Services/AppService.cs
@@ -1020,7 +1020,7 @@ public class AppService(IAppState appState, IRefreshService refreshService, ILeg
     public IReadOnlyList<ComboItem> GetConsoleRegionComboItems() =>
         GameInfo.FilteredSources.ConsoleRegions;
 
-    public LegalityAnalysis GetLegalityAnalysis(PKM pkm)
+    public LegalityAnalysis GetLegalityAnalysis(PKM pkm, bool isParty = false)
     {
         // PKHeX's per-format SetPKM hook (e.g. SAV8BS.SetPKM → pb8.UpdateHandler)
         // runs on every slot write and normalises CurrentHandler / HT fields to
@@ -1032,7 +1032,7 @@ public class AppService(IAppState appState, IRefreshService refreshService, ILeg
         if (AppState.SaveFile is { } sav && pkm.GetType() == sav.PKMType)
         {
             var clone = pkm.Clone();
-            sav.AdaptToSaveFile(clone, isParty: false);
+            sav.AdaptToSaveFile(clone, isParty);
             return new LegalityAnalysis(clone);
         }
 

--- a/Pkmds.Rcl/Services/AppService.cs
+++ b/Pkmds.Rcl/Services/AppService.cs
@@ -1020,7 +1020,24 @@ public class AppService(IAppState appState, IRefreshService refreshService, ILeg
     public IReadOnlyList<ComboItem> GetConsoleRegionComboItems() =>
         GameInfo.FilteredSources.ConsoleRegions;
 
-    public LegalityAnalysis GetLegalityAnalysis(PKM pkm) => new(pkm);
+    public LegalityAnalysis GetLegalityAnalysis(PKM pkm)
+    {
+        // PKHeX's per-format SetPKM hook (e.g. SAV8BS.SetPKM → pb8.UpdateHandler)
+        // runs on every slot write and normalises CurrentHandler / HT fields to
+        // match the loaded trainer. Raw slots read via GetBoxSlotAtIndex skip
+        // that step, so the report can flag an "Invalid Current handler value"
+        // that will silently disappear the next time anything writes the slot.
+        // Mirror the adapt-on-write behaviour by analysing a cloned-and-adapted
+        // copy so the displayed status matches what the save will actually hold.
+        if (AppState.SaveFile is { } sav && pkm.GetType() == sav.PKMType)
+        {
+            var clone = pkm.Clone();
+            sav.AdaptToSaveFile(clone, isParty: false);
+            return new LegalityAnalysis(clone);
+        }
+
+        return new LegalityAnalysis(pkm);
+    }
 
     public IEnumerable<AdvancedSearchResult> SearchPokemon(AdvancedSearchFilter filter)
     {

--- a/Pkmds.Rcl/Services/IAppService.cs
+++ b/Pkmds.Rcl/Services/IAppService.cs
@@ -339,8 +339,12 @@ public interface IAppService
     /// <see cref="LegalityAnalysis" /> engine.
     /// </summary>
     /// <param name="pkm">The Pokémon to analyse.</param>
+    /// <param name="isParty">True if <paramref name="pkm" /> lives in (or is
+    /// about to be written to) a party slot. Forwarded to
+    /// <see cref="SaveFile.AdaptToSaveFile" /> so the adapt step matches what
+    /// the eventual SetPartySlotAtIndex / SetBoxSlotAtIndex call will do.</param>
     /// <returns>A <see cref="LegalityAnalysis" /> result.</returns>
-    LegalityAnalysis GetLegalityAnalysis(PKM pkm);
+    LegalityAnalysis GetLegalityAnalysis(PKM pkm, bool isParty = false);
 
     /// <summary>
     /// Sweeps all party and box slots and returns every Pokémon that satisfies

--- a/Pkmds.Rcl/Services/LegalizationService.cs
+++ b/Pkmds.Rcl/Services/LegalizationService.cs
@@ -683,6 +683,46 @@ public sealed class LegalizationService : ILegalizationService
         IEncounterable enc,
         ShowdownSet set)
     {
+        // Restore event-specific properties that ApplySetDetails (or intermediate
+        // conversions) may have trampled. enc.ConvertToPKM already set these once,
+        // but SetRandomEC / SetIsShiny / IV writes can knock them out of alignment
+        // with the event constraints enforced by LegalityAnalysis.
+        if (enc is MysteryGift mg)
+        {
+            if (mg.FatefulEncounter)
+            {
+                pk.FatefulEncounter = true;
+            }
+
+            // When the gift locks the OT, restore the full trainer tuple. If the
+            // gift has no fixed OT, the receiving trainer's data is correct.
+            if (!string.IsNullOrEmpty(mg.OriginalTrainerName))
+            {
+                pk.OriginalTrainerName = mg.OriginalTrainerName;
+                pk.TID16 = mg.TID16;
+                pk.SID16 = mg.SID16;
+            }
+
+            // PGF (Gen 5 events) has partially-fixed IVs: values >31 are sentinels
+            // meaning "random — keep the caller's IV". ApplySetDetails overwrote
+            // every slot with set.IVs; merge the PGF-locked slots back in.
+            if (mg is PGF pgf)
+            {
+                Span<int> ivs = stackalloc int[6];
+                pk.GetIVs(ivs);
+                var pgfIvs = pgf.IVs;
+                for (var i = 0; i < pgfIvs.Length && i < ivs.Length; i++)
+                {
+                    if (pgfIvs[i] <= 31)
+                    {
+                        ivs[i] = pgfIvs[i];
+                    }
+                }
+
+                pk.SetIVs(ivs);
+            }
+        }
+
         // Clamp level to encounter minimum.
         if (pk.CurrentLevel < enc.LevelMin)
         {

--- a/Pkmds.Rcl/Services/LegalizationService.cs
+++ b/Pkmds.Rcl/Services/LegalizationService.cs
@@ -694,8 +694,13 @@ public sealed class LegalizationService : ILegalizationService
                 pk.FatefulEncounter = true;
             }
 
-            // When the gift locks the OT, restore the full trainer tuple. If the
-            // gift has no fixed OT, the receiving trainer's data is correct.
+            // When the gift locks the OT, restore OT name + TID/SID from the
+            // base MysteryGift surface. OT gender / language are subclass-
+            // specific (PGF/WC8/WA8/WA9 expose OTGender with differing
+            // sentinel rules for "use receiving trainer") and are already set
+            // correctly by enc.ConvertToPKM; ApplySetDetails doesn't touch
+            // them. If the gift has no fixed OT, the receiving trainer's
+            // data is correct.
             if (!string.IsNullOrEmpty(mg.OriginalTrainerName))
             {
                 pk.OriginalTrainerName = mg.OriginalTrainerName;

--- a/Pkmds.Rcl/Services/SettingsService.cs
+++ b/Pkmds.Rcl/Services/SettingsService.cs
@@ -104,6 +104,9 @@ public sealed class SettingsService(
     {
         appState.IsHaXEnabled = Settings.IsHaXEnabled;
         appState.SpriteStyle = Settings.SpriteStyle;
+        appState.ShowLegalIndicator = Settings.ShowLegalIndicator;
+        appState.ShowFishyIndicator = Settings.ShowFishyIndicator;
+        appState.ShowIllegalIndicator = Settings.ShowIllegalIndicator;
         loggingService.IsVerboseLoggingEnabled = Settings.IsVerboseLoggingEnabled;
     }
 }

--- a/Pkmds.Tests/AdvancedSearchTests.cs
+++ b/Pkmds.Tests/AdvancedSearchTests.cs
@@ -243,6 +243,9 @@ public class AdvancedSearchTests
         public bool SelectedSlotsAreValid => true;
         public bool IsHaXEnabled { get; set; }
         public SpriteStyle SpriteStyle { get; set; }
+        public bool ShowLegalIndicator { get; set; } = true;
+        public bool ShowFishyIndicator { get; set; } = true;
+        public bool ShowIllegalIndicator { get; set; } = true;
     }
 
     private sealed class TestRefreshService : IRefreshService

--- a/Pkmds.Tests/AppServiceTests.cs
+++ b/Pkmds.Tests/AppServiceTests.cs
@@ -390,6 +390,9 @@ public class AppServiceTests
         public bool SelectedSlotsAreValid => true;
         public bool IsHaXEnabled { get; set; }
         public SpriteStyle SpriteStyle { get; set; }
+        public bool ShowLegalIndicator { get; set; } = true;
+        public bool ShowFishyIndicator { get; set; } = true;
+        public bool ShowIllegalIndicator { get; set; } = true;
     }
 
     private class TestRefreshService : IRefreshService

--- a/Pkmds.Tests/BoxManagementTests.cs
+++ b/Pkmds.Tests/BoxManagementTests.cs
@@ -104,6 +104,9 @@ public class BoxManagementTests
         public bool SelectedSlotsAreValid => true;
         public bool IsHaXEnabled { get; set; }
         public SpriteStyle SpriteStyle { get; set; }
+        public bool ShowLegalIndicator { get; set; } = true;
+        public bool ShowFishyIndicator { get; set; } = true;
+        public bool ShowIllegalIndicator { get; set; } = true;
     }
 
     private class TestRefreshService : IRefreshService

--- a/Pkmds.Tests/BunitTestHelpers.cs
+++ b/Pkmds.Tests/BunitTestHelpers.cs
@@ -75,6 +75,9 @@ internal class TestAppState : IAppState
     public bool SelectedSlotsAreValid => true;
     public bool IsHaXEnabled { get; set; }
     public SpriteStyle SpriteStyle { get; set; }
+    public bool ShowLegalIndicator { get; set; } = true;
+    public bool ShowFishyIndicator { get; set; } = true;
+    public bool ShowIllegalIndicator { get; set; } = true;
 }
 
 internal class TestRefreshService : IRefreshService

--- a/Pkmds.Tests/EncounterDatabaseTests.cs
+++ b/Pkmds.Tests/EncounterDatabaseTests.cs
@@ -215,6 +215,9 @@ public class EncounterDatabaseTests
         public bool SelectedSlotsAreValid => true;
         public bool IsHaXEnabled { get; set; }
         public SpriteStyle SpriteStyle { get; set; }
+        public bool ShowLegalIndicator { get; set; } = true;
+        public bool ShowFishyIndicator { get; set; } = true;
+        public bool ShowIllegalIndicator { get; set; } = true;
     }
 
     private sealed class TestRefreshService : IRefreshService

--- a/Pkmds.Tests/EvolveTests.cs
+++ b/Pkmds.Tests/EvolveTests.cs
@@ -398,6 +398,9 @@ public class EvolveTests
         public bool SelectedSlotsAreValid => true;
         public bool IsHaXEnabled { get; set; }
         public SpriteStyle SpriteStyle { get; set; }
+        public bool ShowLegalIndicator { get; set; } = true;
+        public bool ShowFishyIndicator { get; set; } = true;
+        public bool ShowIllegalIndicator { get; set; } = true;
     }
 
     private sealed class TestRefreshService : IRefreshService

--- a/Pkmds.Tests/HaXModeTests.cs
+++ b/Pkmds.Tests/HaXModeTests.cs
@@ -168,5 +168,8 @@ public class HaXModeTests
         public bool SelectedSlotsAreValid => true;
         public bool IsHaXEnabled { get; set; }
         public SpriteStyle SpriteStyle { get; set; }
+        public bool ShowLegalIndicator { get; set; } = true;
+        public bool ShowFishyIndicator { get; set; } = true;
+        public bool ShowIllegalIndicator { get; set; } = true;
     }
 }

--- a/Pkmds.Tests/LegalityCheckerTests.cs
+++ b/Pkmds.Tests/LegalityCheckerTests.cs
@@ -245,6 +245,9 @@ public class LegalityCheckerTests
         public bool SelectedSlotsAreValid => true;
         public bool IsHaXEnabled { get; set; }
         public SpriteStyle SpriteStyle { get; set; }
+        public bool ShowLegalIndicator { get; set; } = true;
+        public bool ShowFishyIndicator { get; set; } = true;
+        public bool ShowIllegalIndicator { get; set; } = true;
     }
 
     private class TestRefreshService : IRefreshService

--- a/Pkmds.Web/AppState.cs
+++ b/Pkmds.Web/AppState.cs
@@ -89,4 +89,13 @@ public record AppState : IAppState
 
     /// <inheritdoc />
     public int? PinnedBoxNumber { get; set; }
+
+    /// <inheritdoc />
+    public bool ShowLegalIndicator { get; set; } = true;
+
+    /// <inheritdoc />
+    public bool ShowFishyIndicator { get; set; } = true;
+
+    /// <inheritdoc />
+    public bool ShowIllegalIndicator { get; set; } = true;
 }


### PR DESCRIPTION
## Summary
- Restore `FatefulEncounter`, fixed OT/TID/SID, and PGF partially-fixed IVs in `LegalizationService.ApplyPostGenerationFixes` so Mystery Gift encounters survive `ApplySetDetails` and pass `LegalityAnalysis.Valid`.
- PGF's `IVs` array uses `>31` sentinels to mean "random"; merge locked slots back over whatever the Showdown set wrote.
- Fixes #695.

## Test plan
- [ ] Load a save with a modified event Pokémon, run Legalize, verify the result matches the original event and is Valid.
- [ ] Import a Showdown set for an event-only species (e.g. Mew, Celebi) and verify the engine selects the correct event encounter.
- [ ] Regression: non-event legalization (wild slot, static, trade) still succeeds.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)