### PR TITLE
fix(bag): guard game-data lookups against out-of-range ids

### DIFF
--- a/Pkmds.Core/Utilities/SafeNameLookup.cs
+++ b/Pkmds.Core/Utilities/SafeNameLookup.cs
@@ -1,0 +1,29 @@
+namespace Pkmds.Core.Utilities;
+
+// ROM hacks can reference IDs outside the vanilla game's string tables.
+// These helpers return a stable fallback string instead of throwing IndexOutOfRangeException.
+public static class SafeNameLookup
+{
+    public static string Species(int id) =>
+        Get(GameInfo.Strings.specieslist, id, "Species");
+
+    public static string Ability(int id) =>
+        Get(GameInfo.Strings.abilitylist, id, "Ability");
+
+    public static string Item(int id) =>
+        Get(GameInfo.Strings.itemlist, id, "Item");
+
+    public static string Item(IReadOnlyList<string> itemList, int id) =>
+        Get(itemList, id, "Item");
+
+    public static string Move(int id) =>
+        Get(GameInfo.Strings.movelist, id, "Move");
+
+    public static string Nature(int id) =>
+        Get(GameInfo.Strings.natures, id, "Nature");
+
+    private static string Get(IReadOnlyList<string> table, int id, string label) =>
+        id >= 0 && id < table.Count && !string.IsNullOrEmpty(table[id])
+            ? table[id]
+            : $"({label} #{id:000})";
+}

--- a/Pkmds.Rcl/Components/EditForms/Tabs/MainTab.razor
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/MainTab.razor
@@ -456,7 +456,7 @@
                     Message="@HumanizeCheckResult(GetCheckResult(CheckIdentifier.Ability))"/>
                 <InfoButton>
                     <MudStack Spacing="2">
-                        <MudText Typo="@Typo.subtitle2">@(abilityInfo?.Name ?? GameInfo.Strings.abilitylist[Pokemon!.Ability])</MudText>
+                        <MudText Typo="@Typo.subtitle2">@(abilityInfo?.Name ?? SafeNameLookup.Ability(Pokemon!.Ability))</MudText>
                         <MudText Typo="@Typo.body2">@(abilityInfo is { Description: { Length: > 0 } desc }
                                 ? desc
                                 : "No description available.")</MudText>
@@ -489,7 +489,7 @@
                     Message="@HumanizeCheckResult(GetCheckResult(CheckIdentifier.Ability))"/>
                 <InfoButton>
                     <MudStack Spacing="2">
-                        <MudText Typo="@Typo.subtitle2">@(abilityInfo?.Name ?? GameInfo.Strings.abilitylist[Pokemon!.Ability])</MudText>
+                        <MudText Typo="@Typo.subtitle2">@(abilityInfo?.Name ?? SafeNameLookup.Ability(Pokemon!.Ability))</MudText>
                         <MudText Typo="@Typo.body2">@(abilityInfo is { Description: { Length: > 0 } desc }
                                 ? desc
                                 : "No description available.")</MudText>

--- a/Pkmds.Rcl/Components/EditForms/Tabs/MovesTab.razor
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/MovesTab.razor
@@ -344,11 +344,11 @@
                                  Color="@Color.Secondary">Ability
                         </MudText>
                         <MudText Typo="@Typo.body2">
-                            <b>@GameInfo.Strings.Ability[Pokemon.Ability]</b>
+                            <b>@SafeNameLookup.Ability(Pokemon.Ability)</b>
                         </MudText>
                         <InfoButton>
                             <MudStack Spacing="2">
-                                <MudText Typo="@Typo.subtitle2">@(abilityInfo?.Name ?? GameInfo.Strings.Ability[Pokemon.Ability])</MudText>
+                                <MudText Typo="@Typo.subtitle2">@(abilityInfo?.Name ?? SafeNameLookup.Ability(Pokemon.Ability))</MudText>
                                 <MudText Typo="@Typo.body2">@(abilityInfo is { Description: { Length: > 0 } desc }
                                         ? desc
                                         : "No description available.")</MudText>
