### PR TITLE
feat: cross-save trade Phase 1 — dual-save state + read-only Trade tab

### DIFF
--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor
@@ -1,12 +1,6 @@
 @inherits LayoutComponentBase
 @inject ILogger<MainLayout> Logger
 
-<MudThemeProvider @ref="@mudThemeProvider"
-                  IsDarkMode="@isDarkMode"/>
-<MudPopoverProvider/>
-<MudDialogProvider BackdropClick="false"/>
-<MudSnackbarProvider/>
-
 <MudLayout>
     <MudAppBar Dense>
         <MudBadge Color="@Color.Info"
@@ -171,6 +165,16 @@
                        FullWidth>
                 Report a Bug
             </MudButton>
+            @if (IsDebugBuild)
+            {
+                <MudButton OnClick="@TriggerCrash"
+                           StartIcon="@Icons.Material.Filled.Warning"
+                           Variant="@Variant.Outlined"
+                           Color="@Color.Error"
+                           FullWidth>
+                    [DEBUG] Trigger Crash
+                </MudButton>
+            }
             @if (IsUpdateAvailable)
             {
                 <MudButton OnClick="@ReloadApp"

--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
@@ -10,7 +10,6 @@ public partial class MainLayout : IDisposable
     private IBrowserFile? browserLoadSaveFile;
     private bool isDarkMode;
     private ManicEmuSaveHelper.ManicEmuSaveContext? manicEmuSaveContext;
-    private MudThemeProvider? mudThemeProvider;
     private bool systemIsDarkMode;
     private ThemeMode themeMode = ThemeMode.System;
 
@@ -29,12 +28,14 @@ public partial class MainLayout : IDisposable
     {
         RefreshService.OnAppStateChanged -= StateHasChanged;
         RefreshService.OnUpdateAvailable -= ShowUpdateMessage;
+        RefreshService.OnSystemThemeChanged -= OnSystemPreferenceChanged;
     }
 
     protected override void OnInitialized()
     {
         RefreshService.OnAppStateChanged += StateHasChanged;
         RefreshService.OnUpdateAvailable += ShowUpdateMessage;
+        RefreshService.OnSystemThemeChanged += OnSystemPreferenceChanged;
     }
 
     private void ShowUpdateMessage()
@@ -87,13 +88,10 @@ public partial class MainLayout : IDisposable
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (!firstRender || mudThemeProvider is null)
+        if (!firstRender)
         {
             return;
         }
-
-        systemIsDarkMode = await mudThemeProvider.GetSystemDarkModeAsync();
-        await mudThemeProvider.WatchSystemDarkModeAsync(OnSystemPreferenceChanged);
 
         // Warn users who are running inside a known in-app browser (e.g. Google Search App,
         // Facebook) whose WebView typically blocks file downloads.
@@ -125,7 +123,7 @@ public partial class MainLayout : IDisposable
         StateHasChanged();
     }
 
-    private async Task OnSystemPreferenceChanged(bool newValue)
+    private async void OnSystemPreferenceChanged(bool newValue)
     {
         systemIsDarkMode = newValue;
         if (themeMode == ThemeMode.System)
@@ -171,6 +169,17 @@ public partial class MainLayout : IDisposable
     }
 
     private void DrawerToggle() => AppService.ToggleDrawer();
+
+#if DEBUG
+    private static bool IsDebugBuild => true;
+
+    private static void TriggerCrash() =>
+        throw new InvalidOperationException("Manually triggered crash (DEBUG build only) to test the ErrorBoundary + crash-report dialog.");
+#else
+    private static bool IsDebugBuild => false;
+
+    private static void TriggerCrash() { }
+#endif
 
     private async Task ShowBugReportDialog()
     {

--- a/Pkmds.Rcl/Components/Layout/MinimalLayout.razor
+++ b/Pkmds.Rcl/Components/Layout/MinimalLayout.razor
@@ -1,10 +1,5 @@
 @inherits LayoutComponentBase
 
-<MudThemeProvider IsDarkMode/>
-<MudPopoverProvider/>
-<MudDialogProvider BackdropClick="false"/>
-<MudSnackbarProvider/>
-
 <MudLayout>
     <MudMainContent>
         @Body

--- a/Pkmds.Rcl/Components/MainTabPages/TradePane.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TradePane.razor
@@ -17,7 +17,6 @@
                     : null;
                 <div class="min-w-0">
                     <TradeSlot Pokemon="@pkm"
-                               OwnerSave="@saveFile"
                                IsSelected="@(SelectedPartySlot == slotNum)"
                                OnSlotClick="@(() => SelectParty(slotNum))"/>
                 </div>
@@ -52,7 +51,6 @@
                     var pkm = saveFile.GetBoxSlotAtIndex(currentBox, slotNum);
                     <div class="min-w-0">
                         <TradeSlot Pokemon="@pkm"
-                                   OwnerSave="@saveFile"
                                    IsSelected="@(SelectedBox == currentBox && SelectedBoxSlot == slotNum)"
                                    OnSlotClick="@(() => SelectBoxSlot(currentBox, slotNum))"/>
                     </div>
@@ -65,14 +63,15 @@
             <MudPaper Elevation="1"
                       Class="pa-2 mt-2">
                 @{
-                    // Per-save string tables — GameInfo.Strings / FilteredSources are filtered to
-                    // whichever save PKHeX last initialized against, so a Gen 1 Save A would mask
-                    // Gen 5 species in Save B. Look up names using each save's own language.
-                    var strings = GetStringsForSave(saveFile);
+                    var strings = AppStrings;
                     var speciesName = selected.Species < strings.specieslist.Length
                         ? strings.specieslist[selected.Species]
                         : "Unknown";
-                    var nickname = string.IsNullOrEmpty(selected.Nickname) ? speciesName : selected.Nickname;
+                    // Use IsNicknamed rather than comparing strings — Gen 1/2 auto-nicknames are
+                    // stored in all-caps ("EXEGGCUTE") so a case-sensitive compare against the
+                    // mixed-case species name would wrongly treat them as custom nicknames.
+                    var hasCustomNickname = selected.IsNicknamed && !string.IsNullOrEmpty(selected.Nickname);
+                    var nickname = hasCustomNickname ? selected.Nickname : speciesName;
                     var natureIdx = (int)selected.Nature;
                     var natureName = natureIdx >= 0 && natureIdx < strings.Natures.Count
                         ? strings.Natures[natureIdx]
@@ -89,7 +88,7 @@
                 }
                 <MudText Typo="@Typo.subtitle2">
                     @nickname
-                    @if (!string.Equals(nickname, speciesName, StringComparison.Ordinal))
+                    @if (hasCustomNickname)
                     {
                         <span> (@speciesName)</span>
                     }

--- a/Pkmds.Rcl/Components/MainTabPages/TradePane.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TradePane.razor
@@ -17,6 +17,7 @@
                     : null;
                 <div class="min-w-0">
                     <TradeSlot Pokemon="@pkm"
+                               OwnerVersion="@saveFile.Version"
                                IsSelected="@(SelectedPartySlot == slotNum)"
                                OnSlotClick="@(() => SelectParty(slotNum))"/>
                 </div>
@@ -67,6 +68,7 @@
                     var pkm = saveFile.GetBoxSlotAtIndex(currentBox, slotNum);
                     <div class="min-w-0">
                         <TradeSlot Pokemon="@pkm"
+                                   OwnerVersion="@saveFile.Version"
                                    IsSelected="@(SelectedBox == currentBox && SelectedBoxSlot == slotNum)"
                                    OnSlotClick="@(() => SelectBoxSlot(currentBox, slotNum))"/>
                     </div>

--- a/Pkmds.Rcl/Components/MainTabPages/TradePane.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TradePane.razor
@@ -27,22 +27,38 @@
         @if (saveFile.BoxCount > 0)
         {
             var currentBox = SelectedBox ?? saveFile.CurrentBox;
-            <MudSelect T="@int"
-                       Value="@currentBox"
-                       ValueChanged="@SelectBox"
-                       Dense>
-                @for (var boxId = 0; boxId < saveFile.BoxCount; boxId++)
-                {
-                    var localBoxId = boxId;
-                    var boxName = saveFile is IBoxDetailNameRead boxDetailNameRead
-                        ? boxDetailNameRead.GetBoxName(localBoxId)
-                        : string.Empty;
-                    <MudSelectItem Value="@localBoxId"
-                                   @key="@localBoxId">
-                        @($"Box {localBoxId + 1}: {boxName}")
-                    </MudSelectItem>
-                }
-            </MudSelect>
+            <div class="flex items-center gap-1">
+                <MudIconButton OnClick="@(() => SelectBox((currentBox - 1 + saveFile.BoxCount) % saveFile.BoxCount))"
+                               title="Previous Box"
+                               ButtonType="@ButtonType.Button"
+                               Icon="@Icons.Material.Filled.ArrowLeft"
+                               Variant="@Variant.Filled"
+                               Size="@Size.Small"/>
+                <div class="flex-1 min-w-0">
+                    <MudSelect T="@int"
+                               Value="@currentBox"
+                               ValueChanged="@SelectBox"
+                               Dense>
+                        @for (var boxId = 0; boxId < saveFile.BoxCount; boxId++)
+                        {
+                            var localBoxId = boxId;
+                            var boxName = saveFile is IBoxDetailNameRead boxDetailNameRead
+                                ? boxDetailNameRead.GetBoxName(localBoxId)
+                                : string.Empty;
+                            <MudSelectItem Value="@localBoxId"
+                                           @key="@localBoxId">
+                                @($"Box {localBoxId + 1}: {boxName} ({GetBoxPokemonCount(saveFile, localBoxId)}/{saveFile.BoxSlotCount})")
+                            </MudSelectItem>
+                        }
+                    </MudSelect>
+                </div>
+                <MudIconButton OnClick="@(() => SelectBox((currentBox + 1) % saveFile.BoxCount))"
+                               title="Next Box"
+                               ButtonType="@ButtonType.Button"
+                               Icon="@Icons.Material.Filled.ArrowRight"
+                               Variant="@Variant.Filled"
+                               Size="@Size.Small"/>
+            </div>
 
             <div class="@BoxGridClass(saveFile)">
                 @for (var i = 0; i < saveFile.BoxSlotCount; i++)

--- a/Pkmds.Rcl/Components/MainTabPages/TradePane.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TradePane.razor
@@ -1,0 +1,59 @@
+@inherits RefreshAwareComponent
+
+@if (SaveFile is { } saveFile)
+{
+    <MudStack Spacing="2">
+
+        <MudText Typo="@Typo.subtitle1">@Title</MudText>
+
+        @* Party row *@
+        <MudGrid Spacing="1"
+                 Justify="@Justify.FlexStart">
+            @for (var i = 0; i < 6; i++)
+            {
+                var slotNum = i;
+                var pkm = i < saveFile.PartyCount
+                    ? saveFile.GetPartySlotAtIndex(slotNum)
+                    : null;
+                <MudItem xs="2">
+                    <TradeSlot Pokemon="@pkm"
+                               IsSelected="@(SelectedPartySlot == slotNum)"
+                               OnSlotClick="@(() => SelectParty(slotNum))"/>
+                </MudItem>
+            }
+        </MudGrid>
+
+        @* Box selector — Let's Go saves only have a single 1000-slot storage; gate behind BoxCount > 0 *@
+        @if (saveFile.BoxCount > 0)
+        {
+            var currentBox = SelectedBox ?? saveFile.CurrentBox;
+            <MudSelect T="@int"
+                       Value="@currentBox"
+                       ValueChanged="@SelectBox"
+                       Dense>
+                @for (var boxId = 0; boxId < saveFile.BoxCount; boxId++)
+                {
+                    var localBoxId = boxId;
+                    var boxName = saveFile is IBoxDetailNameRead boxDetailNameRead
+                        ? boxDetailNameRead.GetBoxName(localBoxId)
+                        : string.Empty;
+                    <MudSelectItem Value="@localBoxId"
+                                   @key="@localBoxId">
+                        @($"Box {localBoxId + 1}: {boxName}")
+                    </MudSelectItem>
+                }
+            </MudSelect>
+
+            <div class="@BoxGridClass(saveFile)">
+                @for (var i = 0; i < saveFile.BoxSlotCount; i++)
+                {
+                    var slotNum = i;
+                    var pkm = saveFile.GetBoxSlotAtIndex(currentBox, slotNum);
+                    <TradeSlot Pokemon="@pkm"
+                               IsSelected="@(SelectedBox == currentBox && SelectedBoxSlot == slotNum)"
+                               OnSlotClick="@(() => SelectBoxSlot(currentBox, slotNum))"/>
+                }
+            </div>
+        }
+    </MudStack>
+}

--- a/Pkmds.Rcl/Components/MainTabPages/TradePane.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TradePane.razor
@@ -55,5 +55,59 @@
                 }
             </div>
         }