@@ -365,7 +365,7 @@
                                  Color="@Color.Secondary">Nature
                         </MudText>
                         <MudText Typo="@Typo.body2">
-                            <b>@GameInfo.Strings.natures[(int)statNature]</b>
+                            <b>@SafeNameLookup.Nature((int)statNature)</b>
                         </MudText>
                         <MudText Typo="@Typo.caption">@AppService.GetStatModifierString(statNature)</MudText>
                     </MudStack>

--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
@@ -669,12 +669,12 @@ public partial class MainLayout : IDisposable
             var la = new LegalityAnalysis(editedPkm);
             if (la.Valid)
             {
-                Snackbar.Add($"{title}: {GameInfo.Strings.Species[editedPkm.Species]} imported successfully.", Severity.Success);
+                Snackbar.Add($"{title}: {SafeNameLookup.Species(editedPkm.Species)} imported successfully.", Severity.Success);
             }
             else
             {
                 Snackbar.Add(
-                    $"{title}: {GameInfo.Strings.Species[editedPkm.Species]} imported, but legality check flagged issues. " +
+                    $"{title}: {SafeNameLookup.Species(editedPkm.Species)} imported, but legality check flagged issues. " +
                     "Review the Pokémon in the editor.",
                     Severity.Warning);
             }
@@ -774,7 +774,7 @@ public partial class MainLayout : IDisposable
                 Logger.LogInformation("Mystery Gift Pokémon placed in slot successfully");
 
                 var la = new LegalityAnalysis(editedPkm);
-                var speciesName = GameInfo.Strings.Species[editedPkm.Species];
+                var speciesName = SafeNameLookup.Species(editedPkm.Species);
                 if (la.Valid)
                 {
                     Snackbar.Add($"{speciesName} received from Mystery Gift.", Severity.Success);
@@ -823,7 +823,7 @@ public partial class MainLayout : IDisposable
                 return true;
             }
 