+
+        @if (SelectedPokemon is { Species: > 0 } selected)
+        {
+            <MudPaper Elevation="1"
+                      Class="pa-2 mt-2">
+                @{
+                    var strings = GameInfo.Strings;
+                    var speciesName = AppService.GetPokemonSpeciesName(selected.Species) ?? "Unknown";
+                    var nickname = string.IsNullOrEmpty(selected.Nickname) ? speciesName : selected.Nickname;
+                    var natureName = strings.Natures.Count > (int)selected.Nature
+                        ? strings.Natures[(int)selected.Nature]
+                        : selected.Nature.ToString();
+                    var abilityName = strings.Ability.Count > selected.Ability
+                        ? strings.Ability[selected.Ability]
+                        : selected.Ability.ToString();
+                    var heldItemName = selected.HeldItem > 0 && strings.Item.Count > selected.HeldItem
+                        ? strings.Item[selected.HeldItem]
+                        : "(none)";
+                }
+                <MudText Typo="@Typo.subtitle2">
+                    @nickname
+                    @if (!string.Equals(nickname, speciesName, StringComparison.Ordinal))
+                    {
+                        <span> (@speciesName)</span>
+                    }
+                    <span> · Lv. @selected.CurrentLevel</span>
+                    @if (selected.IsShiny)
+                    {
+                        <span> · ★</span>
+                    }
+                    @if (selected.IsEgg)
+                    {
+                        <span> · Egg</span>
+                    }
+                </MudText>
+                <MudText Typo="@Typo.body2">
+                    Nature: @natureName · Ability: @abilityName · Held: @heldItemName
+                </MudText>
+                <MudText Typo="@Typo.body2">
+                    OT: @selected.OriginalTrainerName · TID: @selected.TID16 · SID: @selected.SID16
+                </MudText>
+                <MudText Typo="@Typo.body2"
+                         Class="mt-1">
+                    Moves:
+                    @{
+                        var moves = new[] { selected.Move1, selected.Move2, selected.Move3, selected.Move4 }
+                            .Where(m => m > 0)
+                            .Select(m => strings.Move.Count > m ? strings.Move[m] : m.ToString())
+                            .ToArray();
+                    }
+                    @(moves.Length == 0 ? "(none)" : string.Join(", ", moves))
+                </MudText>
+            </MudPaper>
+        }
     </MudStack>
 }

--- a/Pkmds.Rcl/Components/MainTabPages/TradePane.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TradePane.razor
@@ -2,26 +2,27 @@
 
 @if (SaveFile is { } saveFile)
 {
-    <MudStack Spacing="2">
+    <MudStack Spacing="2"
+              Class="min-w-0">
 
         <MudText Typo="@Typo.subtitle1">@Title</MudText>
 
         @* Party row *@
-        <MudGrid Spacing="1"
-                 Justify="@Justify.FlexStart">
+        <div class="grid grid-cols-6 gap-1 w-full min-w-0">
             @for (var i = 0; i < 6; i++)
             {
                 var slotNum = i;
                 var pkm = i < saveFile.PartyCount
                     ? saveFile.GetPartySlotAtIndex(slotNum)
                     : null;
-                <MudItem xs="2">
+                <div class="min-w-0">
                     <TradeSlot Pokemon="@pkm"
+                               OwnerSave="@saveFile"
                                IsSelected="@(SelectedPartySlot == slotNum)"
                                OnSlotClick="@(() => SelectParty(slotNum))"/>
-                </MudItem>
+                </div>
             }
-        </MudGrid>
+        </div>
 
         @* Box selector — Let's Go saves only have a single 1000-slot storage; gate behind BoxCount > 0 *@
         @if (saveFile.BoxCount > 0)
@@ -49,9 +50,12 @@
                 {
                     var slotNum = i;
                     var pkm = saveFile.GetBoxSlotAtIndex(currentBox, slotNum);
-                    <TradeSlot Pokemon="@pkm"
-                               IsSelected="@(SelectedBox == currentBox && SelectedBoxSlot == slotNum)"
-                               OnSlotClick="@(() => SelectBoxSlot(currentBox, slotNum))"/>
+                    <div class="min-w-0">
+                        <TradeSlot Pokemon="@pkm"
+                                   OwnerSave="@saveFile"
+                                   IsSelected="@(SelectedBox == currentBox && SelectedBoxSlot == slotNum)"
+                                   OnSlotClick="@(() => SelectBoxSlot(currentBox, slotNum))"/>
+                    </div>
                 }
             </div>
         }
@@ -61,18 +65,27 @@
             <MudPaper Elevation="1"
                       Class="pa-2 mt-2">
                 @{
-                    var strings = GameInfo.Strings;
-                    var speciesName = AppService.GetPokemonSpeciesName(selected.Species) ?? "Unknown";
+                    // Per-save string tables — GameInfo.Strings / FilteredSources are filtered to
+                    // whichever save PKHeX last initialized against, so a Gen 1 Save A would mask
+                    // Gen 5 species in Save B. Look up names using each save's own language.
+                    var strings = GetStringsForSave(saveFile);
+                    var speciesName = selected.Species < strings.specieslist.Length
+                        ? strings.specieslist[selected.Species]
+                        : "Unknown";
                     var nickname = string.IsNullOrEmpty(selected.Nickname) ? speciesName : selected.Nickname;
-                    var natureName = strings.Natures.Count > (int)selected.Nature
-                        ? strings.Natures[(int)selected.Nature]
-                        : selected.Nature.ToString();
-                    var abilityName = strings.Ability.Count > selected.Ability
+                    var natureIdx = (int)selected.Nature;
+                    var natureName = natureIdx >= 0 && natureIdx < strings.Natures.Count
+                        ? strings.Natures[natureIdx]
+                        : null;
+                    var abilityName = selected.Ability >= 0 && selected.Ability < strings.Ability.Count
                         ? strings.Ability[selected.Ability]
-                        : selected.Ability.ToString();
-                    var heldItemName = selected.HeldItem > 0 && strings.Item.Count > selected.HeldItem
+                        : null;
+                    var heldItemName = selected.HeldItem > 0 && selected.HeldItem < strings.Item.Count
                         ? strings.Item[selected.HeldItem]
-                        : "(none)";
+                        : null;
+                    var hasNature = natureName is not null;
+                    var hasAbility = abilityName is not null;
+                    var hasHeldItem = heldItemName is not null;
                 }
                 <MudText Typo="@Typo.subtitle2">
                     @nickname
@@ -90,11 +103,20 @@
                         <span> · Egg</span>
                     }
                 </MudText>
+                @if (hasNature || hasAbility || hasHeldItem)
+                {
+                    <MudText Typo="@Typo.body2">
+                        @{
+                            var parts = new List<string>();
+                            if (hasNature) parts.Add($"Nature: {natureName}");
+                            if (hasAbility) parts.Add($"Ability: {abilityName}");
+                            parts.Add($"Held: {(hasHeldItem ? heldItemName : "(none)")}");
+                        }
+                        @string.Join(" · ", parts)
+                    </MudText>
+                }
                 <MudText Typo="@Typo.body2">
-                    Nature: @natureName · Ability: @abilityName · Held: @heldItemName
-                </MudText>
-                <MudText Typo="@Typo.body2">
-                    OT: @selected.OriginalTrainerName · TID: @selected.TID16 · SID: @selected.SID16
+                    OT: @selected.OriginalTrainerName · TID: @selected.TID16@(selected.SID16 > 0 ? $" · SID: {selected.SID16}" : string.Empty)
                 </MudText>
                 <MudText Typo="@Typo.body2"
                          Class="mt-1">

--- a/Pkmds.Rcl/Components/MainTabPages/TradePane.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TradePane.razor
@@ -17,7 +17,9 @@
                     : null;
                 <div class="min-w-0">
                     <TradeSlot Pokemon="@pkm"
+                               OwnerSaveFile="@saveFile"
                                OwnerVersion="@saveFile.Version"
+                               IsPartySlot="true"
                                IsSelected="@(SelectedPartySlot == slotNum)"
                                OnSlotClick="@(() => SelectParty(slotNum))"/>
                 </div>
@@ -68,6 +70,7 @@
                     var pkm = saveFile.GetBoxSlotAtIndex(currentBox, slotNum);
                     <div class="min-w-0">
                         <TradeSlot Pokemon="@pkm"
+                                   OwnerSaveFile="@saveFile"
                                    OwnerVersion="@saveFile.Version"
                                    IsSelected="@(SelectedBox == currentBox && SelectedBoxSlot == slotNum)"
                                    OnSlotClick="@(() => SelectBoxSlot(currentBox, slotNum))"/>

--- a/Pkmds.Rcl/Components/MainTabPages/TradePane.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradePane.razor.cs
@@ -55,8 +55,8 @@ public partial class TradePane : RefreshAwareComponent
 
     private static string BoxGridClass(SaveFile saveFile) =>
         saveFile.BoxSlotCount == 20
-            ? "grid grid-cols-4 grid-rows-5 gap-1 w-full max-w-80 mx-auto"
-            : "grid grid-cols-6 gap-1 w-full aspect-[6/5] mx-auto";
+            ? "grid grid-cols-4 gap-1 w-full max-w-80 mx-auto"
+            : "grid grid-cols-6 gap-1 w-full mx-auto";
 
     // Bypass GameInfo.FilteredSources (pinned to whichever save PKHeX last initialized
     // against) by going through the raw GameStrings table. Always use the app's current

--- a/Pkmds.Rcl/Components/MainTabPages/TradePane.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradePane.razor.cs
@@ -58,12 +58,11 @@ public partial class TradePane : RefreshAwareComponent
             ? "grid grid-cols-4 grid-rows-5 gap-1 w-full max-w-80 mx-auto"
             : "grid grid-cols-6 gap-1 w-full aspect-[6/5] mx-auto";
 
-    // SaveFile.Language is -1 for Gen 1/2 (no language field); fall back to the current
-    // app language so name lookups still succeed for those saves.
-    private static GameStrings GetStringsForSave(SaveFile saveFile) =>
-        GameInfo.GetStrings(saveFile.Language >= 0
-            ? GameLanguage.LanguageCode(saveFile.Language)
-            : GameInfo.CurrentLanguage);
+    // Bypass GameInfo.FilteredSources (pinned to whichever save PKHeX last initialized
+    // against) by going through the raw GameStrings table. Always use the app's current
+    // language — we don't want info-panel labels showing in the save's *game* language
+    // (e.g. Japanese names for a JP Blue save when the user's app is English).
+    private static GameStrings AppStrings => GameInfo.GetStrings(GameInfo.CurrentLanguage);
 
     internal PKM? SelectedPokemon
     {

--- a/Pkmds.Rcl/Components/MainTabPages/TradePane.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradePane.razor.cs
@@ -55,6 +55,29 @@ public partial class TradePane : RefreshAwareComponent
 
     private static string BoxGridClass(SaveFile saveFile) =>
         saveFile.BoxSlotCount == 20
-            ? "w-80 grid grid-cols-4 grid-rows-5 gap-1"
+            ? "grid grid-cols-4 grid-rows-5 gap-1 w-full max-w-80 mx-auto"
             : "grid grid-cols-6 gap-1 w-full aspect-[6/5] mx-auto";
+
+    internal PKM? SelectedPokemon
+    {
+        get
+        {
+            if (SaveFile is not { } sav)
+            {
+                return null;
+            }
+
+            if (SelectedPartySlot is { } partySlot && partySlot < sav.PartyCount)
+            {
+                return sav.GetPartySlotAtIndex(partySlot);
+            }
+
+            if (SelectedBox is { } boxNum && SelectedBoxSlot is { } boxSlot)
+            {
+                return sav.GetBoxSlotAtIndex(boxNum, boxSlot);
+            }
+
+            return null;
+        }
+    }
 }

--- a/Pkmds.Rcl/Components/MainTabPages/TradePane.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradePane.razor.cs
@@ -58,6 +58,13 @@ public partial class TradePane : RefreshAwareComponent
             ? "grid grid-cols-4 grid-rows-5 gap-1 w-full max-w-80 mx-auto"
             : "grid grid-cols-6 gap-1 w-full aspect-[6/5] mx-auto";
 