-            var occupantName = GameInfo.Strings.Species[AppService.EditFormPokemon!.Species];
+            var occupantName = SafeNameLookup.Species(AppService.EditFormPokemon!.Species);
             var confirmed = await DialogService.ShowMessageBoxAsync(
                 "Overwrite Pokémon?",
                 $"The selected slot contains {occupantName}. Overwrite it?",

--- a/Pkmds.Rcl/Components/MainTabPages/AdvancedSearchTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/AdvancedSearchTab.razor.cs
@@ -140,7 +140,7 @@ public partial class AdvancedSearchTab : RefreshAwareComponent
         var abilityResults = await Task.WhenAll(
             distinctAbilityIds.Select(async id => (id, info: await DescriptionService.GetAbilityInfoAsync(id, version))));
         var heldItemResults = await Task.WhenAll(
-            distinctHeldItemIds.Select(async id => (id, info: await DescriptionService.GetItemInfoAsync(itemlist[id], version))));
+            distinctHeldItemIds.Select(async id => (id, info: await DescriptionService.GetItemInfoAsync(SafeNameLookup.Item(itemlist, id), version))));
         var ballResults = await Task.WhenAll(
             distinctBallIds.Select(async id =>
             {

--- a/Pkmds.Rcl/Components/MainTabPages/BagTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/BagTab.razor
@@ -88,16 +88,16 @@
                                                         type="image/png"
                                                         style="object-fit: contain;"
                                                         data="@ImageHelper.GetItemSpriteFilename(context.Item.Index, saveFile.Context)"
-                                                        title="@ItemList[context.Item.Index]">
+                                                        title="@GetItemName(context.Item.Index)">
                                                     <img class="pkm-sprite"
                                                          src="@ImageHelper.ItemFallbackImageFileName"
-                                                         title="@ItemList[context.Item.Index]"
-                                                         alt="@ItemList[context.Item.Index]">
+                                                         title="@GetItemName(context.Item.Index)"
+                                                         alt="@GetItemName(context.Item.Index)">
                                                 </object>
                                             }
-                                            <MudText>@ItemList[context.Item.Index]</MudText>
+                                            <MudText>@GetItemName(context.Item.Index)</MudText>
                                             <BagItemInfoButton ItemIndex="@context.Item.Index"
-                                                               ItemName="@ItemList[context.Item.Index]"
+                                                               ItemName="@GetItemName(context.Item.Index)"
                                                                PouchType="@pouch.Type"
                                                                Context="@saveFile.Context"
                                                                Version="@saveFile.Version"/>
@@ -112,7 +112,7 @@
                                                              Value="@GetItem(context)"
                                                              ValueChanged="@(newItem => SetItem(context, newItem))"
                                                              SearchFunc="@((searchString, _) => SearchItemNames(pouch, searchString))"
-                                                             ToStringFunc="@(_ => ItemList[context.Item.Index])">
+                                                             ToStringFunc="@(_ => GetItemName(context.Item.Index))">
                                                 <ItemTemplate Context="item">
                                                     <MudStack Row>
                                                         @if (item.Value != 0)
@@ -135,7 +135,7 @@
                                                 </ItemTemplate>
                                             </MudAutocomplete>
                                             <BagItemInfoButton ItemIndex="@context.Item.Index"
-                                                               ItemName="@ItemList[context.Item.Index]"
+                                                               ItemName="@GetItemName(context.Item.Index)"
                                                                PouchType="@pouch.Type"
                                                                Context="@saveFile.Context"
                                                                Version="@saveFile.Version"/>

--- a/Pkmds.Rcl/Components/MainTabPages/BagTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/BagTab.razor.cs
@@ -136,6 +136,12 @@ public partial class BagTab
         ?? ItemComboCache.GetValueOrDefault(0)
         ?? FallbackComboItem;
 
+    // ROM hacks can reference item IDs outside the vanilla item table; guard against out-of-range indices.
+    private string GetItemName(int index) =>
+        index >= 0 && index < ItemList.Length
+            ? ItemList[index]
+            : $"(Item #{index:000})";
+
     private static void SetItem(CellContext<InventoryItem> context, ComboItem item) =>
         context.Item.Index = item.Value;
 

--- a/Pkmds.Rcl/Components/MainTabPages/EncounterDatabaseTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/EncounterDatabaseTab.razor.cs
@@ -185,7 +185,7 @@ public partial class EncounterDatabaseTab : RefreshAwareComponent
                 return true;
             }
 
-            var occupantName = GameInfo.Strings.Species[AppService.EditFormPokemon!.Species];
+            var occupantName = SafeNameLookup.Species(AppService.EditFormPokemon!.Species);
             var confirmed = await DialogService.ShowMessageBoxAsync(
                 "Overwrite Pokémon?",
                 $"The selected slot contains {occupantName}. Overwrite it?",

--- a/Pkmds.Rcl/Components/MainTabPages/Pokedex/PokedexSpeciesGrid.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/Pokedex/PokedexSpeciesGrid.razor
@@ -81,7 +81,7 @@
                  RowClassFunc="@((_, i) => i % 2 != 0
                                    ? "row-alt"
                                    : string.Empty)"
-                 Height="@($"calc(100dvh - {(regionalDexDefinitions.Count > 0 ? 400 : 350)}px)")">
+                 Height="100%">
 
         <Columns>
             <PropertyColumn Property="@(r => r.SpeciesId)"

--- a/Pkmds.Rcl/Components/MainTabPages/Pokedex/PokedexSpeciesGrid.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/Pokedex/PokedexSpeciesGrid.razor
@@ -81,7 +81,7 @@
                  RowClassFunc="@((_, i) => i % 2 != 0
                                    ? "row-alt"
                                    : string.Empty)"
-                 Height="100%">
+                 Class="pokedex-species-grid">
 
         <Columns>
             <PropertyColumn Property="@(r => r.SpeciesId)"