+    // SaveFile.Language is -1 for Gen 1/2 (no language field); fall back to the current
+    // app language so name lookups still succeed for those saves.
+    private static GameStrings GetStringsForSave(SaveFile saveFile) =>
+        GameInfo.GetStrings(saveFile.Language >= 0
+            ? GameLanguage.LanguageCode(saveFile.Language)
+            : GameInfo.CurrentLanguage);
+
     internal PKM? SelectedPokemon
     {
         get

--- a/Pkmds.Rcl/Components/MainTabPages/TradePane.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradePane.razor.cs
@@ -1,0 +1,60 @@
+namespace Pkmds.Rcl.Components.MainTabPages;
+
+public partial class TradePane : RefreshAwareComponent
+{
+    [Parameter]
+    [EditorRequired]
+    public string Title { get; set; } = string.Empty;
+
+    [Parameter]
+    public SaveFile? SaveFile { get; set; }
+
+    [Parameter]
+    public int? SelectedBox { get; set; }
+
+    [Parameter]
+    public EventCallback<int?> SelectedBoxChanged { get; set; }
+
+    [Parameter]
+    public int? SelectedBoxSlot { get; set; }
+
+    [Parameter]
+    public EventCallback<int?> SelectedBoxSlotChanged { get; set; }
+
+    [Parameter]
+    public int? SelectedPartySlot { get; set; }
+
+    [Parameter]
+    public EventCallback<int?> SelectedPartySlotChanged { get; set; }
+
+    private async Task SelectBox(int boxNum)
+    {
+        SelectedBox = boxNum;
+        SelectedBoxSlot = null;
+        await SelectedBoxChanged.InvokeAsync(boxNum);
+        await SelectedBoxSlotChanged.InvokeAsync(null);
+    }
+
+    private async Task SelectBoxSlot(int boxNum, int slotNum)
+    {
+        SelectedBox = boxNum;
+        SelectedBoxSlot = slotNum;
+        SelectedPartySlot = null;
+        await SelectedBoxChanged.InvokeAsync(boxNum);
+        await SelectedBoxSlotChanged.InvokeAsync(slotNum);
+        await SelectedPartySlotChanged.InvokeAsync(null);
+    }
+
+    private async Task SelectParty(int slotNum)
+    {
+        SelectedPartySlot = slotNum;
+        SelectedBoxSlot = null;
+        await SelectedPartySlotChanged.InvokeAsync(slotNum);
+        await SelectedBoxSlotChanged.InvokeAsync(null);
+    }
+
+    private static string BoxGridClass(SaveFile saveFile) =>
+        saveFile.BoxSlotCount == 20
+            ? "w-80 grid grid-cols-4 grid-rows-5 gap-1"
+            : "grid grid-cols-6 gap-1 w-full aspect-[6/5] mx-auto";
+}

--- a/Pkmds.Rcl/Components/MainTabPages/TradePane.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradePane.razor.cs
@@ -64,6 +64,19 @@ public partial class TradePane : RefreshAwareComponent
     // (e.g. Japanese names for a JP Blue save when the user's app is English).
     private static GameStrings AppStrings => GameInfo.GetStrings(GameInfo.CurrentLanguage);
 
+    private static int GetBoxPokemonCount(SaveFile saveFile, int boxNumber)
+    {
+        var count = 0;
+        for (var i = 0; i < saveFile.BoxSlotCount; i++)
+        {
+            if (saveFile.GetBoxSlotAtIndex(boxNumber, i) is { Species: > 0 })
+            {
+                count++;
+            }
+        }
+        return count;
+    }
+
     internal PKM? SelectedPokemon
     {
         get

--- a/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor
@@ -28,7 +28,7 @@
             @if (highResUrl is not null)
             {
                 <img @key="@((Pokemon.Species, Pokemon.Form, Pokemon.GetFormArgument(0), isShiny, lastLoadedIsFemale, AppState.SpriteStyle))"
-                     class="@($"pkm-sprite-hires {GetHiResSizeClass()} {(highResLoaded ? "pkm-sprite-hires--loaded" : string.Empty)}")"
+                     class="@($"pkm-sprite-hires {(highResLoaded ? "pkm-sprite-hires--loaded" : string.Empty)}")"
                      src="@highResUrl"
                      title="@title"
                      alt="@title"

--- a/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor
@@ -8,7 +8,13 @@
         {
             var title = GetSpeciesTitle(Pokemon.Species);
             var isShiny = Pokemon.GetIsShinySafe();
+            var highResUrl = AppState.SpriteStyle == SpriteStyle.Game
+                ? ImageHelper.GetPokeApiVersionSpriteUrl(Pokemon.Species, Pokemon.Form,
+                    Pokemon.GetFormArgument(0), isShiny, Pokemon.Gender, OwnerVersion)
+                : ImageHelper.GetPokeApiHomeSpriteUrl(Pokemon.Species, Pokemon.Form,
+                    Pokemon.GetFormArgument(0), isShiny, Pokemon.Gender);
             <object class="pkm-sprite w-full h-auto object-contain block"
+                    style="@(highResLoaded ? "display:none" : string.Empty)"
                     type="image/png"
                     data="@ImageHelper.GetPokemonSpriteFilename(Pokemon)"
                     title="@title"
@@ -19,6 +25,17 @@
                      alt="@title"
                      draggable="false">
             </object>
+            @if (highResUrl is not null)
+            {
+                <img @key="@((Pokemon.Species, Pokemon.Form, Pokemon.GetFormArgument(0), isShiny, lastLoadedIsFemale, AppState.SpriteStyle))"
+                     class="@($"pkm-sprite-hires {GetHiResSizeClass()} {(highResLoaded ? "pkm-sprite-hires--loaded" : string.Empty)}")"
+                     src="@highResUrl"
+                     title="@title"
+                     alt="@title"
+                     draggable="false"
+                     @onload="OnHighResSpriteLoaded"
+                     @onerror="OnHighResSpriteError"/>
+            }
 
             @if (isShiny)
             {

--- a/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor
@@ -6,7 +6,7 @@
     <div class="w-full h-full aspect-square flex items-center justify-center overflow-hidden p-0 box-border border border-transparent relative">
         @if (Pokemon is { Species: > 0 })
         {
-            var title = AppService.GetPokemonSpeciesName(Pokemon.Species) ?? "Unknown";
+            var title = GetSpeciesTitle(Pokemon.Species);
             var isShiny = Pokemon.GetIsShinySafe();
             <object class="pkm-sprite w-full h-auto object-contain block"
                     type="image/png"

--- a/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor
@@ -1,0 +1,46 @@
+@inherits RefreshAwareComponent
+
+<MudPaper Elevation="3"
+          @onclick="@HandleClick"
+          Class="@($"square-slot {(IsSelected ? Constants.SelectedSlotClass : string.Empty)} {ImageHelper.GetSpriteCssClass(Pokemon)}")">
+    <div class="w-full h-full aspect-square flex items-center justify-center overflow-hidden p-0 box-border border border-transparent relative">
+        @if (Pokemon is { Species: > 0 })
+        {
+            var title = AppService.GetPokemonSpeciesName(Pokemon.Species) ?? "Unknown";
+            var isShiny = Pokemon.GetIsShinySafe();
+            <object class="pkm-sprite w-full h-auto object-contain block"
+                    type="image/png"
+                    data="@ImageHelper.GetPokemonSpriteFilename(Pokemon)"
+                    title="@title"
+                    draggable="false">
+                <img class="pkm-sprite w-full h-auto object-contain block"
+                     src="@ImageHelper.PokemonFallbackImageFileName"
+                     title="@title"
+                     alt="@title"
+                     draggable="false">
+            </object>
+
+            @if (isShiny)
+            {
+                <div class="shiny-indicator-icon"
+                     title="Shiny">
+                    <img src="@ImageHelper.GetShinyIndicatorSpriteFileName(ShinyExtensions.GetType(Pokemon) is Shiny.AlwaysSquare)"
+                         alt="Shiny"
+                         class="w-full h-full object-contain"
+                         draggable="false">
+                </div>
+            }
+
+            @if (!AppState.IsHaXEnabled && legalityStatus is { } status && ShouldShow(status))
+            {
+                <div class="legality-indicator-icon"
+                     title="@StatusTitle(status)">
+                    <MudIcon Icon="@StatusIcon(status)"
+                             Color="@StatusColor(status)"
+                             Class="w-full h-full"
+                             Style="font-size: 16px;"/>
+                </div>
+            }
+        }
+    </div>
+</MudPaper>

--- a/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor
@@ -50,12 +50,10 @@
 
             @if (!AppState.IsHaXEnabled && legalityStatus is { } status && ShouldShow(status))
             {
-                <div class="legality-indicator-icon"
+                <div class="@($"legality-indicator-icon {StatusClass(status)}")"
                      title="@StatusTitle(status)">
                     <MudIcon Icon="@StatusIcon(status)"
-                             Color="@StatusColor(status)"
-                             Class="w-full h-full"
-                             Style="font-size: 16px;"/>
+                             Style="font-size: 14px; color: white;"/>
                 </div>
             }
         }

--- a/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor.cs
@@ -2,6 +2,21 @@ namespace Pkmds.Rcl.Components.MainTabPages;
 
 public partial class TradeSlot : RefreshAwareComponent
 {
+    // Tracks which sprite combos have loaded high-res in this session to avoid re-flashing
+    // the bundled fallback when re-rendering. Shared with PokemonSlotComponent's tracking semantics
+    // but kept independent so a separate (species, ..., style) can be cached without stepping on it.
+    private static readonly
+        HashSet<(ushort Species, byte Form, uint FormArg, bool IsShiny, bool IsFemale, SpriteStyle Style)>
+        HighResLoadedSpecies = [];
+
+    private bool highResLoaded;
+    private byte lastLoadedForm;
+    private uint lastLoadedFormArg;
+    private bool lastLoadedIsFemale;
+    private bool lastLoadedIsShiny;
+    private ushort lastLoadedSpecies;
+    private SpriteStyle lastLoadedSpriteStyle;
+
     private LegalityStatus? legalityStatus;
 
     [Parameter]
@@ -13,6 +28,12 @@ public partial class TradeSlot : RefreshAwareComponent
     [Parameter]
     public EventCallback OnSlotClick { get; set; }
 
+    // Version of the save file owning this slot — Game-style high-res sprites are version-specific
+    // (e.g. RB vs YW Gen 1 art) so each pane passes its own save's Version instead of piggybacking
+    // on AppState.SaveFile which always points at Save A.
+    [Parameter]
+    public GameVersion OwnerVersion { get; set; } = GameVersion.Any;
+
     // Resolve a species name via the full per-language table (GameInfo.GetStrings),
     // bypassing GameInfo.FilteredSources — the filtered source is pinned to whichever
     // save PKHeX last initialized against, so Gen 5 species render blank when Save A
@@ -23,7 +44,78 @@ public partial class TradeSlot : RefreshAwareComponent
         return species < names.Length ? names[species] : "Unknown";
     }
 
-    protected override void OnParametersSet() => ComputeLegality();
+    protected override void OnParametersSet()
+    {
+        ComputeLegality();
+        UpdateSpriteState();
+    }
+
+    private void UpdateSpriteState()
+    {
+        var currentIsShiny = Pokemon?.GetIsShinySafe() ?? false;
+        var currentForm = Pokemon?.Form ?? 0;
+        var currentFormArg = Pokemon?.GetFormArgument(0) ?? 0;
+        var currentIsFemale = Pokemon is not null && ImageHelper.HasFemaleHomeSprite(Pokemon.Species, Pokemon.Gender);
+        var currentSpriteStyle = AppState.SpriteStyle;
+        if (Pokemon?.Species == lastLoadedSpecies
+            && currentForm == lastLoadedForm
+            && currentFormArg == lastLoadedFormArg
+            && currentIsShiny == lastLoadedIsShiny
+            && currentIsFemale == lastLoadedIsFemale
+            && currentSpriteStyle == lastLoadedSpriteStyle)
+        {
+            return;
+        }
+
+        lastLoadedSpecies = Pokemon?.Species ?? 0;
+        lastLoadedForm = currentForm;
+        lastLoadedFormArg = currentFormArg;
+        lastLoadedIsShiny = currentIsShiny;
+        lastLoadedIsFemale = currentIsFemale;
+        lastLoadedSpriteStyle = currentSpriteStyle;
+        highResLoaded = lastLoadedSpecies > 0
+                        && HighResLoadedSpecies.Contains((lastLoadedSpecies, lastLoadedForm, lastLoadedFormArg,
+                            lastLoadedIsShiny, lastLoadedIsFemale, lastLoadedSpriteStyle));
+    }
+
+    // Gen 1/2 sprites are 40×40 and upscale; XY/ORAS are tightly cropped 60×60 and downscale slightly.
+    private string GetHiResSizeClass()
+    {
+        if (AppState.SpriteStyle != SpriteStyle.Game)
+        {
+            return string.Empty;
+        }
+
+        return OwnerVersion switch
+        {
+            GameVersion.RD or GameVersion.GN or GameVersion.BU
+                or GameVersion.RB or GameVersion.RBY or GameVersion.YW
+                or GameVersion.GD or GameVersion.GS or GameVersion.SI or GameVersion.C
+                => "pkm-sprite-hires--lg",
+            GameVersion.X or GameVersion.Y or GameVersion.OR or GameVersion.AS
+                => "pkm-sprite-hires--sm",
+            _ => string.Empty
+        };
+    }
+
+    // ReSharper disable once UnusedMember.Local
+    private void OnHighResSpriteLoaded()
+    {
+        highResLoaded = true;
+        if (lastLoadedSpecies > 0)
+        {
+            HighResLoadedSpecies.Add((lastLoadedSpecies, lastLoadedForm, lastLoadedFormArg, lastLoadedIsShiny,
+                lastLoadedIsFemale, lastLoadedSpriteStyle));
+        }
+
+        StateHasChanged();
+    }
+
+    // ReSharper disable once UnusedMember.Local
+    private static void OnHighResSpriteError()
+    {
+        /* keep showing the bundled sprite — highResLoaded is already false */
+    }
 
     private async Task HandleClick() => await OnSlotClick.InvokeAsync();
 

--- a/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor.cs
@@ -2,13 +2,8 @@ namespace Pkmds.Rcl.Components.MainTabPages;
 
 public partial class TradeSlot : RefreshAwareComponent
 {
-    // Tracks which sprite combos have loaded high-res in this session to avoid re-flashing
-    // the bundled fallback when re-rendering. Shared with PokemonSlotComponent's tracking semantics
-    // but kept independent so a separate (species, ..., style) can be cached without stepping on it.
-    private static readonly
-        HashSet<(ushort Species, byte Form, uint FormArg, bool IsShiny, bool IsFemale, SpriteStyle Style)>
-        HighResLoadedSpecies = [];
-
+    // Sprite cache is shared with PokemonSlotComponent via static helpers so the settings
+    // "Clear Sprite Cache" action (which targets PokemonSlotComponent) clears this too.
     private bool highResLoaded;
     private byte lastLoadedForm;
     private uint lastLoadedFormArg;
@@ -33,6 +28,14 @@ public partial class TradeSlot : RefreshAwareComponent
     // on AppState.SaveFile which always points at Save A.
     [Parameter]
     public GameVersion OwnerVersion { get; set; } = GameVersion.Any;
+
+    // Owning save file — used for legality analysis so Save B slots aren't adapted against
+    // AppState.SaveFile (which is always Save A).
+    [Parameter]
+    public SaveFile? OwnerSaveFile { get; set; }
+
+    [Parameter]
+    public bool IsPartySlot { get; set; }
 
     // Resolve a species name via the full per-language table (GameInfo.GetStrings),
     // bypassing GameInfo.FilteredSources — the filtered source is pinned to whichever
@@ -74,8 +77,8 @@ public partial class TradeSlot : RefreshAwareComponent
         lastLoadedIsFemale = currentIsFemale;
         lastLoadedSpriteStyle = currentSpriteStyle;
         highResLoaded = lastLoadedSpecies > 0
-                        && HighResLoadedSpecies.Contains((lastLoadedSpecies, lastLoadedForm, lastLoadedFormArg,
-                            lastLoadedIsShiny, lastLoadedIsFemale, lastLoadedSpriteStyle));
+                        && PokemonSlotComponent.IsHighResLoaded(lastLoadedSpecies, lastLoadedForm, lastLoadedFormArg,
+                            lastLoadedIsShiny, lastLoadedIsFemale, lastLoadedSpriteStyle);
     }
 
     // ReSharper disable once UnusedMember.Local
@@ -84,8 +87,8 @@ public partial class TradeSlot : RefreshAwareComponent
         highResLoaded = true;
         if (lastLoadedSpecies > 0)
         {
-            HighResLoadedSpecies.Add((lastLoadedSpecies, lastLoadedForm, lastLoadedFormArg, lastLoadedIsShiny,
-                lastLoadedIsFemale, lastLoadedSpriteStyle));
+            PokemonSlotComponent.MarkHighResLoaded(lastLoadedSpecies, lastLoadedForm, lastLoadedFormArg,
+                lastLoadedIsShiny, lastLoadedIsFemale, lastLoadedSpriteStyle);
         }
 
         StateHasChanged();
@@ -139,7 +142,19 @@ public partial class TradeSlot : RefreshAwareComponent
             return;
         }
 
-        var la = AppService.GetLegalityAnalysis(Pokemon);
+        // Analyse against the owning save so Save B slots aren't adapted to Save A.
+        // Mirrors AppService.GetLegalityAnalysis's adapt-on-write behaviour locally.
+        LegalityAnalysis la;
+        if (OwnerSaveFile is { } owner && Pokemon.GetType() == owner.PKMType)
+        {
+            var clone = Pokemon.Clone();
+            owner.AdaptToSaveFile(clone, IsPartySlot);
+            la = new LegalityAnalysis(clone);
+        }
+        else
+        {
+            la = new LegalityAnalysis(Pokemon);
+        }
         var hasInvalid = la.Results.Any(r => r.Judgement == PKHeX.Core.Severity.Invalid)
                          || !MoveResult.AllValid(la.Info.Moves)
                          || !MoveResult.AllValid(la.Info.Relearn);

--- a/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor.cs
@@ -78,26 +78,6 @@ public partial class TradeSlot : RefreshAwareComponent
                             lastLoadedIsShiny, lastLoadedIsFemale, lastLoadedSpriteStyle));
     }
 
-    // Gen 1/2 sprites are 40×40 and upscale; XY/ORAS are tightly cropped 60×60 and downscale slightly.
-    private string GetHiResSizeClass()
-    {
-        if (AppState.SpriteStyle != SpriteStyle.Game)
-        {
-            return string.Empty;
-        }
-
-        return OwnerVersion switch
-        {
-            GameVersion.RD or GameVersion.GN or GameVersion.BU
-                or GameVersion.RB or GameVersion.RBY or GameVersion.YW
-                or GameVersion.GD or GameVersion.GS or GameVersion.SI or GameVersion.C
-                => "pkm-sprite-hires--lg",
-            GameVersion.X or GameVersion.Y or GameVersion.OR or GameVersion.AS
-                => "pkm-sprite-hires--sm",
-            _ => string.Empty
-        };
-    }
-
     // ReSharper disable once UnusedMember.Local
     private void OnHighResSpriteLoaded()
     {

--- a/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor.cs
@@ -114,18 +114,21 @@ public partial class TradeSlot : RefreshAwareComponent
         _ => "Illegal"
     };
 
+    // Use solid glyphs rather than the *Circle / Cancel variants — those are drawn as
+    // cutouts and inherit the sprite behind them. The coloured disc comes from the
+    // wrapper's CSS class, so the glyph itself just needs to be a solid white symbol.
     private static string StatusIcon(LegalityStatus status) => status switch
     {
-        LegalityStatus.Legal => Icons.Material.Filled.CheckCircle,
-        LegalityStatus.Fishy => Icons.Material.Filled.Warning,
-        _ => Icons.Material.Filled.Cancel
+        LegalityStatus.Legal => Icons.Material.Filled.Check,
+        LegalityStatus.Fishy => Icons.Material.Filled.PriorityHigh,
+        _ => Icons.Material.Filled.Close
     };
 
-    private static Color StatusColor(LegalityStatus status) => status switch
+    private static string StatusClass(LegalityStatus status) => status switch
     {
-        LegalityStatus.Legal => Color.Success,
-        LegalityStatus.Fishy => Color.Warning,
-        _ => Color.Error
+        LegalityStatus.Legal => "legality-indicator-icon--legal",
+        LegalityStatus.Fishy => "legality-indicator-icon--fishy",
+        _ => "legality-indicator-icon--illegal"
     };
 
     private void ComputeLegality()

--- a/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor.cs
@@ -1,0 +1,72 @@
+namespace Pkmds.Rcl.Components.MainTabPages;
+
+public partial class TradeSlot : RefreshAwareComponent
+{
+    private LegalityStatus? legalityStatus;
+
+    [Parameter]
+    public PKM? Pokemon { get; set; }
+
+    [Parameter]
+    public bool IsSelected { get; set; }
+
+    [Parameter]
+    public EventCallback OnSlotClick { get; set; }
+
+    protected override void OnParametersSet() => ComputeLegality();
+
+    private async Task HandleClick() => await OnSlotClick.InvokeAsync();
+
+    private bool ShouldShow(LegalityStatus status) => status switch
+    {
+        LegalityStatus.Legal => AppState.ShowLegalIndicator,
+        LegalityStatus.Fishy => AppState.ShowFishyIndicator,
+        LegalityStatus.Illegal => AppState.ShowIllegalIndicator,
+        _ => false
+    };
+
+    private static string StatusTitle(LegalityStatus status) => status switch
+    {
+        LegalityStatus.Legal => "Legal",
+        LegalityStatus.Fishy => "Fishy",
+        _ => "Illegal"
+    };
+
+    private static string StatusIcon(LegalityStatus status) => status switch
+    {
+        LegalityStatus.Legal => Icons.Material.Filled.CheckCircle,
+        LegalityStatus.Fishy => Icons.Material.Filled.Warning,
+        _ => Icons.Material.Filled.Cancel
+    };
+
+    private static Color StatusColor(LegalityStatus status) => status switch
+    {
+        LegalityStatus.Legal => Color.Success,
+        LegalityStatus.Fishy => Color.Warning,
+        _ => Color.Error
+    };
+
+    private void ComputeLegality()
+    {
+        if (Pokemon is not { Species: > 0 } || AppState.IsHaXEnabled)
+        {
+            legalityStatus = null;
+            return;
+        }
+
+        var la = AppService.GetLegalityAnalysis(Pokemon);
+        var hasInvalid = la.Results.Any(r => r.Judgement == PKHeX.Core.Severity.Invalid)
+                         || !MoveResult.AllValid(la.Info.Moves)
+                         || !MoveResult.AllValid(la.Info.Relearn);
+        if (hasInvalid)
+        {
+            legalityStatus = LegalityStatus.Illegal;
+            return;
+        }
+
+        var hasFishy = la.Results.Any(r => r.Judgement == PKHeX.Core.Severity.Fishy);
+        legalityStatus = hasFishy
+            ? LegalityStatus.Fishy
+            : LegalityStatus.Legal;
+    }
+}

--- a/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor.cs
@@ -13,6 +13,26 @@ public partial class TradeSlot : RefreshAwareComponent
     [Parameter]
     public EventCallback OnSlotClick { get; set; }
 
+    [Parameter]
+    public SaveFile? OwnerSave { get; set; }
+
+    // Resolve a species name using the owner save's language, bypassing
+    // GameInfo.FilteredSources (which is pinned to whichever save PKHeX last
+    // initialized against — can't name Gen 5 species when Save A is Gen 1).
+    internal string GetSpeciesTitle(ushort species)
+    {
+        if (OwnerSave is null)
+        {
+            return AppService.GetPokemonSpeciesName(species) ?? "Unknown";
+        }
+
+        var lang = OwnerSave.Language >= 0
+            ? GameLanguage.LanguageCode(OwnerSave.Language)
+            : GameInfo.CurrentLanguage;
+        var names = GameInfo.GetStrings(lang).specieslist;
+        return species < names.Length ? names[species] : "Unknown";
+    }
+
     protected override void OnParametersSet() => ComputeLegality();
 
     private async Task HandleClick() => await OnSlotClick.InvokeAsync();

--- a/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor.cs
@@ -13,23 +13,13 @@ public partial class TradeSlot : RefreshAwareComponent
     [Parameter]
     public EventCallback OnSlotClick { get; set; }
 
-    [Parameter]
-    public SaveFile? OwnerSave { get; set; }
-
-    // Resolve a species name using the owner save's language, bypassing
-    // GameInfo.FilteredSources (which is pinned to whichever save PKHeX last
-    // initialized against — can't name Gen 5 species when Save A is Gen 1).
-    internal string GetSpeciesTitle(ushort species)
+    // Resolve a species name via the full per-language table (GameInfo.GetStrings),
+    // bypassing GameInfo.FilteredSources — the filtered source is pinned to whichever
+    // save PKHeX last initialized against, so Gen 5 species render blank when Save A
+    // is Gen 1. Always use the app language, not the save's game language.
+    private static string GetSpeciesTitle(ushort species)
     {
-        if (OwnerSave is null)
-        {
-            return AppService.GetPokemonSpeciesName(species) ?? "Unknown";
-        }
-
-        var lang = OwnerSave.Language >= 0
-            ? GameLanguage.LanguageCode(OwnerSave.Language)
-            : GameInfo.CurrentLanguage;
-        var names = GameInfo.GetStrings(lang).specieslist;
+        var names = GameInfo.GetStrings(GameInfo.CurrentLanguage).specieslist;
         return species < names.Length ? names[species] : "Unknown";
     }
 

--- a/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor
@@ -14,8 +14,9 @@ else
         @* ── Slot A (read-only Phase 1) ── *@
         <MudItem xs="12"
                  lg="6"
-                 Style="max-width: 480px;">
-            <MudPaper Elevation="0">
+                 Style="max-width: 480px; min-width: 0;">
+            <MudPaper Elevation="0"
+                      Class="min-w-0">
                 <TradePane Title="@SlotATitle"
                            SaveFile="@AppState.SaveFile"
                            SelectedBox="@AppState.SelectedBoxNumber"
@@ -30,8 +31,9 @@ else
         @* ── Slot B ── *@
         <MudItem xs="12"
                  lg="6"
-                 Style="max-width: 480px;">
-            <MudPaper Elevation="0">
+                 Style="max-width: 480px; min-width: 0;">
+            <MudPaper Elevation="0"
+                      Class="min-w-0">
                 @if (AppState.SaveFileB is null)
                 {
                     <MudStack Spacing="2"

--- a/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor
@@ -8,6 +8,12 @@
 }
 else
 {
+    <MudAlert Severity="@Severity.Info"
+              Class="mb-2">
+        This tab is read-only for now — you can view both saves side-by-side, but
+        transfers between them will arrive in a future update.
+    </MudAlert>
+
     <MudGrid Spacing="2"
              Justify="@Justify.FlexStart">
 

--- a/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor
@@ -1,0 +1,85 @@
+@inherits RefreshAwareComponent
+
+@if (AppState.SaveFile is null)
+{
+    <MudAlert Severity="@Severity.Info">
+        Load a save file first to use the Trade tab.
+    </MudAlert>
+}
+else
+{
+    <MudGrid Spacing="2"
+             Justify="@Justify.FlexStart">
+
+        @* ── Slot A (read-only Phase 1) ── *@
+        <MudItem xs="12"
+                 lg="6"
+                 Style="max-width: 480px;">
+            <MudPaper Elevation="0">
+                <TradePane Title="@SlotATitle"
+                           SaveFile="@AppState.SaveFile"
+                           SelectedBox="@AppState.SelectedBoxNumber"
+                           SelectedBoxChanged="@(b => AppState.SelectedBoxNumber = b)"
+                           SelectedBoxSlot="@AppState.SelectedBoxSlotNumber"
+                           SelectedBoxSlotChanged="@(s => AppState.SelectedBoxSlotNumber = s)"
+                           SelectedPartySlot="@AppState.SelectedPartySlotNumber"
+                           SelectedPartySlotChanged="@(s => AppState.SelectedPartySlotNumber = s)"/>
+            </MudPaper>
+        </MudItem>
+
+        @* ── Slot B ── *@
+        <MudItem xs="12"
+                 lg="6"
+                 Style="max-width: 480px;">
+            <MudPaper Elevation="0">
+                @if (AppState.SaveFileB is null)
+                {
+                    <MudStack Spacing="2"
+                              AlignItems="@AlignItems.Start"
+                              Class="pa-3">
+                        <MudText Typo="@Typo.subtitle1">Second save</MudText>
+                        <MudText Typo="@Typo.body2">
+                            Load a second save file to view its party and boxes side-by-side
+                            with the first save. Phase 1 is read-only — transfers will arrive
+                            in a future update.
+                        </MudText>
+                        <MudButton Variant="@Variant.Filled"
+                                   Color="@Color.Primary"
+                                   StartIcon="@Icons.Material.Filled.UploadFile"
+                                   OnClick="@LoadSecondarySaveAsync"
+                                   Disabled="@isLoading">
+                            Load second save
+                        </MudButton>
+                    </MudStack>
+                }
+                else
+                {
+                    <MudStack Spacing="1">
+                        <MudStack Row
+                                  AlignItems="@AlignItems.Center"
+                                  Spacing="1">
+                            <MudSpacer/>
+                            <MudIconButton Icon="@Icons.Material.Filled.SwapHoriz"
+                                           OnClick="@LoadSecondarySaveAsync"
+                                           Disabled="@isLoading"
+                                           title="Replace second save"
+                                           Size="@Size.Small"/>
+                            <MudIconButton Icon="@Icons.Material.Filled.Close"
+                                           OnClick="@UnloadSecondarySave"
+                                           title="Close second save"
+                                           Size="@Size.Small"/>
+                        </MudStack>
+                        <TradePane Title="@SlotBTitle"
+                                   SaveFile="@AppState.SaveFileB"
+                                   SelectedBox="@AppState.SelectedBoxNumberB"
+                                   SelectedBoxChanged="@(b => AppState.SelectedBoxNumberB = b)"
+                                   SelectedBoxSlot="@AppState.SelectedBoxSlotNumberB"
+                                   SelectedBoxSlotChanged="@(s => AppState.SelectedBoxSlotNumberB = s)"
+                                   SelectedPartySlot="@AppState.SelectedPartySlotNumberB"
+                                   SelectedPartySlotChanged="@(s => AppState.SelectedPartySlotNumberB = s)"/>
+                    </MudStack>
+                }
+            </MudPaper>
+        </MudItem>
+    </MudGrid>
+}

--- a/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor.cs
@@ -1,0 +1,162 @@
+namespace Pkmds.Rcl.Components.MainTabPages;
+
+public partial class TradeTab : RefreshAwareComponent
+{
+    private bool isLoading;
+
+    [Inject]
+    private IBackupService BackupService { get; set; } = null!;
+
+    [Inject]
+    private ISettingsService SettingsService { get; set; } = null!;
+
+    [Inject]
+    private ILogger<TradeTab> Logger { get; set; } = null!;
+
+    private string SlotATitle =>
+        $"Slot A — {AppState.SaveFileName ?? "Loaded save"}";
+
+    private string SlotBTitle =>
+        $"Slot B — {AppState.SaveFileNameB ?? "Loaded save"}";
+
+    private async Task LoadSecondarySaveAsync()
+    {
+        const string message = "Choose a second save file";
+        var dialogParameters = new DialogParameters
+        {
+            { nameof(FileUploadDialog.Message), message }
+        };
+
+        var dialog = await DialogService.ShowAsync<FileUploadDialog>(
+            "Load Second Save File",
+            dialogParameters,
+            new DialogOptions { CloseOnEscapeKey = true, BackdropClick = false });
+
+        var result = await dialog.Result;
+        if (result is not { Data: IBrowserFile selectedFile })
+        {
+            return;
+        }
+
+        await LoadSecondarySaveFile(selectedFile);
+    }
+
+    private async Task LoadSecondarySaveFile(IBrowserFile selectedFile)
+    {
+        if (selectedFile.Size == 0)
+        {
+            await DialogService.ShowMessageBoxAsync("Error", "The selected file is empty.");
+            return;
+        }
+
+        var fileExtension = Path.GetExtension(selectedFile.Name);
+        if (fileExtension.Equals(".state", StringComparison.OrdinalIgnoreCase) ||
+            fileExtension.Equals(".savestate", StringComparison.OrdinalIgnoreCase))
+        {
+            await DialogService.ShowMessageBoxAsync("Wrong file type",
+                "This looks like an emulator save state, not a save file. " +
+                "Please export the actual save file from your emulator instead.");
+            return;
+        }
+
+        isLoading = true;
+        StateHasChanged();
+
+        SaveFile? loadedSave = null;
+        ManicEmuSaveHelper.ManicEmuSaveContext? manicContext = null;
+
+        try
+        {
+            await using var fileStream = selectedFile.OpenReadStream(Constants.MaxFileSize);
+            using var memoryStream = new MemoryStream();
+            await fileStream.CopyToAsync(memoryStream);
+            var data = memoryStream.ToArray();
+
+            if (SaveUtil.TryGetSaveFile(data, out var saveFile, selectedFile.Name))
+            {
+                if (!saveFile.State.Exportable)
+                {
+                    await DialogService.ShowMessageBoxAsync("Unsupported save file",
+                        "This save file cannot be loaded — it may be from an unsupported ROM hack or format.");
+                    return;
+                }
+
+                loadedSave = saveFile;
+            }
+            else if (ManicEmuSaveHelper.TryExtractSaveFromZip(data, selectedFile.Name, out saveFile, out var ctx))
+            {
+                if (!saveFile.State.Exportable)
+                {
+                    await DialogService.ShowMessageBoxAsync("Unsupported save file",
+                        "This save file cannot be loaded — it may be from an unsupported ROM hack or format.");
+                    return;
+                }
+
+                loadedSave = saveFile;
+                manicContext = ctx;
+            }
+            else
+            {
+                await DialogService.ShowMessageBoxAsync("Error",
+                    "The selected save file is invalid. If this save file came from a ROM hack, it is not supported.");
+                return;
+            }
+
+            // NOTE: Do NOT call ParseSettings.InitFromSaveFileData(loadedSave) here.
+            // That mutates global ParseSettings.ActiveTrainer and would break legality
+            // analysis on slot A. Slot B legality is read using the global settings already
+            // tuned to slot A's trainer; some handler-state checks may be slightly off for
+            // slot B Pokémon but Phase 1 is read-only so this is acceptable.
+
+            AppState.SaveFileB = loadedSave;
+            AppState.SaveFileNameB = selectedFile.Name;
+            AppState.BoxEditB?.LoadBox(loadedSave.CurrentBox);
+            AppState.SelectedBoxNumberB = loadedSave.CurrentBox;
+            AppState.SelectedBoxSlotNumberB = null;
+            AppState.SelectedPartySlotNumberB = null;
+
+            // Per-slot on-load backup. Identical contract to the slot-A load path:
+            // bytes come from the freshly loaded SaveFile (handles Manic EMU rebuild),
+            // metadata is keyed by filename + save metadata + source so slot A and slot B
+            // backups coexist in IndexedDB. EnforceRetentionAsync remains global —
+            // Phase 1 only ever produces one slot-B backup so the shared pool is fine.
+            if (SettingsService.Settings.IsAutoBackupEnabled)
+            {
+                try
+                {
+                    var rawSave = loadedSave.Write().ToArray();
+                    var backupBytes = manicContext is not null
+                        ? ManicEmuSaveHelper.RebuildZip(manicContext, rawSave)
+                        : rawSave;
+                    await BackupService.CreateBackupAsync(
+                        backupBytes, loadedSave, selectedFile.Name,
+                        isManicEmu: manicContext is not null, source: "auto");
+                    await BackupService.EnforceRetentionAsync(SettingsService.Settings.MaxBackupCount);
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogWarning(ex, "Auto-backup failed for slot-B {FileName}", selectedFile.Name);
+                }
+            }
+
+            Snackbar.Add($"Loaded second save: {selectedFile.Name}", Severity.Success);
+            RefreshService.Refresh();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error loading slot-B save file: {FileName}", selectedFile.Name);
+            await DialogService.ShowMessageBoxAsync("Error", $"Failed to load save: {ex.Message}");
+        }
+        finally
+        {
+            isLoading = false;
+            StateHasChanged();
+        }
+    }
+
+    private void UnloadSecondarySave()
+    {
+        AppState.SaveFileB = null;
+        RefreshService.Refresh();
+    }
+}

--- a/Pkmds.Rcl/Components/PokemonSlotComponent.razor.cs
+++ b/Pkmds.Rcl/Components/PokemonSlotComponent.razor.cs
@@ -50,6 +50,16 @@ public partial class PokemonSlotComponent : IDisposable
     /// <summary>Clears the session sprite cache, forcing all high-res sprites to reload.</summary>
     public static void ClearSpriteCache() => HighResLoadedSpecies.Clear();
 
+    /// <summary>Returns whether the given sprite combo has loaded high-res in this session.</summary>
+    public static bool IsHighResLoaded(ushort species, byte form, uint formArg, bool isShiny, bool isFemale,
+        SpriteStyle style) =>
+        HighResLoadedSpecies.Contains((species, form, formArg, isShiny, isFemale, style));
+
+    /// <summary>Marks the given sprite combo as high-res-loaded for this session.</summary>
+    public static void MarkHighResLoaded(ushort species, byte form, uint formArg, bool isShiny, bool isFemale,
+        SpriteStyle style) =>
+        HighResLoadedSpecies.Add((species, form, formArg, isShiny, isFemale, style));
+
     private async Task HandleClick() =>
         await OnSlotClick.InvokeAsync();
 
@@ -97,8 +107,8 @@ public partial class PokemonSlotComponent : IDisposable
         lastLoadedSpriteStyle = currentSpriteStyle;
         // If this combo has already loaded high-res in this session, skip the bundled sprite entirely.
         highResLoaded = lastLoadedSpecies > 0
-                        && HighResLoadedSpecies.Contains((lastLoadedSpecies, lastLoadedForm, lastLoadedFormArg,
-                            lastLoadedIsShiny, lastLoadedIsFemale, lastLoadedSpriteStyle));
+                        && IsHighResLoaded(lastLoadedSpecies, lastLoadedForm, lastLoadedFormArg,
+                            lastLoadedIsShiny, lastLoadedIsFemale, lastLoadedSpriteStyle);
     }
 
     // Gen I/II transparent sprites are 40×40 px — scale up to fill the slot.
@@ -128,8 +138,8 @@ public partial class PokemonSlotComponent : IDisposable
         highResLoaded = true;
         if (lastLoadedSpecies > 0)
         {
-            HighResLoadedSpecies.Add((lastLoadedSpecies, lastLoadedForm, lastLoadedFormArg, lastLoadedIsShiny,
-                lastLoadedIsFemale, lastLoadedSpriteStyle));
+            MarkHighResLoaded(lastLoadedSpecies, lastLoadedForm, lastLoadedFormArg, lastLoadedIsShiny,
+                lastLoadedIsFemale, lastLoadedSpriteStyle);
         }
 
         StateHasChanged();

--- a/Pkmds.Rcl/Components/SaveFileComponent.razor
+++ b/Pkmds.Rcl/Components/SaveFileComponent.razor
@@ -113,5 +113,11 @@ else
             </div>
         </MudTabPanel>
 
+        <MudTabPanel Text="Trade">
+            <div class="mt-3">
+                <TradeTab/>
+            </div>
+        </MudTabPanel>
+
     </MudTabs>
 }

--- a/Pkmds.Rcl/Components/SaveFileComponent.razor
+++ b/Pkmds.Rcl/Components/SaveFileComponent.razor
@@ -114,7 +114,7 @@ else
         </MudTabPanel>
 
         <MudTabPanel Text="Trade">
-            <div class="mt-3">
+            <div class="mt-3 trade-tab-content">
                 <TradeTab/>
             </div>
         </MudTabPanel>

--- a/Pkmds.Rcl/IAppState.cs
+++ b/Pkmds.Rcl/IAppState.cs
@@ -30,10 +30,28 @@ public interface IAppState
     string? SaveFileName { get; set; }
 
     /// <summary>
+    /// Gets or sets the secondary save file used by the cross-save Trade tab.
+    /// Independent from <see cref="SaveFile" />; remains null until the user explicitly
+    /// loads a second save from the Trade tab. Read-only in Phase 1 of the cross-save trade work.
+    /// </summary>
+    SaveFile? SaveFileB { get; set; }
+
+    /// <summary>
+    /// Gets or sets the original file name of the secondary (slot-B) save file.
+    /// </summary>
+    string? SaveFileNameB { get; set; }
+
+    /// <summary>
     /// Gets the box editor interface for the current save file.
     /// This provides access to box manipulation operations.
     /// </summary>
     BoxEdit? BoxEdit { get; }