--- a/Pkmds.Rcl/Components/MainTabPages/PokedexTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/PokedexTab.razor
@@ -3,7 +3,7 @@
 @if (AppState.SaveFile is { HasPokeDex: true })
 {
     <div class="pokedex-tab-content">
-        <MudStack>
+        <MudStack Style="height: 100%">
             <MudText Typo="@Typo.body2">Seen: @displaySeenCount / @dexTotal</MudText>
             <MudProgressLinear Color="@Color.Info"
                                Value="@seenPercent"/>
@@ -178,15 +178,17 @@
                     break;
             }
 
-            @if (AppState.SaveFile is SAV8LA)
-            {
-                <PokedexLaResearchPanel RefreshToken="@gridRefreshToken"/>
-            }
-            else
-            {
-                <PokedexSpeciesGrid RefreshToken="@gridRefreshToken"
-                                    OnSpeciesChanged="@OnSpeciesChangedInGrid"/>
-            }
+            <div class="pokedex-grid-wrapper">
+                @if (AppState.SaveFile is SAV8LA)
+                {
+                    <PokedexLaResearchPanel RefreshToken="@gridRefreshToken"/>
+                }
+                else
+                {
+                    <PokedexSpeciesGrid RefreshToken="@gridRefreshToken"
+                                        OnSpeciesChanged="@OnSpeciesChangedInGrid"/>
+                }
+            </div>
         </MudStack>
     </div>
 }

--- a/Pkmds.Rcl/wwwroot/css/app.css
+++ b/Pkmds.Rcl/wwwroot/css/app.css
@@ -299,11 +299,21 @@ body, html {
         flex: 1;
         min-height: 0;
         overflow: hidden;
+        display: flex;
+        flex-direction: column;
     }
 
-    .pokedex-grid-wrapper .pokedex-species-grid,
+    .pokedex-grid-wrapper .pokedex-species-grid {
+        flex: 1;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+    }
+
     .pokedex-grid-wrapper .pokedex-species-grid > .mud-table-container {
-        height: 100%;
+        flex: 1;
+        min-height: 0;
+        overflow-y: auto;
     }
 
     /* Teams tab content: simple vertical scroll for team cards */

--- a/Pkmds.Rcl/wwwroot/css/app.css
+++ b/Pkmds.Rcl/wwwroot/css/app.css
@@ -301,6 +301,11 @@ body, html {
         overflow: hidden;
     }
 
+    .pokedex-grid-wrapper .pokedex-species-grid,
+    .pokedex-grid-wrapper .pokedex-species-grid > .mud-table-container {
+        height: 100%;
+    }
+
     /* Teams tab content: simple vertical scroll for team cards */
     .teams-tab-content {
         height: 100%;

--- a/Pkmds.Rcl/wwwroot/css/app.css
+++ b/Pkmds.Rcl/wwwroot/css/app.css
@@ -295,6 +295,12 @@ body, html {
         overflow: hidden;
     }
 
+    .pokedex-grid-wrapper {
+        flex: 1;
+        min-height: 0;
+        overflow: hidden;
+    }
+
     /* Teams tab content: simple vertical scroll for team cards */
     .teams-tab-content {
         height: 100%;


### PR DESCRIPTION
## Summary
- Adds `SafeNameLookup` helper in `Pkmds.Core/Utilities/` with `Species`/`Ability`/`Item`/`Move`/`Nature` methods that fall back to `(Label #NNN)` when the id is outside the vanilla PKHeX string tables.
- Routes previously unchecked lookups in `BagTab`, `MainTab`, `MovesTab`, `MainLayout`, `EncounterDatabaseTab`, and `AdvancedSearchTab` through the helper so ROM-hack saves (e.g. Modern Emerald) no longer crash the UI.
- Fixes `IndexOutOfRangeException` in `BagTab` reported against a Modern Emerald `.srm` save.

Closes #717

## Test plan
- [x] `dotnet build Pkmds.slnx -c Debug` — 0 warnings, 0 errors
- [ ] Load the Modern Emerald v3.3.1 save and open the Bag tab without crashing
- [ ] Verify vanilla Emerald saves still display correct item/species/ability names