+
+    /// <summary>
+    /// Gets the box editor interface for the secondary (slot-B) save file.
+    /// Null when no secondary save file is loaded.
+    /// </summary>
+    BoxEdit? BoxEditB { get; }
 
     /// <summary>
     /// Gets or sets the Pokémon currently stored in the clipboard for copy/paste operations.
@@ -57,6 +75,21 @@ public interface IAppState
     /// Null when no party slot is selected or when a box slot is selected.
     /// </summary>
     int? SelectedPartySlotNumber { get; set; }
+
+    /// <summary>
+    /// Gets or sets the slot-B currently selected box number (0-based index) on the Trade tab.
+    /// </summary>
+    int? SelectedBoxNumberB { get; set; }
+
+    /// <summary>
+    /// Gets or sets the slot-B currently selected box slot number (0-based index within a box).
+    /// </summary>
+    int? SelectedBoxSlotNumberB { get; set; }
+
+    /// <summary>
+    /// Gets or sets the slot-B currently selected party slot number (0-based index, 0-5).
+    /// </summary>
+    int? SelectedPartySlotNumberB { get; set; }
 
     /// <summary>
     /// Gets or sets whether the progress indicator should be displayed.

--- a/Pkmds.Rcl/Services/IRefreshService.cs
+++ b/Pkmds.Rcl/Services/IRefreshService.cs
@@ -59,6 +59,18 @@ public interface IRefreshService
     void RefreshTheme(bool isDarkMode);
 
     /// <summary>
+    /// Event triggered when the OS-level dark mode preference changes. Raised by the
+    /// top-level MudThemeProvider watcher so layouts can recompute their effective theme.
+    /// </summary>
+    event Action<bool>? OnSystemThemeChanged;
+
+    /// <summary>
+    /// Broadcasts a change to the OS-level dark mode preference.
+    /// </summary>
+    /// <param name="systemIsDarkMode">True if the OS is in dark mode.</param>
+    void RefreshSystemTheme(bool systemIsDarkMode);
+
+    /// <summary>
     /// Event triggered when a component should navigate to the Party/Box tab.
     /// </summary>
     event Action? OnRequestJumpToPartyBox;

--- a/Pkmds.Rcl/wwwroot/css/app.css
+++ b/Pkmds.Rcl/wwwroot/css/app.css
@@ -110,6 +110,11 @@ body, html {
     pointer-events: none;
     z-index: 10;
     filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.5));
+    /* Material's "Filled" check/cancel icons draw the symbol as a cutout, so it
+       inherits whatever is behind the icon (usually a Pokémon sprite). Paint a
+       white disc behind the icon so the symbol reads as solid white. */
+    background: white;
+    border-radius: 50%;
 }
 
 .egg-indicator-icon {

--- a/Pkmds.Rcl/wwwroot/css/app.css
+++ b/Pkmds.Rcl/wwwroot/css/app.css
@@ -112,9 +112,9 @@ body, html {
     filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.5));
     /* Material's "Filled" check/cancel icons draw the symbol as a cutout, so it
        inherits whatever is behind the icon (usually a Pokémon sprite). Paint a
-       white disc behind the icon so the symbol reads as solid white. */
-    background: white;
-    border-radius: 50%;
+       white disc — sized to the icon's inner circle rather than the full bounding
+       box — so the symbol reads as solid white without a big white halo. */
+    background: radial-gradient(circle, white 0 42%, transparent 44%);
 }
 
 .egg-indicator-icon {

--- a/Pkmds.Rcl/wwwroot/css/app.css
+++ b/Pkmds.Rcl/wwwroot/css/app.css
@@ -15,7 +15,6 @@ body, html {
 
 .pkm-sprite-hires {
     position: absolute;
-    width: 80%;
     left: 50%;
     top: 50%;
     transform: translate(-50%, -50%);
@@ -110,12 +109,20 @@ body, html {
     pointer-events: none;
     z-index: 10;
     filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.5));
-    /* Material's "Filled" check/cancel icons draw the symbol as a cutout, so it
-       inherits whatever is behind the icon (usually a Pokémon sprite). Paint a
-       white disc — sized to the icon's inner circle rather than the full bounding
-       box — so the symbol reads as solid white without a big white halo. */
-    background: radial-gradient(circle, white 0 42%, transparent 44%);
+    /* Material's "Filled" CheckCircle / Cancel icons are cutouts — the symbol shows
+       whatever is behind the icon. Instead of painting a disc behind them, the
+       markup uses solid symbols (Check / PriorityHigh / Close) inside a coloured
+       disc wrapper: the disc provides the circle, the glyph is drawn solid white. */
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
 }
+
+.legality-indicator-icon--legal { background: var(--mud-palette-success); }
+.legality-indicator-icon--fishy { background: var(--mud-palette-warning); }
+.legality-indicator-icon--illegal { background: var(--mud-palette-error); }
 
 .egg-indicator-icon {
     position: absolute;

--- a/Pkmds.Rcl/wwwroot/css/app.css
+++ b/Pkmds.Rcl/wwwroot/css/app.css
@@ -239,6 +239,14 @@ body, html {
         overflow: hidden;
     }
 
+    /* Trade tab content: the parent .mud-tab-panel has overflow:hidden, which would
+       clip the last row of box slots when no Pokémon is selected (no info panel to
+       compress the grid into place). Let this scroll so the full content is reachable. */
+    .trade-tab-content {
+        height: 100%;
+        overflow-y: auto;
+    }
+
     /* Bank tab: the tab panel becomes a flex column so the card grid can
        fill remaining vertical space without a fragile calc() offset. */
     .save-file-outer-tabs > .mud-tabs-panels > .mud-tab-panel:has(.bank-tab-content) {

--- a/Pkmds.Tests/AdvancedSearchTests.cs
+++ b/Pkmds.Tests/AdvancedSearchTests.cs
@@ -246,6 +246,12 @@ public class AdvancedSearchTests
         public bool ShowLegalIndicator { get; set; } = true;
         public bool ShowFishyIndicator { get; set; } = true;
         public bool ShowIllegalIndicator { get; set; } = true;
+        public SaveFile? SaveFileB { get; set; }
+        public string? SaveFileNameB { get; set; }
+        public BoxEdit? BoxEditB => null;
+        public int? SelectedBoxNumberB { get; set; }
+        public int? SelectedBoxSlotNumberB { get; set; }
+        public int? SelectedPartySlotNumberB { get; set; }
     }
 
     private sealed class TestRefreshService : IRefreshService

--- a/Pkmds.Tests/AdvancedSearchTests.cs
+++ b/Pkmds.Tests/AdvancedSearchTests.cs
@@ -276,6 +276,10 @@ public class AdvancedSearchTests
         {
         }
 
+        public void RefreshSystemTheme(bool systemIsDarkMode)
+        {
+        }
+
         public void ShowUpdateMessage()
         {
         }
@@ -290,6 +294,7 @@ public class AdvancedSearchTests
         public event Action? OnPartyStateChanged;
         public event Action? OnUpdateAvailable;
         public event Action<bool>? OnThemeChanged;
+        public event Action<bool>? OnSystemThemeChanged;
         public event Action? OnRequestJumpToPartyBox;
 #pragma warning restore CS0067
     }

--- a/Pkmds.Tests/AppServiceTests.cs
+++ b/Pkmds.Tests/AppServiceTests.cs
@@ -417,6 +417,10 @@ public class AppServiceTests
         {
         }
 
+        public void RefreshSystemTheme(bool systemIsDarkMode)
+        {
+        }
+
         public void ShowUpdateMessage()
         {
         }
@@ -431,6 +435,7 @@ public class AppServiceTests
         public event Action? OnPartyStateChanged;
         public event Action? OnUpdateAvailable;
         public event Action<bool>? OnThemeChanged;
+        public event Action<bool>? OnSystemThemeChanged;
         public event Action? OnRequestJumpToPartyBox;
 #pragma warning restore CS0067
     }

--- a/Pkmds.Tests/AppServiceTests.cs
+++ b/Pkmds.Tests/AppServiceTests.cs
@@ -393,6 +393,12 @@ public class AppServiceTests
         public bool ShowLegalIndicator { get; set; } = true;
         public bool ShowFishyIndicator { get; set; } = true;
         public bool ShowIllegalIndicator { get; set; } = true;
+        public SaveFile? SaveFileB { get; set; }
+        public string? SaveFileNameB { get; set; }
+        public BoxEdit? BoxEditB => null;
+        public int? SelectedBoxNumberB { get; set; }
+        public int? SelectedBoxSlotNumberB { get; set; }
+        public int? SelectedPartySlotNumberB { get; set; }
     }
 
     private class TestRefreshService : IRefreshService

--- a/Pkmds.Tests/BoxManagementTests.cs
+++ b/Pkmds.Tests/BoxManagementTests.cs
@@ -107,6 +107,12 @@ public class BoxManagementTests
         public bool ShowLegalIndicator { get; set; } = true;
         public bool ShowFishyIndicator { get; set; } = true;
         public bool ShowIllegalIndicator { get; set; } = true;
+        public SaveFile? SaveFileB { get; set; }
+        public string? SaveFileNameB { get; set; }
+        public BoxEdit? BoxEditB => null;
+        public int? SelectedBoxNumberB { get; set; }
+        public int? SelectedBoxSlotNumberB { get; set; }
+        public int? SelectedPartySlotNumberB { get; set; }
     }
 
     private class TestRefreshService : IRefreshService

--- a/Pkmds.Tests/BoxManagementTests.cs
+++ b/Pkmds.Tests/BoxManagementTests.cs
@@ -131,6 +131,10 @@ public class BoxManagementTests
         {
         }
 
+        public void RefreshSystemTheme(bool systemIsDarkMode)
+        {
+        }
+
         public void ShowUpdateMessage()
         {
         }
@@ -145,6 +149,7 @@ public class BoxManagementTests
         public event Action? OnPartyStateChanged;
         public event Action? OnUpdateAvailable;
         public event Action<bool>? OnThemeChanged;
+        public event Action<bool>? OnSystemThemeChanged;
         public event Action? OnRequestJumpToPartyBox;
 #pragma warning restore CS0067
     }

--- a/Pkmds.Tests/BunitTestHelpers.cs
+++ b/Pkmds.Tests/BunitTestHelpers.cs
@@ -94,6 +94,7 @@ internal class TestRefreshService : IRefreshService
     public void RefreshPartyState() { }
     public void RefreshBoxAndPartyState() { }
     public void RefreshTheme(bool isDarkMode) { }
+    public void RefreshSystemTheme(bool systemIsDarkMode) { }
     public void ShowUpdateMessage() { }
     public void RequestJumpToPartyBox() { }
 
@@ -103,6 +104,7 @@ internal class TestRefreshService : IRefreshService
     public event Action? OnPartyStateChanged;
     public event Action? OnUpdateAvailable;
     public event Action<bool>? OnThemeChanged;
+    public event Action<bool>? OnSystemThemeChanged;
     public event Action? OnRequestJumpToPartyBox;
 #pragma warning restore CS0067
 }

--- a/Pkmds.Tests/BunitTestHelpers.cs
+++ b/Pkmds.Tests/BunitTestHelpers.cs
@@ -77,6 +77,12 @@ internal class TestAppState : IAppState
     public bool ShowLegalIndicator { get; set; } = true;
     public bool ShowFishyIndicator { get; set; } = true;
     public bool ShowIllegalIndicator { get; set; } = true;
+    public SaveFile? SaveFileB { get; set; }
+    public string? SaveFileNameB { get; set; }
+    public BoxEdit? BoxEditB => null;
+    public int? SelectedBoxNumberB { get; set; }
+    public int? SelectedBoxSlotNumberB { get; set; }
+    public int? SelectedPartySlotNumberB { get; set; }
 }
 
 internal class TestRefreshService : IRefreshService

--- a/Pkmds.Tests/EncounterDatabaseTests.cs
+++ b/Pkmds.Tests/EncounterDatabaseTests.cs
@@ -218,6 +218,12 @@ public class EncounterDatabaseTests
         public bool ShowLegalIndicator { get; set; } = true;
         public bool ShowFishyIndicator { get; set; } = true;
         public bool ShowIllegalIndicator { get; set; } = true;
+        public SaveFile? SaveFileB { get; set; }
+        public string? SaveFileNameB { get; set; }
+        public BoxEdit? BoxEditB => null;
+        public int? SelectedBoxNumberB { get; set; }
+        public int? SelectedBoxSlotNumberB { get; set; }
+        public int? SelectedPartySlotNumberB { get; set; }
     }
 
     private sealed class TestRefreshService : IRefreshService

--- a/Pkmds.Tests/EncounterDatabaseTests.cs
+++ b/Pkmds.Tests/EncounterDatabaseTests.cs
@@ -248,6 +248,10 @@ public class EncounterDatabaseTests
         {
         }
 
+        public void RefreshSystemTheme(bool systemIsDarkMode)
+        {
+        }
+
         public void ShowUpdateMessage()
         {
         }
@@ -262,6 +266,7 @@ public class EncounterDatabaseTests
         public event Action? OnPartyStateChanged;
         public event Action? OnUpdateAvailable;
         public event Action<bool>? OnThemeChanged;
+        public event Action<bool>? OnSystemThemeChanged;
         public event Action? OnRequestJumpToPartyBox;
 #pragma warning restore CS0067
     }

--- a/Pkmds.Tests/EvolveTests.cs
+++ b/Pkmds.Tests/EvolveTests.cs
@@ -416,6 +416,7 @@ public class EvolveTests
         public event Action? OnPartyStateChanged { add { } remove { } }
         public event Action? OnUpdateAvailable { add { } remove { } }
         public event Action<bool>? OnThemeChanged { add { } remove { } }
+        public event Action<bool>? OnSystemThemeChanged { add { } remove { } }
         public event Action? OnRequestJumpToPartyBox { add { } remove { } }
 
         public void Refresh() { }
@@ -423,6 +424,7 @@ public class EvolveTests
         public void RefreshPartyState() { }
         public void RefreshBoxAndPartyState() { }
         public void RefreshTheme(bool isDarkMode) { }
+        public void RefreshSystemTheme(bool systemIsDarkMode) { }
         public void ShowUpdateMessage() { }
         public void RequestJumpToPartyBox() { }
     }

--- a/Pkmds.Tests/EvolveTests.cs
+++ b/Pkmds.Tests/EvolveTests.cs
@@ -401,6 +401,12 @@ public class EvolveTests
         public bool ShowLegalIndicator { get; set; } = true;
         public bool ShowFishyIndicator { get; set; } = true;
         public bool ShowIllegalIndicator { get; set; } = true;
+        public SaveFile? SaveFileB { get; set; }
+        public string? SaveFileNameB { get; set; }
+        public BoxEdit? BoxEditB => null;
+        public int? SelectedBoxNumberB { get; set; }
+        public int? SelectedBoxSlotNumberB { get; set; }
+        public int? SelectedPartySlotNumberB { get; set; }
     }
 
     private sealed class TestRefreshService : IRefreshService

--- a/Pkmds.Tests/HaXModeTests.cs
+++ b/Pkmds.Tests/HaXModeTests.cs
@@ -171,5 +171,11 @@ public class HaXModeTests
         public bool ShowLegalIndicator { get; set; } = true;
         public bool ShowFishyIndicator { get; set; } = true;
         public bool ShowIllegalIndicator { get; set; } = true;
+        public SaveFile? SaveFileB { get; set; }
+        public string? SaveFileNameB { get; set; }
+        public BoxEdit? BoxEditB => null;
+        public int? SelectedBoxNumberB { get; set; }
+        public int? SelectedBoxSlotNumberB { get; set; }
+        public int? SelectedPartySlotNumberB { get; set; }
     }
 }

--- a/Pkmds.Tests/LegalityCheckerTests.cs
+++ b/Pkmds.Tests/LegalityCheckerTests.cs
@@ -96,7 +96,7 @@ public class LegalityCheckerTests
             }
         }
 
-        foundCandidate:
+    foundCandidate:
 
         pkm.Should().NotBeNull("Black full completion save must have at least one non-shiny box Pokémon");
 
@@ -249,6 +249,12 @@ public class LegalityCheckerTests
         public bool ShowLegalIndicator { get; set; } = true;
         public bool ShowFishyIndicator { get; set; } = true;
         public bool ShowIllegalIndicator { get; set; } = true;
+        public SaveFile? SaveFileB { get; set; }
+        public string? SaveFileNameB { get; set; }
+        public BoxEdit? BoxEditB => null;
+        public int? SelectedBoxNumberB { get; set; }
+        public int? SelectedBoxSlotNumberB { get; set; }
+        public int? SelectedPartySlotNumberB { get; set; }
     }
 
     private class TestRefreshService : IRefreshService

--- a/Pkmds.Tests/LegalityCheckerTests.cs
+++ b/Pkmds.Tests/LegalityCheckerTests.cs
@@ -264,6 +264,7 @@ public class LegalityCheckerTests
         public void RefreshPartyState() { }
         public void RefreshBoxAndPartyState() { }
         public void RefreshTheme(bool isDarkMode) { }
+        public void RefreshSystemTheme(bool systemIsDarkMode) { }
         public void ShowUpdateMessage() { }
         public void RequestJumpToPartyBox() { }
 
@@ -273,6 +274,7 @@ public class LegalityCheckerTests
         public event Action? OnPartyStateChanged;
         public event Action? OnUpdateAvailable;
         public event Action<bool>? OnThemeChanged;
+        public event Action<bool>? OnSystemThemeChanged;
         public event Action? OnRequestJumpToPartyBox;
 #pragma warning restore CS0067
     }

--- a/Pkmds.Tests/RefreshAwareComponentTests.cs
+++ b/Pkmds.Tests/RefreshAwareComponentTests.cs
@@ -140,6 +140,7 @@ public class RefreshAwareComponentTests
 
         public event Action? OnUpdateAvailable;
         public event Action<bool>? OnThemeChanged;
+        public event Action<bool>? OnSystemThemeChanged;
 
         public void Refresh() => _onAppStateChanged?.Invoke();
         public void RefreshBoxState() => _onBoxStateChanged?.Invoke();
@@ -152,6 +153,7 @@ public class RefreshAwareComponentTests
         }
 
         public void RefreshTheme(bool isDarkMode) => OnThemeChanged?.Invoke(isDarkMode);
+        public void RefreshSystemTheme(bool systemIsDarkMode) => OnSystemThemeChanged?.Invoke(systemIsDarkMode);
         public void ShowUpdateMessage() => OnUpdateAvailable?.Invoke();
 
         public event Action? OnRequestJumpToPartyBox;

--- a/Pkmds.Web/App.razor
+++ b/Pkmds.Web/App.razor
@@ -6,6 +6,16 @@
 @inject IDialogService DialogService
 @inject IAppState AppState
 
+@* Mud providers live OUTSIDE the ErrorBoundary so dialogs/snackbars/popovers      *@
+@* (and their themed styling) survive the ErrorBoundary firing. Without this, the *@
+@* crash-report dialog would have no provider to render into when the child tree  *@
+@* is unmounted, and would also lose theme CSS so it'd render unstyled.           *@
+<MudThemeProvider @ref="@mudThemeProvider"
+                  IsDarkMode="@isDarkMode"/>
+<MudPopoverProvider/>
+<MudDialogProvider BackdropClick="false"/>
+<MudSnackbarProvider/>
+
 <ErrorBoundary @ref="errorBoundary">
     <ChildContent>
         <Router AppAssembly="@typeof(MainLayout).Assembly"

--- a/Pkmds.Web/App.razor.cs
+++ b/Pkmds.Web/App.razor.cs
@@ -1,11 +1,32 @@
+using Microsoft.AspNetCore.Components;
 using MudBlazor;
 using Pkmds.Rcl.Components.Dialogs;
+using Pkmds.Rcl.Services;
 
 namespace Pkmds.Web;
 
-public partial class App
+public partial class App : IDisposable
 {
     private ErrorBoundary? errorBoundary;
+    private MudThemeProvider? mudThemeProvider;
+    private bool isDarkMode;
+
+    [Inject]
+    private IRefreshService RefreshService { get; set; } = null!;
+
+    public void Dispose()
+    {
+        RefreshService.OnThemeChanged -= HandleThemeChanged;
+    }
+
+    protected override void OnInitialized() =>
+        RefreshService.OnThemeChanged += HandleThemeChanged;
+
+    private void HandleThemeChanged(bool darkMode)
+    {
+        isDarkMode = darkMode;
+        StateHasChanged();
+    }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -15,36 +36,37 @@ public partial class App
         }
 
         await JsRuntime.InvokeVoidAsync("addUpdateListener");
+
+        if (mudThemeProvider is not null)
+        {
+            var systemIsDarkMode = await mudThemeProvider.GetSystemDarkModeAsync();
+            RefreshService.RefreshSystemTheme(systemIsDarkMode);
+            await mudThemeProvider.WatchSystemDarkModeAsync(OnSystemPreferenceChanged);
+        }
+    }
+
+    private Task OnSystemPreferenceChanged(bool newValue)
+    {
+        RefreshService.RefreshSystemTheme(newValue);
+        return Task.CompletedTask;
     }
 
     private async Task ShowCrashReportDialog(Exception? exception)
     {
-        try
+        var parameters = new DialogParameters
         {
-            var parameters = new DialogParameters { { nameof(BugReportDialog.HasSaveFile), AppState.SaveFile is not null }, { nameof(BugReportDialog.AppVersion), AppState.AppVersion ?? string.Empty }, { nameof(BugReportDialog.CapturedException), exception } };
-            var options = new DialogOptions { MaxWidth = MaxWidth.Small, FullWidth = true, CloseOnEscapeKey = false, BackdropClick = false };
-            var dialog = await DialogService.ShowAsync<BugReportDialog>("Report this crash", parameters, options);
-            await dialog.Result;
-        }
-        catch
+            { nameof(BugReportDialog.HasSaveFile), AppState.SaveFile is not null },
+            { nameof(BugReportDialog.AppVersion), AppState.AppVersion ?? string.Empty },
+            { nameof(BugReportDialog.CapturedException), exception },
+        };
+        var options = new DialogOptions
         {
-            // MudDialogProvider lives inside the ErrorBoundary's child content (via MainLayout).
-            // When the boundary fires, the entire child tree is unmounted — the dialog provider
-            // is gone and ShowAsync silently fails. Fall back to opening the GitHub new-issue
-            // page in a new tab with crash details pre-filled.
-            await OpenGitHubIssueAsync(exception);
-        }
-    }
-
-    private async Task OpenGitHubIssueAsync(Exception? exception)
-    {
-        var title = Uri.EscapeDataString($"[Crash] {exception?.GetType().Name}: {exception?.Message}");
-        var body = Uri.EscapeDataString(
-            $"**Version:** {AppState.AppVersion}\n\n" +
-            $"**Error:** `{exception?.GetType().Name}: {exception?.Message}`\n\n" +
-            $"**Stack trace:**\n```\n{exception?.StackTrace?.Trim()}\n```\n\n" +
-            "**Steps to reproduce:**\n*(Please describe what you were doing when this crash occurred)*");
-        var url = $"https://github.com/codemonkey85/PKMDS-Blazor/issues/new?title={title}&body={body}&labels=bug";
-        await JsRuntime.InvokeVoidAsync("window.open", url, "_blank");
+            MaxWidth = MaxWidth.Small,
+            FullWidth = true,
+            CloseOnEscapeKey = false,
+            BackdropClick = false,
+        };
+        var dialog = await DialogService.ShowAsync<BugReportDialog>("Report this crash", parameters, options);
+        await dialog.Result;
     }
 }

--- a/Pkmds.Web/AppState.cs
+++ b/Pkmds.Web/AppState.cs
@@ -50,7 +50,35 @@ public record AppState : IAppState
     public string? SaveFileName { get; set; }
 
     /// <inheritdoc />
+    public SaveFile? SaveFileB
+    {
+        get;
+        set
+        {
+            field = value;
+
+            BoxEditB = field is not null
+                ? new(field)
+                : null;
+
+            if (field is null)
+            {
+                SaveFileNameB = null;
+                SelectedBoxNumberB = null;
+                SelectedBoxSlotNumberB = null;
+                SelectedPartySlotNumberB = null;
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public string? SaveFileNameB { get; set; }
+
+    /// <inheritdoc />
     public BoxEdit? BoxEdit { get; private set; }
+
+    /// <inheritdoc />
+    public BoxEdit? BoxEditB { get; private set; }
 
     /// <inheritdoc />
     public int CurrentLanguageId => SaveFile?.Language ?? (int)LanguageID.English;
@@ -63,6 +91,15 @@ public record AppState : IAppState
 
     /// <inheritdoc />
     public int? SelectedPartySlotNumber { get; set; }
+
+    /// <inheritdoc />
+    public int? SelectedBoxNumberB { get; set; }
+
+    /// <inheritdoc />
+    public int? SelectedBoxSlotNumberB { get; set; }
+
+    /// <inheritdoc />
+    public int? SelectedPartySlotNumberB { get; set; }
 
     /// <inheritdoc />
     public bool ShowProgressIndicator { get; set; }

--- a/Pkmds.Web/Services/RefreshService.cs
+++ b/Pkmds.Web/Services/RefreshService.cs
@@ -35,6 +35,12 @@ public class RefreshService : IRefreshService
     public event Action<bool>? OnThemeChanged;
 
     /// <inheritdoc />
+    public event Action<bool>? OnSystemThemeChanged;
+
+    /// <inheritdoc />
+    public void RefreshSystemTheme(bool systemIsDarkMode) => OnSystemThemeChanged?.Invoke(systemIsDarkMode);
+
+    /// <inheritdoc />
     void IRefreshService.ShowUpdateMessage() => ShowUpdateMessage();
 
     /// <inheritdoc />


### PR DESCRIPTION
## Summary
- Adds slot-B state fields to `IAppState`/`AppState` (`SaveFileB`, `SaveFileNameB`, `BoxEditB`, `SelectedBoxNumberB`/`SlotNumberB`/`PartySlotNumberB`)
- New **Trade** `MudTabPanel` in `SaveFileComponent` with side-by-side read-only `TradePane` views (party row + box dropdown + grid + per-slot legality)
- Slot B loads via the tab itself with its own per-slot auto-backup (`source: "auto"`); `EnforceRetentionAsync` stays global per the Phase 1 plan
- No transfer logic yet — lands in Phase 2 (#711)

Closes #710. Parent: #14.

## Test plan
- [ ] Load a save into slot A → Trade tab is visible
- [ ] Open Trade tab → left pane shows slot A's party + box; right pane shows "Load second save" prompt
- [ ] Load a second save → right pane shows slot B's party + box; switch boxes; per-slot legality icons render
- [ ] Replace second save via swap icon; close it via X icon → prompt returns
- [ ] Confirm slot A's box/party tab still works (unaffected by slot-B selection state)
- [ ] Verify a backup entry is created for slot B in the Backup Manager

🤖 Generated with [Claude Code](https://claude.com/claude-code)