### PR TITLE
feat(trade): cross-save single-mon transfer via EntityConverter (#711)

### DIFF
--- a/Pkmds.Rcl/Components/EditForms/Tabs/LegalityTab.razor.cs
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/LegalityTab.razor.cs
@@ -50,14 +50,14 @@ public partial class LegalityTab : IDisposable
     private bool HasRelearnMoveIssues => Analysis is { } la &&
                                          (!MoveResult.AllValid(la.Info.Relearn) ||
                                           la.Results.Any(r => r is
-                                              { Valid: false, Identifier: CheckIdentifier.RelearnMove }));
+                                          { Valid: false, Identifier: CheckIdentifier.RelearnMove }));
 
     private bool HasBallIssues => Analysis is { } la &&
                                   la.Results.Any(r => r is { Valid: false, Identifier: CheckIdentifier.Ball });
 
     private bool HasEncounterIssues => Analysis is { } la &&
                                        la.Results.Any(r => r is
-                                           { Valid: false, Identifier: CheckIdentifier.Encounter });
+                                       { Valid: false, Identifier: CheckIdentifier.Encounter });
 
     private bool HasMetLocationIssues => Analysis is { } la &&
                                          la.Results.Any(r => r is

--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
@@ -70,7 +70,7 @@ public partial class MainLayout : IDisposable
                 await Task.Delay(4000);
                 IsUpdateCheckFailed = false;
                 break;
-            // "found": JS already dispatched 'updateAvailable' → ShowUpdateMessage() sets IsUpdateAvailable = true
+                // "found": JS already dispatched 'updateAvailable' → ShowUpdateMessage() sets IsUpdateAvailable = true
         }
 
         StateHasChanged();

--- a/Pkmds.Rcl/Components/MainTabPages/TradePane.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TradePane.razor
@@ -18,6 +18,7 @@
                 <div class="min-w-0">
                     <TradeSlot Pokemon="@pkm"
                                OwnerSaveFile="@saveFile"
+                               CounterpartSaveFile="@CounterpartSaveFile"
                                OwnerVersion="@saveFile.Version"
                                IsPartySlot="true"
                                BoxNumber="@((int?)null)"
@@ -74,6 +75,7 @@
                     <div class="min-w-0">
                         <TradeSlot Pokemon="@pkm"
                                    OwnerSaveFile="@saveFile"
+                                   CounterpartSaveFile="@CounterpartSaveFile"
                                    OwnerVersion="@saveFile.Version"
                                    BoxNumber="@currentBox"
                                    SlotNumber="@slotNum"

--- a/Pkmds.Rcl/Components/MainTabPages/TradePane.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TradePane.razor
@@ -20,8 +20,11 @@
                                OwnerSaveFile="@saveFile"
                                OwnerVersion="@saveFile.Version"
                                IsPartySlot="true"
+                               BoxNumber="@((int?)null)"
+                               SlotNumber="@slotNum"
                                IsSelected="@(SelectedPartySlot == slotNum)"
-                               OnSlotClick="@(() => SelectParty(slotNum))"/>
+                               OnSlotClick="@(() => SelectParty(slotNum))"
+                               OnDrop="@OnSlotDrop"/>
                 </div>
             }
         </div>
@@ -72,8 +75,11 @@
                         <TradeSlot Pokemon="@pkm"
                                    OwnerSaveFile="@saveFile"
                                    OwnerVersion="@saveFile.Version"
+                                   BoxNumber="@currentBox"
+                                   SlotNumber="@slotNum"
                                    IsSelected="@(SelectedBox == currentBox && SelectedBoxSlot == slotNum)"
-                                   OnSlotClick="@(() => SelectBoxSlot(currentBox, slotNum))"/>
+                                   OnSlotClick="@(() => SelectBoxSlot(currentBox, slotNum))"
+                                   OnDrop="@OnSlotDrop"/>
                     </div>
                 }
             </div>

--- a/Pkmds.Rcl/Components/MainTabPages/TradePane.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradePane.razor.cs
@@ -27,6 +27,11 @@ public partial class TradePane : RefreshAwareComponent
     [Parameter]
     public EventCallback<int?> SelectedPartySlotChanged { get; set; }
 
+    // Fired when a Pokémon is dropped onto any slot in this pane. Propagated up to
+    // TradeTab, which reads the drag source from IDragDropService and runs the transfer.
+    [Parameter]
+    public EventCallback<TradeSlotTarget> OnSlotDrop { get; set; }
+
     private async Task SelectBox(int boxNum)
     {
         SelectedBox = boxNum;

--- a/Pkmds.Rcl/Components/MainTabPages/TradePane.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradePane.razor.cs
@@ -9,6 +9,11 @@ public partial class TradePane : RefreshAwareComponent
     [Parameter]
     public SaveFile? SaveFile { get; set; }
 
+    // The paired save in the Trade tab — forwarded to each TradeSlot so it can indicate
+    // which Pokémon are ineligible to transfer to the other pane.
+    [Parameter]
+    public SaveFile? CounterpartSaveFile { get; set; }
+
     [Parameter]
     public int? SelectedBox { get; set; }
 

--- a/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor
@@ -2,7 +2,7 @@
 
 <MudPaper Elevation="3"
           @onclick="@HandleClick"
-          Class="@($"square-slot {(IsSelected ? Constants.SelectedSlotClass : string.Empty)} {GetDragClass()} {ImageHelper.GetSpriteCssClass(Pokemon)}")">
+          Class="@($"square-slot {(IsSelected ? Constants.SelectedSlotClass : string.Empty)} {GetDragClass()} {(transferIneligibleReason is not null ? "slot-ineligible-transfer" : string.Empty)} {ImageHelper.GetSpriteCssClass(Pokemon)}")">
     <div draggable="@(IsDraggable() ? "true" : "false")"
          @ondragstart="@HandleDragStart"
          @ondragend="@HandleDragEnd"
@@ -10,6 +10,8 @@
          @ondrop="@HandleDrop"
          @ondrop:preventDefault="true"
          @ondrop:stopPropagation="true"
+         title="@transferIneligibleReason"
+         aria-label="@transferIneligibleReason"
          class="w-full h-full aspect-square flex items-center justify-center overflow-hidden p-0 box-border border border-transparent relative">
         @if (Pokemon is { Species: > 0 })
         {
@@ -60,6 +62,15 @@
                 <div class="@($"legality-indicator-icon {StatusClass(status)}")"
                      title="@StatusTitle(status)">
                     <MudIcon Icon="@StatusIcon(status)"
+                             Style="font-size: 14px; color: white;"/>
+                </div>
+            }
+
+            @if (transferIneligibleReason is { } ineligibleReason)
+            {
+                <div class="transfer-block-indicator-icon"
+                     title="@ineligibleReason">
+                    <MudIcon Icon="@Icons.Material.Filled.Block"
                              Style="font-size: 14px; color: white;"/>
                 </div>
             }

--- a/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor
@@ -2,8 +2,15 @@
 
 <MudPaper Elevation="3"
           @onclick="@HandleClick"
-          Class="@($"square-slot {(IsSelected ? Constants.SelectedSlotClass : string.Empty)} {ImageHelper.GetSpriteCssClass(Pokemon)}")">
-    <div class="w-full h-full aspect-square flex items-center justify-center overflow-hidden p-0 box-border border border-transparent relative">
+          Class="@($"square-slot {(IsSelected ? Constants.SelectedSlotClass : string.Empty)} {GetDragClass()} {ImageHelper.GetSpriteCssClass(Pokemon)}")">
+    <div draggable="@(IsDraggable() ? "true" : "false")"
+         @ondragstart="@HandleDragStart"
+         @ondragend="@HandleDragEnd"
+         @ondragover:preventDefault="true"
+         @ondrop="@HandleDrop"
+         @ondrop:preventDefault="true"
+         @ondrop:stopPropagation="true"
+         class="w-full h-full aspect-square flex items-center justify-center overflow-hidden p-0 box-border border border-transparent relative">
         @if (Pokemon is { Species: > 0 })
         {
             var title = GetSpeciesTitle(Pokemon.Species);

--- a/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor.cs
@@ -206,6 +206,29 @@ public partial class TradeSlot : RefreshAwareComponent
             return;
         }
 
+        // Silently reject drops of cross-save incompatible Pokémon — the source pane already
+        // dims these with a Block badge, so firing an error snackbar on drop would be noise.
+        // Same format-level rule as ComputeTransferEligibility; HaX mode bypasses the block
+        // to match the source-side dim behaviour.
+        if (!AppState.IsHaXEnabled
+            && DragDropService.DraggedPokemon is { Species: > 0 } dragged
+            && DragDropService.DragSourceSaveFile is { } dragSource
+            && !ReferenceEquals(dragSource, OwnerSaveFile))
+        {
+            if (dragSource is SAV7b || OwnerSaveFile is SAV7b)
+            {
+                DragDropService.ClearDrag();
+                return;
+            }
+
+            if (dragged.GetType() != OwnerSaveFile.PKMType
+                && !EntityConverter.IsConvertibleToFormat(dragged, OwnerSaveFile.Generation))
+            {
+                DragDropService.ClearDrag();
+                return;
+            }
+        }
+
         var target = new TradeSlotTarget(OwnerSaveFile, IsPartySlot, BoxNumber, SlotNumber);
         await OnDrop.InvokeAsync(target);
     }

--- a/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor.cs
@@ -13,6 +13,7 @@ public partial class TradeSlot : RefreshAwareComponent
     private SpriteStyle lastLoadedSpriteStyle;
 
     private LegalityStatus? legalityStatus;
+    private string? transferIneligibleReason;
 
     [Inject]
     private IDragDropService DragDropService { get; set; } = null!;
@@ -36,6 +37,11 @@ public partial class TradeSlot : RefreshAwareComponent
     // AppState.SaveFile (which is always Save A).
     [Parameter]
     public SaveFile? OwnerSaveFile { get; set; }
+
+    // The paired save in the Trade tab (if any). When set, the slot computes whether this
+    // Pokémon can be transferred to it and paints a dimmed / badged state when it can't.
+    [Parameter]
+    public SaveFile? CounterpartSaveFile { get; set; }
 
     [Parameter]
     public bool IsPartySlot { get; set; }
@@ -66,7 +72,43 @@ public partial class TradeSlot : RefreshAwareComponent
     protected override void OnParametersSet()
     {
         ComputeLegality();
+        ComputeTransferEligibility();
         UpdateSpriteState();
+    }
+
+    // Proactive eligibility hint. Only flags cases where the conversion is impossible at
+    // the *type/format* level — the user still sees an error snackbar for per-mon failures
+    // (e.g. DLC-gated species) that only surface during a real ConvertToType call. HaX mode
+    // disables the hint because the reflection fallback can force some of these through.
+    private void ComputeTransferEligibility()
+    {
+        transferIneligibleReason = null;
+
+        if (Pokemon is not { Species: > 0 } pk
+            || OwnerSaveFile is null
+            || CounterpartSaveFile is not { } counterpart
+            || AppState.IsHaXEnabled)
+        {
+            return;
+        }
+
+        // Let's Go transfers aren't wired up in either direction (see TradeTab.ExecuteTransferAsync).
+        if (OwnerSaveFile is SAV7b || counterpart is SAV7b)
+        {
+            transferIneligibleReason = "Transfers involving Let’s Go saves aren’t supported.";
+            return;
+        }
+
+        if (pk.GetType() == counterpart.PKMType)
+        {
+            return;
+        }
+
+        if (!EntityConverter.IsConvertibleToFormat(pk, counterpart.Generation))
+        {
+            transferIneligibleReason =
+                $"Can’t transfer {pk.GetType().Name} to {counterpart.PKMType.Name} (incompatible generation).";
+        }
     }
 
     private void UpdateSpriteState()

--- a/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor.cs
@@ -99,15 +99,21 @@ public partial class TradeSlot : RefreshAwareComponent
             return;
         }
 
-        if (pk.GetType() == counterpart.PKMType)
-        {
-            return;
-        }
-
-        if (!EntityConverter.IsConvertibleToFormat(pk, counterpart.Generation))
+        if (pk.GetType() != counterpart.PKMType
+            && !EntityConverter.IsConvertibleToFormat(pk, counterpart.Generation))
         {
             transferIneligibleReason =
                 $"Can’t transfer {pk.GetType().Name} to {counterpart.PKMType.Name} (incompatible generation).";
+            return;
+        }
+
+        // Species/form availability in the destination game. IsConvertibleToFormat only
+        // covers the format-level transition (e.g. PK7→PK9); species that don't exist in
+        // the destination's dex (e.g. Zygarde in Scarlet/Violet) still need to be blocked.
+        if (!counterpart.Personal.IsPresentInGame(pk.Species, pk.Form))
+        {
+            transferIneligibleReason =
+                $"{GetSpeciesTitle(pk.Species)} can’t exist in {counterpart.Version} — species/form isn’t in that game’s dex.";
         }
     }
 
@@ -223,6 +229,12 @@ public partial class TradeSlot : RefreshAwareComponent
 
             if (dragged.GetType() != OwnerSaveFile.PKMType
                 && !EntityConverter.IsConvertibleToFormat(dragged, OwnerSaveFile.Generation))
+            {
+                DragDropService.ClearDrag();
+                return;
+            }
+
+            if (!OwnerSaveFile.Personal.IsPresentInGame(dragged.Species, dragged.Form))
             {
                 DragDropService.ClearDrag();
                 return;

--- a/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor.cs
@@ -14,6 +14,9 @@ public partial class TradeSlot : RefreshAwareComponent
 
     private LegalityStatus? legalityStatus;
 
+    [Inject]
+    private IDragDropService DragDropService { get; set; } = null!;
+
     [Parameter]
     public PKM? Pokemon { get; set; }
 
@@ -36,6 +39,19 @@ public partial class TradeSlot : RefreshAwareComponent
 
     [Parameter]
     public bool IsPartySlot { get; set; }
+
+    // Box/slot coordinates used by drag/drop. Box slots pass a non-null BoxNumber; party
+    // slots leave it null. SlotNumber is the index within that box or the party.
+    [Parameter]
+    public int? BoxNumber { get; set; }
+
+    [Parameter]
+    public int SlotNumber { get; set; }
+
+    // Fired when a Pokémon is dropped onto this slot. The receiver (TradeTab) reads the
+    // drag source from IDragDropService and routes to the transfer logic.
+    [Parameter]
+    public EventCallback<TradeSlotTarget> OnDrop { get; set; }
 
     // Resolve a species name via the full per-language table (GameInfo.GetStrings),
     // bypassing GameInfo.FilteredSources — the filtered source is pinned to whichever
@@ -101,6 +117,74 @@ public partial class TradeSlot : RefreshAwareComponent
     }
 
     private async Task HandleClick() => await OnSlotClick.InvokeAsync();
+
+    private bool IsDraggable()
+    {
+        if (Pokemon is not { Species: > 0 } || OwnerSaveFile is null)
+        {
+            return false;
+        }
+
+        // Drag and drop is not supported for Let's Go — mirrors PokemonSlotComponent.
+        if (OwnerSaveFile is SAV7b)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private void HandleDragStart(DragEventArgs e)
+    {
+        if (Pokemon is not { Species: > 0 } || OwnerSaveFile is null)
+        {
+            return;
+        }
+
+        DragDropService.StartDrag(Pokemon, OwnerSaveFile, BoxNumber, SlotNumber, IsPartySlot);
+        e.DataTransfer.EffectAllowed = "move";
+    }
+
+    private void HandleDragEnd(DragEventArgs e) => DragDropService.ClearDrag();
+
+    private async Task HandleDrop(DragEventArgs e)
+    {
+        if (!DragDropService.IsDragging || OwnerSaveFile is null)
+        {
+            return;
+        }
+
+        // Don't fire when dropping onto the exact same slot that the drag started from.
+        if (ReferenceEquals(DragDropService.DragSourceSaveFile, OwnerSaveFile)
+            && DragDropService.IsDragSourceParty == IsPartySlot
+            && DragDropService.DragSourceBoxNumber == BoxNumber
+            && DragDropService.DragSourceSlotNumber == SlotNumber)
+        {
+            DragDropService.ClearDrag();
+            return;
+        }
+
+        var target = new TradeSlotTarget(OwnerSaveFile, IsPartySlot, BoxNumber, SlotNumber);
+        await OnDrop.InvokeAsync(target);
+    }
+
+    private string GetDragClass()
+    {
+        if (!DragDropService.IsDragging)
+        {
+            return string.Empty;
+        }
+
+        if (ReferenceEquals(DragDropService.DragSourceSaveFile, OwnerSaveFile)
+            && DragDropService.IsDragSourceParty == IsPartySlot
+            && DragDropService.DragSourceBoxNumber == BoxNumber
+            && DragDropService.DragSourceSlotNumber == SlotNumber)
+        {
+            return "slot-dragging";
+        }
+
+        return string.Empty;
+    }
 
     private bool ShouldShow(LegalityStatus status) => status switch
     {

--- a/Pkmds.Rcl/Components/MainTabPages/TradeSlotTarget.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeSlotTarget.cs
@@ -1,0 +1,16 @@
+namespace Pkmds.Rcl.Components.MainTabPages;
+
+/// <summary>
+/// Identifies a slot in a Trade tab pane — used as the drop-target payload so
+/// <see cref="TradeTab" /> can route cross-save and intra-save transfers based on which
+/// save file owns the slot and whether it is a party or box slot.
+/// </summary>
+/// <param name="OwnerSaveFile">The save file that owns this slot (slot A or slot B).</param>
+/// <param name="IsParty">Whether this is a party slot.</param>
+/// <param name="BoxNumber">The 0-based box number (null for party slots or Let's Go).</param>
+/// <param name="SlotNumber">The 0-based slot index within the box or party.</param>
+public readonly record struct TradeSlotTarget(
+    SaveFile OwnerSaveFile,
+    bool IsParty,
+    int? BoxNumber,
+    int SlotNumber);

--- a/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor
@@ -8,16 +8,10 @@
 }
 else
 {
-    <MudAlert Severity="@Severity.Info"
-              Class="mb-2">
-        This tab is read-only for now — you can view both saves side-by-side, but
-        transfers between them will arrive in a future update.
-    </MudAlert>
-
     <MudGrid Spacing="2"
              Justify="@Justify.FlexStart">
 
-        @* ── Slot A (read-only Phase 1) ── *@
+        @* ── Slot A ── *@
         <MudItem xs="12"
                  lg="6"
                  Style="max-width: 480px; min-width: 0;">
@@ -30,7 +24,8 @@ else
                            SelectedBoxSlot="@AppState.SelectedBoxSlotNumber"
                            SelectedBoxSlotChanged="@(s => AppState.SelectedBoxSlotNumber = s)"
                            SelectedPartySlot="@AppState.SelectedPartySlotNumber"
-                           SelectedPartySlotChanged="@(s => AppState.SelectedPartySlotNumber = s)"/>
+                           SelectedPartySlotChanged="@(s => AppState.SelectedPartySlotNumber = s)"
+                           OnSlotDrop="@HandleSlotDropAsync"/>
             </MudPaper>
         </MudItem>
 
@@ -66,6 +61,16 @@ else
                         <MudStack Row
                                   AlignItems="@AlignItems.Center"
                                   Spacing="1">
+                            <MudIconButton Icon="@Icons.Material.Filled.ArrowBack"
+                                           OnClick="@(() => TransferSelectedAsync(fromA: false))"
+                                           Disabled="@(!CanTransferFromB())"
+                                           title="Send selected Pokémon from Slot B to Slot A"
+                                           Size="@Size.Small"/>
+                            <MudIconButton Icon="@Icons.Material.Filled.ArrowForward"
+                                           OnClick="@(() => TransferSelectedAsync(fromA: true))"
+                                           Disabled="@(!CanTransferFromA())"
+                                           title="Send selected Pokémon from Slot A to Slot B"
+                                           Size="@Size.Small"/>
                             <MudSpacer/>
                             <MudIconButton Icon="@Icons.Material.Filled.SwapHoriz"
                                            OnClick="@LoadSecondarySaveAsync"
@@ -84,7 +89,8 @@ else
                                    SelectedBoxSlot="@AppState.SelectedBoxSlotNumberB"
                                    SelectedBoxSlotChanged="@(s => AppState.SelectedBoxSlotNumberB = s)"
                                    SelectedPartySlot="@AppState.SelectedPartySlotNumberB"
-                                   SelectedPartySlotChanged="@(s => AppState.SelectedPartySlotNumberB = s)"/>
+                                   SelectedPartySlotChanged="@(s => AppState.SelectedPartySlotNumberB = s)"
+                                   OnSlotDrop="@HandleSlotDropAsync"/>
                     </MudStack>
                 }
             </MudPaper>

--- a/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor
@@ -82,7 +82,7 @@ else
                                            title="Replace second save"
                                            Size="@Size.Small"/>
                             <MudIconButton Icon="@Icons.Material.Filled.Close"
-                                           OnClick="@UnloadSecondarySave"
+                                           OnClick="@UnloadSecondarySaveAsync"
                                            title="Close second save"
                                            Size="@Size.Small"/>
                         </MudStack>

--- a/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor
@@ -42,9 +42,9 @@ else
                               Class="pa-3">
                         <MudText Typo="@Typo.subtitle1">Second save</MudText>
                         <MudText Typo="@Typo.body2">
-                            Load a second save file to view its party and boxes side-by-side
-                            with the first save. Phase 1 is read-only — transfers will arrive
-                            in a future update.
+                            Load a second save file to transfer Pokémon side-by-side with the
+                            first save. Drag a Pokémon between panes, or select one and use
+                            the arrow buttons to move it across.
                         </MudText>
                         <MudButton Variant="@Variant.Filled"
                                    Color="@Color.Primary"
@@ -72,6 +72,10 @@ else
                                            title="Send selected Pokémon from Slot A to Slot B"
                                            Size="@Size.Small"/>
                             <MudSpacer/>
+                            <MudIconButton Icon="@Icons.Material.Filled.IosShare"
+                                           OnClick="@ExportSecondarySaveAsync"
+                                           title="Export second save"
+                                           Size="@Size.Small"/>
                             <MudIconButton Icon="@Icons.Material.Filled.SwapHoriz"
                                            OnClick="@LoadSecondarySaveAsync"
                                            Disabled="@isLoading"

--- a/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor
@@ -19,6 +19,7 @@ else
                       Class="min-w-0">
                 <TradePane Title="@SlotATitle"
                            SaveFile="@AppState.SaveFile"
+                           CounterpartSaveFile="@AppState.SaveFileB"
                            SelectedBox="@AppState.SelectedBoxNumber"
                            SelectedBoxChanged="@(b => AppState.SelectedBoxNumber = b)"
                            SelectedBoxSlot="@AppState.SelectedBoxSlotNumber"
@@ -88,6 +89,7 @@ else
                         </MudStack>
                         <TradePane Title="@SlotBTitle"
                                    SaveFile="@AppState.SaveFileB"
+                                   CounterpartSaveFile="@AppState.SaveFile"
                                    SelectedBox="@AppState.SelectedBoxNumberB"
                                    SelectedBoxChanged="@(b => AppState.SelectedBoxNumberB = b)"
                                    SelectedBoxSlot="@AppState.SelectedBoxSlotNumberB"

--- a/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor.cs
@@ -871,12 +871,28 @@ public partial class TradeTab : RefreshAwareComponent
         _ = destSave;
 
         var severity = invalid ? "illegal" : "fishy";
-        var body = messages.Count > 0
-            ? $"The converted Pokémon is {severity}:\n\n• {string.Join("\n• ", messages)}\n\nProceed with the transfer?"
-            : $"The converted Pokémon is {severity}. Proceed with the transfer?";
+        // MudBlazor's message box collapses whitespace in plain strings, so a bulleted list
+        // has to be rendered as HTML via the MarkupString overload (same pattern as
+        // ConfirmHeldItemLossAsync) — otherwise the bullets all wrap onto one line.
+        var body = new StringBuilder();
+        if (messages.Count > 0)
+        {
+            body.Append("<p>The converted Pokémon is ").Append(severity).Append(":</p>");
+            body.Append("<ul style=\"margin:8px 0 0 0;padding-left:1.25rem;\">");
+            foreach (var msg in messages)
+            {
+                body.Append("<li>").Append(WebUtility.HtmlEncode(msg)).Append("</li>");
+            }
+            body.Append("</ul>");
+            body.Append("<p>Proceed with the transfer?</p>");
+        }
+        else
+        {
+            body.Append("<p>The converted Pokémon is ").Append(severity).Append(". Proceed with the transfer?</p>");
+        }
         var result = await DialogService.ShowMessageBoxAsync(
             invalid ? "Illegal after conversion" : "Fishy after conversion",
-            body,
+            new MarkupString(body.ToString()),
             yesText: "Transfer anyway",
             cancelText: "Cancel");
         return result == true;

--- a/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor.cs
@@ -513,8 +513,41 @@ public partial class TradeTab : RefreshAwareComponent
             return;
         }
 
+        // Held-item handling: the mon leaves its save, so its held item goes back to the
+        // source bag rather than riding along (EntityConverter can silently strip incompatible
+        // items across generations). We pre-check returnability so we can warn about losses
+        // up-front and let the user cancel to free up bag space; the actual deposit is deferred
+        // to the final commit so a cancellation at the legality step doesn't leave the bag
+        // out of sync with the slot state.
+        var srcHeldItem = (ushort)Math.Max(0, srcPkm.HeldItem);
+        var destHeldItem = destPkmPrev.Species > 0
+            ? (ushort)Math.Max(0, destPkmPrev.HeldItem)
+            : (ushort)0;
+
+        var itemLossLines = new List<string>(2);
+        if (srcHeldItem > 0 && !CanReturnItemToBag(srcSave, srcHeldItem))
+        {
+            itemLossLines.Add(DescribeHeldItem(srcPkm, srcSave, srcHeldItem));
+        }
+        if (destHeldItem > 0 && !CanReturnItemToBag(destSave, destHeldItem))
+        {
+            itemLossLines.Add(DescribeHeldItem(destPkmPrev, destSave, destHeldItem));
+        }
+
+        if (itemLossLines.Count > 0)
+        {
+            var proceedLoss = await ConfirmHeldItemLossAsync(itemLossLines);
+            if (!proceedLoss)
+            {
+                return;
+            }
+        }
+
         var haxEnabled = AppState.IsHaXEnabled;
-        var converted = ConvertForSave(srcPkm.Clone(), destSave, haxEnabled, out var forwardMessage);
+        var srcClone = srcPkm.Clone();
+        srcClone.HeldItem = 0;
+
+        var converted = ConvertForSave(srcClone, destSave, haxEnabled, out var forwardMessage);
         if (converted is null)
         {
             ShowTransferIssueSnackbar("Could not transfer", forwardMessage,
@@ -529,7 +562,9 @@ public partial class TradeTab : RefreshAwareComponent
         PKM? convertedBack = null;
         if (destPkmPrev.Species > 0)
         {
-            convertedBack = ConvertForSave(destPkmPrev.Clone(), srcSave, haxEnabled, out var reverseMessage);
+            var destClone = destPkmPrev.Clone();
+            destClone.HeldItem = 0;
+            convertedBack = ConvertForSave(destClone, srcSave, haxEnabled, out var reverseMessage);
             if (convertedBack is null)
             {
                 ShowTransferIssueSnackbar("Swap not possible", reverseMessage,
@@ -565,6 +600,18 @@ public partial class TradeTab : RefreshAwareComponent
                 RefreshService.Refresh();
                 return;
             }
+        }
+
+        // Transfer is committed — now deposit the held items we pre-checked. Items the user
+        // agreed to lose (CanReturnItemToBag returned false) are simply dropped: HeldItem was
+        // already cleared on the clones, so they don't ride along to the destination save.
+        if (srcHeldItem > 0)
+        {
+            ReturnItemToBag(srcSave, srcHeldItem);
+        }
+        if (destHeldItem > 0)
+        {
+            ReturnItemToBag(destSave, destHeldItem);
         }
 
         if (!string.IsNullOrEmpty(forwardMessage))
@@ -614,6 +661,108 @@ public partial class TradeTab : RefreshAwareComponent
         bullets.Append("</ul>");
 
         Snackbar.Add(new MarkupString(bullets.ToString()), severity);
+    }
+
+    // ── Held-item handoff ─────────────────────────────────────────────────────
+
+    // Pre-flight check: is there room in any compatible pouch of `save` to receive one more
+    // copy of `itemId`? Matches InventoryPouch.GiveItem's placement rules (existing slot with
+    // room, or first empty slot in a pouch that accepts the item). No side effects.
+    private static bool CanReturnItemToBag(SaveFile save, ushort itemId)
+    {
+        if (itemId == 0)
+        {
+            return true;
+        }
+
+        var bag = save.Inventory;
+        foreach (var pouch in bag.Pouches)
+        {
+            if (!pouch.CanContain(itemId))
+            {
+                continue;
+            }
+
+            var max = bag.GetMaxCount(pouch.Type, itemId);
+            if (max <= 0)
+            {
+                return false;
+            }
+
+            foreach (var item in pouch.Items)
+            {
+                if (item.Index == itemId && item.Count < max)
+                {
+                    return true;
+                }
+                if (item.Index == 0)
+                {
+                    return true;
+                }
+            }
+
+            // Item is allowed in this pouch but every eligible slot is taken or maxed out.
+            return false;
+        }
+
+        // No pouch in the bag accepts this item id (unsupported save or cross-gen item).
+        return false;
+    }
+
+    // Deposits one unit of `itemId` back into `save`'s bag and persists it. Assumed to be
+    // called only after CanReturnItemToBag returned true for the same (save, itemId) pair.
+    private static void ReturnItemToBag(SaveFile save, ushort itemId)
+    {
+        if (itemId == 0)
+        {
+            return;
+        }
+
+        var bag = save.Inventory;
+        foreach (var pouch in bag.Pouches)
+        {
+            if (!pouch.CanContain(itemId))
+            {
+                continue;
+            }
+
+            pouch.GiveItem(bag, itemId, 1);
+            bag.CopyTo(save);
+            return;
+        }
+    }
+
+    private string DescribeHeldItem(PKM pkm, SaveFile save, ushort itemId)
+    {
+        var strings = GameInfo.GetStrings(GameInfo.CurrentLanguage);
+        var speciesName = pkm.Species < strings.specieslist.Length
+            ? strings.specieslist[pkm.Species]
+            : $"Species #{pkm.Species}";
+        var itemName = itemId < strings.Item.Count
+            ? strings.Item[itemId]
+            : $"Item #{itemId}";
+        var bagLabel = ReferenceEquals(save, AppState.SaveFile) ? "Slot A" : "Slot B";
+        return $"{speciesName}’s {itemName} (from {bagLabel}’s bag)";
+    }
+
+    private async Task<bool> ConfirmHeldItemLossAsync(IReadOnlyList<string> lines)
+    {
+        var bullets = new StringBuilder();
+        bullets.Append("<p>These held items can’t be returned to their save’s bag and will be lost if you continue:</p>");
+        bullets.Append("<ul style=\"margin:8px 0 0 0;padding-left:1.25rem;\">");
+        foreach (var line in lines)
+        {
+            bullets.Append("<li>").Append(WebUtility.HtmlEncode(line)).Append("</li>");
+        }
+        bullets.Append("</ul>");
+        bullets.Append("<p>Cancel and make room in the bag to keep the item, or continue to transfer anyway.</p>");
+
+        var result = await DialogService.ShowMessageBoxAsync(
+            "Held items will be lost",
+            new MarkupString(bullets.ToString()),
+            yesText: "Continue",
+            cancelText: "Cancel");
+        return result == true;
     }
 
     private static PKM? ConvertForSave(PKM pkm, SaveFile destSave, bool haxEnabled, out string message)

--- a/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor.cs
@@ -517,10 +517,8 @@ public partial class TradeTab : RefreshAwareComponent
         var converted = ConvertForSave(srcPkm.Clone(), destSave, haxEnabled, out var forwardMessage);
         if (converted is null)
         {
-            Snackbar.Add(
-                string.IsNullOrEmpty(forwardMessage)
-                    ? "Could not convert the source Pokémon to the destination's format."
-                    : $"Could not transfer: {forwardMessage}",
+            ShowTransferIssueSnackbar("Could not transfer", forwardMessage,
+                "Could not convert the source Pokémon to the destination's format.",
                 Severity.Error);
             return;
         }
@@ -534,10 +532,8 @@ public partial class TradeTab : RefreshAwareComponent
             convertedBack = ConvertForSave(destPkmPrev.Clone(), srcSave, haxEnabled, out var reverseMessage);
             if (convertedBack is null)
             {
-                Snackbar.Add(
-                    string.IsNullOrEmpty(reverseMessage)
-                        ? "Could not convert the destination Pokémon back to the source's format for a swap."
-                        : $"Swap not possible: {reverseMessage}",
+                ShowTransferIssueSnackbar("Swap not possible", reverseMessage,
+                    "Could not convert the destination Pokémon back to the source's format for a swap.",
                     Severity.Error);
                 return;
             }
@@ -573,7 +569,8 @@ public partial class TradeTab : RefreshAwareComponent
 
         if (!string.IsNullOrEmpty(forwardMessage))
         {
-            Snackbar.Add($"Warning: {forwardMessage}", Severity.Warning);
+            ShowTransferIssueSnackbar("Warning", forwardMessage,
+                "The transfer succeeded with warnings.", Severity.Warning);
         }
 
         MarkSlotBDirtyIfInvolved(srcSave, destSave);
@@ -587,6 +584,36 @@ public partial class TradeTab : RefreshAwareComponent
         {
             AppState.HasUnsavedChangesB = true;
         }
+    }
+
+    // Render conversion errors/warnings as a bulleted list when PKHeX returns a multi-line
+    // message (e.g. "Cannot convert a PK7 to PK3\nCannot transfer this format..."). A plain
+    // snackbar string collapses the newline and looks like one run-on sentence, which is what
+    // prompted this. Falls back to a single-line snackbar when there's only one line.
+    private static readonly string[] MessageLineSeparators = ["\r\n", "\n", "\r"];
+
+    private void ShowTransferIssueSnackbar(string heading, string? details, string fallback, Severity severity)
+    {
+        var lines = string.IsNullOrWhiteSpace(details)
+            ? [fallback]
+            : details.Split(MessageLineSeparators, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        if (lines.Length <= 1)
+        {
+            Snackbar.Add($"{heading}: {lines[0]}", severity);
+            return;
+        }
+
+        var bullets = new StringBuilder();
+        bullets.Append("<strong>").Append(WebUtility.HtmlEncode(heading)).Append(":</strong>");
+        bullets.Append("<ul style=\"margin:4px 0 0 0;padding-left:1.25rem;\">");
+        foreach (var line in lines)
+        {
+            bullets.Append("<li>").Append(WebUtility.HtmlEncode(line)).Append("</li>");
+        }
+        bullets.Append("</ul>");
+
+        Snackbar.Add(new MarkupString(bullets.ToString()), severity);
     }
 
     private static PKM? ConvertForSave(PKM pkm, SaveFile destSave, bool haxEnabled, out string message)

--- a/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor.cs
@@ -513,12 +513,14 @@ public partial class TradeTab : RefreshAwareComponent
             return;
         }
 
-        // Held-item handling: the mon leaves its save, so its held item goes back to the
-        // source bag rather than riding along (EntityConverter can silently strip incompatible
-        // items across generations). We pre-check returnability so we can warn about losses
-        // up-front and let the user cancel to free up bag space; the actual deposit is deferred
-        // to the final commit so a cancellation at the legality step doesn't leave the bag
-        // out of sync with the slot state.
+        // Held-item handling: the mon leaves its save, so we strip its held item and return
+        // it to that same save's bag. The item came from that game's item table in the first
+        // place, so it normally fits — the failure cases are (1) the bag is full (no empty
+        // slot and the existing stack is already at max), or (2) a HaX-edited nonsense item
+        // ID no pouch recognizes. We pre-check returnability so we can warn the user up-front
+        // and let them cancel to free up bag space, and defer the actual deposit to the final
+        // commit so a cancellation at the legality step doesn't leave the bag out of sync
+        // with the slot state.
         var srcHeldItem = (ushort)Math.Max(0, srcPkm.HeldItem);
         var destHeldItem = destPkmPrev.Species > 0
             ? (ushort)Math.Max(0, destPkmPrev.HeldItem)

--- a/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor.cs
@@ -28,6 +28,21 @@ public partial class TradeTab : RefreshAwareComponent
 
     private async Task LoadSecondarySaveAsync()
     {
+        // Guard the replace path: if slot B has uncommitted transfers, give the user
+        // a chance to back out before the picker opens and we tear down the save.
+        if (AppState.SaveFileB is not null && AppState.HasUnsavedChangesB)
+        {
+            var proceed = await DialogService.ShowMessageBoxAsync(
+                "Unsaved changes in Slot B",
+                "Slot B has transfers that haven't been exported yet. Replacing it will discard those changes.",
+                yesText: "Discard and replace",
+                cancelText: "Cancel");
+            if (proceed != true)
+            {
+                return;
+            }
+        }
+
         const string message = "Choose a second save file";
         var dialogParameters = new DialogParameters
         {
@@ -162,8 +177,21 @@ public partial class TradeTab : RefreshAwareComponent
         }
     }
 
-    private void UnloadSecondarySave()
+    private async Task UnloadSecondarySaveAsync()
     {
+        if (AppState.HasUnsavedChangesB)
+        {
+            var proceed = await DialogService.ShowMessageBoxAsync(
+                "Unsaved changes in Slot B",
+                "Slot B has transfers that haven't been exported yet. Closing it will discard those changes.",
+                yesText: "Discard and close",
+                cancelText: "Cancel");
+            if (proceed != true)
+            {
+                return;
+            }
+        }
+
         AppState.SaveFileB = null;
         AppState.SaveFileNameB = null;
         manicEmuSaveContextB = null;
@@ -181,28 +209,36 @@ public partial class TradeTab : RefreshAwareComponent
         var rawSaveBytes = saveB.Write().ToArray();
         var originalName = AppState.SaveFileNameB;
 
+        bool wrote;
         // Same branching as MainLayout.ExportSaveFile — rebuild the Manic EMU ZIP
         // when the slot-B save came from one, otherwise preserve the original name.
         if (manicEmuSaveContextB is not null)
         {
             var (exportName, compoundExt) = ManicEmuSaveHelper.GetExportFileName(originalName);
             var zipBytes = ManicEmuSaveHelper.RebuildZip(manicEmuSaveContextB, rawSaveBytes);
-            await WriteSlotBFileAsync(zipBytes, exportName, compoundExt);
+            wrote = await WriteSlotBFileAsync(zipBytes, exportName, compoundExt);
         }
         else if (string.IsNullOrWhiteSpace(originalName))
         {
-            await WriteSlotBFileAsync(rawSaveBytes, "save.sav", ".sav");
+            wrote = await WriteSlotBFileAsync(rawSaveBytes, "save.sav", ".sav");
         }
         else
         {
             var ext = Path.GetExtension(originalName);
-            await WriteSlotBFileAsync(rawSaveBytes, originalName, ext);
+            wrote = await WriteSlotBFileAsync(rawSaveBytes, originalName, ext);
+        }
+
+        if (wrote)
+        {
+            AppState.HasUnsavedChangesB = false;
         }
     }
 
     // Minimal duplicate of MainLayout's WriteFile: File System Access API when supported,
-    // fall back to an anchor click for legacy browsers.
-    private async Task WriteSlotBFileAsync(byte[] data, string fileName, string fileTypeExtension)
+    // fall back to an anchor click for legacy browsers. Returns whether the file was
+    // actually written (false on user cancel or failure) so the caller knows whether
+    // to clear the dirty flag.
+    private async Task<bool> WriteSlotBFileAsync(byte[] data, string fileName, string fileTypeExtension)
     {
         if (!await FileSystemAccessService.IsSupportedAsync())
         {
@@ -214,23 +250,26 @@ public partial class TradeTab : RefreshAwareComponent
                 $"data:application/x-pokemon-savedata;base64,{base64}");
             await element.InvokeVoidAsync("setAttribute", "download", finalName);
             await element.InvokeVoidAsync("click");
-            return;
+            return true;
         }
 
         try
         {
             await JSRuntime.InvokeVoidAsync("showFilePickerAndWrite",
                 fileName, data, fileTypeExtension, "Save File");
+            return true;
         }
         catch (JSException ex) when (ex.Message.Contains("AbortError", StringComparison.OrdinalIgnoreCase)
                                      || ex.Message.Contains("aborted a request", StringComparison.OrdinalIgnoreCase))
         {
             // User dismissed the picker — not an error.
+            return false;
         }
         catch (JSException ex)
         {
             Logger.LogError(ex, "Error exporting slot-B save file: {FileName}", fileName);
             Snackbar.Add("Export failed. Please try again or use a different browser.", Severity.Error);
+            return false;
         }
     }
 
@@ -450,6 +489,7 @@ public partial class TradeTab : RefreshAwareComponent
                 return;
             }
 
+            MarkSlotBDirtyIfInvolved(srcSave, destSave);
             RefreshService.Refresh();
             return;
         }
@@ -536,7 +576,17 @@ public partial class TradeTab : RefreshAwareComponent
             Snackbar.Add($"Warning: {forwardMessage}", Severity.Warning);
         }
 
+        MarkSlotBDirtyIfInvolved(srcSave, destSave);
         RefreshService.Refresh();
+    }
+
+    private void MarkSlotBDirtyIfInvolved(SaveFile srcSave, SaveFile destSave)
+    {
+        if (AppState.SaveFileB is { } slotB
+            && (ReferenceEquals(srcSave, slotB) || ReferenceEquals(destSave, slotB)))
+        {
+            AppState.HasUnsavedChangesB = true;
+        }
     }
 
     private static PKM? ConvertForSave(PKM pkm, SaveFile destSave, bool haxEnabled, out string message)

--- a/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor.cs
@@ -11,6 +11,9 @@ public partial class TradeTab : RefreshAwareComponent
     private ISettingsService SettingsService { get; set; } = null!;
 
     [Inject]
+    private IDragDropService DragDropService { get; set; } = null!;
+
+    [Inject]
     private ILogger<TradeTab> Logger { get; set; } = null!;
 
     private string SlotATitle =>
@@ -158,5 +161,500 @@ public partial class TradeTab : RefreshAwareComponent
     {
         AppState.SaveFileB = null;
         RefreshService.Refresh();
+    }
+
+    // ── Transfer logic ────────────────────────────────────────────────────────
+
+    private bool CanTransferFromA() =>
+        AppState.SaveFile is not null
+        && AppState.SaveFileB is not null
+        && TryGetSelectedSource(fromA: true, out _, out _, out _, out _);
+
+    private bool CanTransferFromB() =>
+        AppState.SaveFile is not null
+        && AppState.SaveFileB is not null
+        && TryGetSelectedSource(fromA: false, out _, out _, out _, out _);
+
+    private bool TryGetSelectedSource(bool fromA, out SaveFile source, out bool isParty,
+        out int? boxNumber, out int slotNumber)
+    {
+        source = null!;
+        isParty = false;
+        boxNumber = null;
+        slotNumber = -1;
+
+        var sav = fromA ? AppState.SaveFile : AppState.SaveFileB;
+        if (sav is null)
+        {
+            return false;
+        }
+
+        var partySel = fromA ? AppState.SelectedPartySlotNumber : AppState.SelectedPartySlotNumberB;
+        if (partySel is { } partySlot && partySlot < sav.PartyCount)
+        {
+            var pkm = sav.GetPartySlotAtIndex(partySlot);
+            if (pkm is { Species: > 0 })
+            {
+                source = sav;
+                isParty = true;
+                slotNumber = partySlot;
+                return true;
+            }
+        }
+
+        var boxSel = fromA ? AppState.SelectedBoxNumber : AppState.SelectedBoxNumberB;
+        var boxSlotSel = fromA ? AppState.SelectedBoxSlotNumber : AppState.SelectedBoxSlotNumberB;
+        if (boxSel is { } selBox && boxSlotSel is { } selSlot && sav.BoxCount > 0)
+        {
+            var pkm = sav.GetBoxSlotAtIndex(selBox, selSlot);
+            if (pkm is { Species: > 0 })
+            {
+                source = sav;
+                isParty = false;
+                boxNumber = selBox;
+                slotNumber = selSlot;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private async Task TransferSelectedAsync(bool fromA)
+    {
+        if (!TryGetSelectedSource(fromA, out var srcSave, out var srcIsParty,
+                out var srcBox, out var srcSlot))
+        {
+            Snackbar.Add("Select a Pokémon in the source pane first.", Severity.Warning);
+            return;
+        }
+
+        var destSave = fromA ? AppState.SaveFileB : AppState.SaveFile;
+        if (destSave is null)
+        {
+            return;
+        }
+
+        // Prefer the user's selected dest slot when one is chosen; otherwise pick the
+        // first empty slot (party first, then the currently-selected box, then any box).
+        if (!TryGetSelectedDest(fromA: !fromA, destSave, out var destIsParty,
+                out var destBox, out var destSlot)
+            && !TryFindFirstEmptyDest(destSave, srcIsParty, fromA: !fromA,
+                out destIsParty, out destBox, out destSlot))
+        {
+            Snackbar.Add("No empty slot in the destination save.", Severity.Warning);
+            return;
+        }
+
+        await ExecuteTransferAsync(srcSave, srcIsParty, srcBox, srcSlot,
+            destSave, destIsParty, destBox, destSlot);
+    }
+
+    private bool TryGetSelectedDest(bool fromA, SaveFile destSave, out bool isParty,
+        out int? boxNumber, out int slotNumber)
+    {
+        isParty = false;
+        boxNumber = null;
+        slotNumber = -1;
+
+        var partySel = fromA ? AppState.SelectedPartySlotNumber : AppState.SelectedPartySlotNumberB;
+        if (partySel is { } partySlot && partySlot <= destSave.PartyCount && partySlot < 6)
+        {
+            isParty = true;
+            slotNumber = partySlot;
+            return true;
+        }
+
+        var boxSel = fromA ? AppState.SelectedBoxNumber : AppState.SelectedBoxNumberB;
+        var boxSlotSel = fromA ? AppState.SelectedBoxSlotNumber : AppState.SelectedBoxSlotNumberB;
+        if (boxSel is { } selBox && boxSlotSel is { } selSlot && destSave.BoxCount > 0)
+        {
+            boxNumber = selBox;
+            slotNumber = selSlot;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryFindFirstEmptyDest(SaveFile destSave, bool srcIsParty, bool fromA,
+        out bool isParty, out int? boxNumber, out int slotNumber)
+    {
+        _ = fromA;
+        isParty = false;
+        boxNumber = null;
+        slotNumber = -1;
+
+        // Prefer the party if the source came from a party slot and there's room.
+        if (srcIsParty && destSave.PartyCount < 6)
+        {
+            isParty = true;
+            slotNumber = destSave.PartyCount;
+            return true;
+        }
+
+        // Scan boxes for the first empty slot.
+        for (var box = 0; box < destSave.BoxCount; box++)
+        {
+            for (var slot = 0; slot < destSave.BoxSlotCount; slot++)
+            {
+                if (destSave.GetBoxSlotAtIndex(box, slot) is { Species: 0 })
+                {
+                    isParty = false;
+                    boxNumber = box;
+                    slotNumber = slot;
+                    return true;
+                }
+            }
+        }
+
+        // Fall back to appending to the party if no box slot is available.
+        if (destSave.PartyCount < 6)
+        {
+            isParty = true;
+            slotNumber = destSave.PartyCount;
+            return true;
+        }
+
+        return false;
+    }
+
+    private async Task HandleSlotDropAsync(TradeSlotTarget dest)
+    {
+        // Snapshot the drag source before ClearDrag runs — dragend fires concurrently.
+        var srcPokemon = DragDropService.DraggedPokemon;
+        var srcSave = DragDropService.DragSourceSaveFile ?? AppState.SaveFile;
+        var srcBox = DragDropService.DragSourceBoxNumber;
+        var srcSlot = DragDropService.DragSourceSlotNumber;
+        var srcIsParty = DragDropService.IsDragSourceParty;
+        DragDropService.ClearDrag();
+
+        if (srcPokemon is null || srcSave is null || srcSlot < 0)
+        {
+            return;
+        }
+
+        await ExecuteTransferAsync(srcSave, srcIsParty, srcBox, srcSlot,
+            dest.OwnerSaveFile, dest.IsParty, dest.BoxNumber, dest.SlotNumber);
+    }
+
+    private async Task ExecuteTransferAsync(
+        SaveFile srcSave, bool srcIsParty, int? srcBox, int srcSlot,
+        SaveFile destSave, bool destIsParty, int? destBox, int destSlot)
+    {
+        // Reject in-place moves outright.
+        if (ReferenceEquals(srcSave, destSave)
+            && srcIsParty == destIsParty
+            && srcBox == destBox
+            && srcSlot == destSlot)
+        {
+            return;
+        }
+
+        // Let's Go storage has its own set-semantics via the slot-index overload; keep
+        // behavior parity with PokemonSlotComponent, which disables drag/drop for SAV7b.
+        if (srcSave is SAV7b || destSave is SAV7b)
+        {
+            Snackbar.Add("Transfers involving Let's Go saves aren't supported yet.", Severity.Warning);
+            return;
+        }
+
+        var srcPkm = srcIsParty
+            ? srcSave.GetPartySlotAtIndex(srcSlot)
+            : srcBox.HasValue
+                ? srcSave.GetBoxSlotAtIndex(srcBox.Value, srcSlot)
+                : null;
+        if (srcPkm is not { Species: > 0 })
+        {
+            return;
+        }
+
+        // Intra-save moves: delegate to the same move/swap logic used by the Party/Box tab,
+        // but parameterised to the owning save file so slot B also works.
+        if (ReferenceEquals(srcSave, destSave))
+        {
+            if (!MoveWithinSave(srcSave, srcIsParty, srcBox, srcSlot,
+                    destIsParty, destBox, destSlot))
+            {
+                return;
+            }
+
+            RefreshService.Refresh();
+            return;
+        }
+
+        // Cross-save transfer.
+        var destPkmPrev = destIsParty
+            ? destSave.GetPartySlotAtIndex(destSlot)
+            : destBox.HasValue
+                ? destSave.GetBoxSlotAtIndex(destBox.Value, destSlot)
+                : null;
+        if (destPkmPrev is null)
+        {
+            return;
+        }
+
+        var haxEnabled = AppState.IsHaXEnabled;
+        var converted = ConvertForSave(srcPkm.Clone(), destSave, haxEnabled, out var forwardMessage);
+        if (converted is null)
+        {
+            Snackbar.Add(
+                string.IsNullOrEmpty(forwardMessage)
+                    ? "Could not convert the source Pokémon to the destination's format."
+                    : $"Could not transfer: {forwardMessage}",
+                Severity.Error);
+            return;
+        }
+        destSave.AdaptToSaveFile(converted, destIsParty);
+
+        // If the destination slot has a Pokémon, we swap by converting it back to the
+        // source's format. Otherwise we clear the source slot after the write.
+        PKM? convertedBack = null;
+        if (destPkmPrev.Species > 0)
+        {
+            convertedBack = ConvertForSave(destPkmPrev.Clone(), srcSave, haxEnabled, out var reverseMessage);
+            if (convertedBack is null)
+            {
+                Snackbar.Add(
+                    string.IsNullOrEmpty(reverseMessage)
+                        ? "Could not convert the destination Pokémon back to the source's format for a swap."
+                        : $"Swap not possible: {reverseMessage}",
+                    Severity.Error);
+                return;
+            }
+            srcSave.AdaptToSaveFile(convertedBack, srcIsParty);
+        }
+
+        // Apply writes before running legality — LegalityAnalysis re-runs below so we
+        // catch any adapt-on-write surprises introduced by AdaptToSaveFile.
+        WriteSlot(destSave, destIsParty, destBox, destSlot, converted);
+        if (convertedBack is not null)
+        {
+            WriteSlot(srcSave, srcIsParty, srcBox, srcSlot, convertedBack);
+        }
+        else
+        {
+            ClearSlot(srcSave, srcIsParty, srcBox, srcSlot);
+        }
+
+        // Re-run legality on the destination-side result. In HaX mode we trust the user
+        // and skip the confirmation; otherwise prompt before committing to the write.
+        if (!AppState.IsHaXEnabled)
+        {
+            var proceed = await ConfirmLegalityAsync(converted, destSave);
+            if (!proceed)
+            {
+                // Revert: restore the original destination and source PKMs.
+                WriteSlot(destSave, destIsParty, destBox, destSlot, destPkmPrev);
+                WriteSlot(srcSave, srcIsParty, srcBox, srcSlot, srcPkm);
+                RefreshService.Refresh();
+                return;
+            }
+        }
+
+        if (!string.IsNullOrEmpty(forwardMessage))
+        {
+            Snackbar.Add($"Warning: {forwardMessage}", Severity.Warning);
+        }
+
+        RefreshService.Refresh();
+    }
+
+    private static PKM? ConvertForSave(PKM pkm, SaveFile destSave, bool haxEnabled, out string message)
+    {
+        message = string.Empty;
+        var destType = destSave.PKMType;
+        if (pkm.GetType() == destType)
+        {
+            return pkm;
+        }
+
+        var converted = EntityConverter.ConvertToType(pkm, destType, out var result);
+        if (converted is not null && result.IsSuccess)
+        {
+            return converted;
+        }
+
+        // HaX fallback mirrors PokemonSlotComponent / PokemonBankTab — retry with
+        // AllowIncompatibleAll so DLC-gated species (e.g. Bibarel into pre-Teal-Mask
+        // Violet) can still transfer. The original message becomes a warning.
+        if (haxEnabled)
+        {
+            var previous = EntityConverter.AllowIncompatibleConversion;
+            EntityConverter.AllowIncompatibleConversion = EntityCompatibilitySetting.AllowIncompatibleAll;
+            try
+            {
+                converted = EntityConverter.ConvertToType(pkm, destType, out result);
+            }
+            finally
+            {
+                EntityConverter.AllowIncompatibleConversion = previous;
+            }
+
+            if (converted is not null && result.IsSuccess)
+            {
+                message = result.GetDisplayString(pkm, destType);
+                return converted;
+            }
+        }
+
+        message = result.GetDisplayString(pkm, destType);
+        return null;
+    }
+
+    private static void WriteSlot(SaveFile save, bool isParty, int? boxNumber, int slotNumber, PKM pkm)
+    {
+        if (isParty)
+        {
+            save.SetPartySlotAtIndex(pkm, slotNumber);
+        }
+        else if (boxNumber.HasValue)
+        {
+            save.SetBoxSlotAtIndex(pkm, boxNumber.Value, slotNumber);
+        }
+    }
+
+    private static void ClearSlot(SaveFile save, bool isParty, int? boxNumber, int slotNumber)
+    {
+        if (isParty)
+        {
+            // DeletePartySlot keeps the party compact, matching AppService.MovePokemon.
+            save.DeletePartySlot(slotNumber);
+        }
+        else if (boxNumber.HasValue)
+        {
+            save.SetBoxSlotAtIndex(save.BlankPKM, boxNumber.Value, slotNumber);
+        }
+    }
+
+    private async Task<bool> ConfirmLegalityAsync(PKM pkm, SaveFile destSave)
+    {
+        // Adapt-aware analysis: the converted PKM is already placed in the dest save, so
+        // a plain LegalityAnalysis reflects what the user will see if we commit.
+        var la = new LegalityAnalysis(pkm);
+        var invalid = la.Results.Any(r => r.Judgement == PKHeX.Core.Severity.Invalid)
+                      || !MoveResult.AllValid(la.Info.Moves)
+                      || !MoveResult.AllValid(la.Info.Relearn);
+        var fishy = !invalid && la.Results.Any(r => r.Judgement == PKHeX.Core.Severity.Fishy);
+        if (!invalid && !fishy)
+        {
+            return true;
+        }
+
+        // LegalityLocalizationContext is a ref struct, so we can't use LINQ over it —
+        // materialise the humanized strings via a plain loop.
+        var ctx = LegalityLocalizationContext.Create(la);
+        var messages = new List<string>(3);
+        foreach (var r in la.Results)
+        {
+            if (r.Judgement is not (PKHeX.Core.Severity.Invalid or PKHeX.Core.Severity.Fishy))
+            {
+                continue;
+            }
+            var humanized = ctx.Humanize(in r, verbose: false);
+            if (!string.IsNullOrWhiteSpace(humanized))
+            {
+                messages.Add(humanized);
+            }
+            if (messages.Count >= 3)
+            {
+                break;
+            }
+        }
+        _ = destSave;
+
+        var severity = invalid ? "illegal" : "fishy";
+        var body = messages.Count > 0
+            ? $"The converted Pokémon is {severity}:\n\n• {string.Join("\n• ", messages)}\n\nProceed with the transfer?"
+            : $"The converted Pokémon is {severity}. Proceed with the transfer?";
+        var result = await DialogService.ShowMessageBoxAsync(
+            invalid ? "Illegal after conversion" : "Fishy after conversion",
+            body,
+            yesText: "Transfer anyway",
+            cancelText: "Cancel");
+        return result == true;
+    }
+
+    // ── Intra-save move (both slot A→A and slot B→B) ──────────────────────────
+
+    // Deliberately duplicates the branching in AppService.MovePokemon so slot B has the
+    // same move/swap + Gen 1/2 compacting semantics without taking a dependency on
+    // AppState.SaveFile. Returns false when the move is a no-op (e.g. trying to move
+    // the last battle-ready party member out).
+    private static bool MoveWithinSave(SaveFile save,
+        bool srcIsParty, int? srcBox, int srcSlot,
+        bool destIsParty, int? destBox, int destSlot)
+    {
+        var source = srcIsParty
+            ? save.GetPartySlotAtIndex(srcSlot)
+            : srcBox.HasValue ? save.GetBoxSlotAtIndex(srcBox.Value, srcSlot) : null;
+        if (source is null)
+        {
+            return false;
+        }
+
+        var dest = destIsParty
+            ? save.GetPartySlotAtIndex(destSlot)
+            : destBox.HasValue ? save.GetBoxSlotAtIndex(destBox.Value, destSlot) : null;
+        if (dest is null)
+        {
+            return false;
+        }
+
+        var isSwap = source.Species > 0 && dest.Species > 0;
+
+        // Party safety: don't let the last non-Egg party member get moved out.
+        if (srcIsParty && !destIsParty && !isSwap)
+        {
+            var battleReady = 0;
+            for (var i = 0; i < save.PartyCount; i++)
+            {
+                if (i == srcSlot)
+                {
+                    continue;
+                }
+                var partyMon = save.GetPartySlotAtIndex(i);
+                if (partyMon is { Species: > 0, IsEgg: false })
+                {
+                    battleReady++;
+                }
+            }
+            if (battleReady == 0)
+            {
+                return false;
+            }
+        }
+
+        if (isSwap)
+        {
+            WriteSlot(save, srcIsParty, srcBox, srcSlot, dest);
+            WriteSlot(save, destIsParty, destBox, destSlot, source);
+            return true;
+        }
+
+        if (srcIsParty && !destIsParty)
+        {
+            if (destBox.HasValue)
+            {
+                save.SetBoxSlotAtIndex(source, destBox.Value, destSlot);
+            }
+            save.DeletePartySlot(srcSlot);
+            return true;
+        }
+
+        if (!srcIsParty && destIsParty)
+        {
+            if (srcBox.HasValue)
+            {
+                save.SetBoxSlotAtIndex(save.BlankPKM, srcBox.Value, srcSlot);
+            }
+            var target = destSlot >= save.PartyCount ? save.PartyCount : destSlot;
+            save.SetPartySlotAtIndex(source, target);
+            return true;
+        }
+
+        WriteSlot(save, destIsParty, destBox, destSlot, source);
+        ClearSlot(save, srcIsParty, srcBox, srcSlot);
+        return true;
     }
 }

--- a/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor.cs
@@ -836,9 +836,32 @@ public partial class TradeTab : RefreshAwareComponent
 
     private async Task<bool> ConfirmLegalityAsync(PKM pkm, SaveFile destSave)
     {
-        // Adapt-aware analysis: the converted PKM is already placed in the dest save, so
-        // a plain LegalityAnalysis reflects what the user will see if we commit.
-        var la = new LegalityAnalysis(pkm);
+        // Adapt-aware analysis: the converted PKM has already had UpdateHandler run
+        // against destSave (via AdaptToSaveFile), so its HT fields match destSave's
+        // trainer. HistoryVerifier.VerifyHandlerState, however, checks those HT fields
+        // against the *global* ParseSettings.ActiveTrainer — which is pinned to Save A
+        // throughout the app's lifetime so slot-A legality stays correct. When the
+        // destination is Save B, the global still points at Save A and the handler
+        // check fires false-positive "Handling trainer does not match" errors.
+        // Repoint ActiveTrainer at destSave for the duration of this analysis, then
+        // restore it so the rest of the app keeps seeing Save A as the active trainer.
+        LegalityAnalysis la;
+        if (AppState.SaveFile is { } savA && !ReferenceEquals(savA, destSave))
+        {
+            ParseSettings.InitFromSaveFileData(destSave);
+            try
+            {
+                la = new LegalityAnalysis(pkm);
+            }
+            finally
+            {
+                ParseSettings.InitFromSaveFileData(savA);
+            }
+        }
+        else
+        {
+            la = new LegalityAnalysis(pkm);
+        }
         var invalid = la.Results.Any(r => r.Judgement == PKHeX.Core.Severity.Invalid)
                       || !MoveResult.AllValid(la.Info.Moves)
                       || !MoveResult.AllValid(la.Info.Relearn);
@@ -868,7 +891,6 @@ public partial class TradeTab : RefreshAwareComponent
                 break;
             }
         }
-        _ = destSave;
 
         var severity = invalid ? "illegal" : "fishy";
         // MudBlazor's message box collapses whitespace in plain strings, so a bulleted list

--- a/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor.cs
@@ -384,6 +384,14 @@ public partial class TradeTab : RefreshAwareComponent
         }
 
         // Cross-save transfer.
+        // Keep the destination party compact: if the user dropped past PartyCount on an
+        // empty slot, clamp to PartyCount so SetPartySlotAtIndex appends rather than
+        // leaving a gap (mirrors the intra-save clamp in MoveWithinSave).
+        if (destIsParty && destSlot >= destSave.PartyCount)
+        {
+            destSlot = destSave.PartyCount;
+        }
+
         var destPkmPrev = destIsParty
             ? destSave.GetPartySlotAtIndex(destSlot)
             : destBox.HasValue

--- a/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor.cs
@@ -4,6 +4,10 @@ public partial class TradeTab : RefreshAwareComponent
 {
     private bool isLoading;
 
+    // Preserve the slot-B Manic EMU ZIP context across the session so Export Slot B
+    // can rebuild the .3ds.sav/.3ds.save ZIP without requiring the user to re-upload.
+    private ManicEmuSaveHelper.ManicEmuSaveContext? manicEmuSaveContextB;
+
     [Inject]
     private IBackupService BackupService { get; set; } = null!;
 
@@ -107,9 +111,10 @@ public partial class TradeTab : RefreshAwareComponent
 
             // NOTE: Do NOT call ParseSettings.InitFromSaveFileData(loadedSave) here.
             // That mutates global ParseSettings.ActiveTrainer and would break legality
-            // analysis on slot A. Slot B legality is read using the global settings already
-            // tuned to slot A's trainer; some handler-state checks may be slightly off for
-            // slot B Pokémon but Phase 1 is read-only so this is acceptable.
+            // analysis on slot A. Slot B legality is read using the global settings
+            // already tuned to slot A's trainer; some handler-state checks may be
+            // slightly off for slot B Pokémon but the post-transfer confirmation dialog
+            // picks up the important cases.
 
             AppState.SaveFileB = loadedSave;
             AppState.SaveFileNameB = selectedFile.Name;
@@ -117,12 +122,12 @@ public partial class TradeTab : RefreshAwareComponent
             AppState.SelectedBoxNumberB = loadedSave.CurrentBox;
             AppState.SelectedBoxSlotNumberB = null;
             AppState.SelectedPartySlotNumberB = null;
+            manicEmuSaveContextB = manicContext;
 
             // Per-slot on-load backup. Identical contract to the slot-A load path:
             // bytes come from the freshly loaded SaveFile (handles Manic EMU rebuild),
             // metadata is keyed by filename + save metadata + source so slot A and slot B
-            // backups coexist in IndexedDB. EnforceRetentionAsync remains global —
-            // Phase 1 only ever produces one slot-B backup so the shared pool is fine.
+            // backups coexist in IndexedDB.
             if (SettingsService.Settings.IsAutoBackupEnabled)
             {
                 try
@@ -160,7 +165,73 @@ public partial class TradeTab : RefreshAwareComponent
     private void UnloadSecondarySave()
     {
         AppState.SaveFileB = null;
+        AppState.SaveFileNameB = null;
+        manicEmuSaveContextB = null;
         RefreshService.Refresh();
+    }
+
+    private async Task ExportSecondarySaveAsync()
+    {
+        if (AppState.SaveFileB is not { } saveB)
+        {
+            return;
+        }
+
+        Logger.LogInformation("Exporting slot-B save file");
+        var rawSaveBytes = saveB.Write().ToArray();
+        var originalName = AppState.SaveFileNameB;
+
+        // Same branching as MainLayout.ExportSaveFile — rebuild the Manic EMU ZIP
+        // when the slot-B save came from one, otherwise preserve the original name.
+        if (manicEmuSaveContextB is not null)
+        {
+            var (exportName, compoundExt) = ManicEmuSaveHelper.GetExportFileName(originalName);
+            var zipBytes = ManicEmuSaveHelper.RebuildZip(manicEmuSaveContextB, rawSaveBytes);
+            await WriteSlotBFileAsync(zipBytes, exportName, compoundExt);
+        }
+        else if (string.IsNullOrWhiteSpace(originalName))
+        {
+            await WriteSlotBFileAsync(rawSaveBytes, "save.sav", ".sav");
+        }
+        else
+        {
+            var ext = Path.GetExtension(originalName);
+            await WriteSlotBFileAsync(rawSaveBytes, originalName, ext);
+        }
+    }
+
+    // Minimal duplicate of MainLayout's WriteFile: File System Access API when supported,
+    // fall back to an anchor click for legacy browsers.
+    private async Task WriteSlotBFileAsync(byte[] data, string fileName, string fileTypeExtension)
+    {
+        if (!await FileSystemAccessService.IsSupportedAsync())
+        {
+            var finalName = string.IsNullOrWhiteSpace(fileName) ? "save.sav" : fileName;
+            var base64 = Convert.ToBase64String(data);
+            var element = await JSRuntime.InvokeAsync<IJSObjectReference>(
+                "eval", "document.createElement('a')");
+            await element.InvokeVoidAsync("setAttribute", "href",
+                $"data:application/x-pokemon-savedata;base64,{base64}");
+            await element.InvokeVoidAsync("setAttribute", "download", finalName);
+            await element.InvokeVoidAsync("click");
+            return;
+        }
+
+        try
+        {
+            await JSRuntime.InvokeVoidAsync("showFilePickerAndWrite",
+                fileName, data, fileTypeExtension, "Save File");
+        }
+        catch (JSException ex) when (ex.Message.Contains("AbortError", StringComparison.OrdinalIgnoreCase)
+                                     || ex.Message.Contains("aborted a request", StringComparison.OrdinalIgnoreCase))
+        {
+            // User dismissed the picker — not an error.
+        }
+        catch (JSException ex)
+        {
+            Logger.LogError(ex, "Error exporting slot-B save file: {FileName}", fileName);
+            Snackbar.Add("Export failed. Please try again or use a different browser.", Severity.Error);
+        }
     }
 
     // ── Transfer logic ────────────────────────────────────────────────────────

--- a/Pkmds.Rcl/IAppState.cs
+++ b/Pkmds.Rcl/IAppState.cs
@@ -42,6 +42,13 @@ public interface IAppState
     string? SaveFileNameB { get; set; }
 
     /// <summary>
+    /// Gets or sets whether the secondary (slot-B) save file has uncommitted edits
+    /// from the Trade tab that have not yet been exported. Reset to false when slot B
+    /// is loaded, replaced, exported, or unloaded.
+    /// </summary>
+    bool HasUnsavedChangesB { get; set; }
+
+    /// <summary>
     /// Gets the box editor interface for the current save file.
     /// This provides access to box manipulation operations.
     /// </summary>

--- a/Pkmds.Rcl/IAppState.cs
+++ b/Pkmds.Rcl/IAppState.cs
@@ -32,7 +32,7 @@ public interface IAppState
     /// <summary>
     /// Gets or sets the secondary save file used by the cross-save Trade tab.
     /// Independent from <see cref="SaveFile" />; remains null until the user explicitly
-    /// loads a second save from the Trade tab. Read-only in Phase 1 of the cross-save trade work.
+    /// loads a second save from the Trade tab.
     /// </summary>
     SaveFile? SaveFileB { get; set; }
 

--- a/Pkmds.Rcl/ImageHelper.cs
+++ b/Pkmds.Rcl/ImageHelper.cs
@@ -809,8 +809,8 @@ public static partial class ImageHelper
                     or { species: (ushort)Species.Eevee, form: EeveeStarterForm }) => $"{species}-{form}p",
                 // Frillish and Jellicent have gender differences
                 {
-                        species: (ushort)Species.Frillish or (ushort)Species.Jellicent, gender: (byte)Gender.Female
-                    } => $"{species}f",
+                    species: (ushort)Species.Frillish or (ushort)Species.Jellicent, gender: (byte)Gender.Female
+                } => $"{species}f",
                 // Alcremie has form and decoration variations
                 { species: (ushort)Species.Alcremie } => $"{species}-{form}-{formArg1}",
                 // Handle Totem forms by mapping to base form

--- a/Pkmds.Rcl/Services/DragDropService.cs
+++ b/Pkmds.Rcl/Services/DragDropService.cs
@@ -10,6 +10,9 @@ public class DragDropService : IDragDropService
     public PKM? DraggedPokemon { get; set; }
 
     /// <inheritdoc />
+    public SaveFile? DragSourceSaveFile { get; set; }
+
+    /// <inheritdoc />
     public int? DragSourceBoxNumber { get; set; }
 
     /// <inheritdoc />
@@ -22,9 +25,14 @@ public class DragDropService : IDragDropService
     public bool IsDragging => DraggedPokemon is not null;
 
     /// <inheritdoc />
-    public void StartDrag(PKM? pokemon, int? boxNumber, int slotNumber, bool isParty)
+    public void StartDrag(PKM? pokemon, int? boxNumber, int slotNumber, bool isParty) =>
+        StartDrag(pokemon, sourceSaveFile: null, boxNumber, slotNumber, isParty);
+
+    /// <inheritdoc />
+    public void StartDrag(PKM? pokemon, SaveFile? sourceSaveFile, int? boxNumber, int slotNumber, bool isParty)
     {
         DraggedPokemon = pokemon;
+        DragSourceSaveFile = sourceSaveFile;
         DragSourceBoxNumber = boxNumber;
         DragSourceSlotNumber = slotNumber;
         IsDragSourceParty = isParty;
@@ -41,6 +49,7 @@ public class DragDropService : IDragDropService
     public void ClearDrag()
     {
         DraggedPokemon = null;
+        DragSourceSaveFile = null;
         DragSourceBoxNumber = null;
         DragSourceSlotNumber = -1;
         IsDragSourceParty = false;

--- a/Pkmds.Rcl/Services/IDragDropService.cs
+++ b/Pkmds.Rcl/Services/IDragDropService.cs
@@ -12,6 +12,14 @@ public interface IDragDropService
     PKM? DraggedPokemon { get; set; }
 
     /// <summary>
+    /// Gets or sets the save file that owns the source slot of the drag.
+    /// Null for legacy callers (the Party/Box tab), which always operate on
+    /// <see cref="IAppState.SaveFile" />. Set by the Trade tab so drops can tell
+    /// whether the drag came from slot A or slot B.
+    /// </summary>
+    SaveFile? DragSourceSaveFile { get; set; }
+
+    /// <summary>
     /// Gets or sets the source box number where the drag started.
     /// Null for party slots or Let's Go storage.
     /// </summary>
@@ -40,6 +48,17 @@ public interface IDragDropService
     /// <param name="slotNumber">The source slot number.</param>
     /// <param name="isParty">Whether the source is a party slot.</param>
     void StartDrag(PKM? pokemon, int? boxNumber, int slotNumber, bool isParty);
+
+    /// <summary>
+    /// Starts a drag operation with an explicit owning save file.
+    /// Used by the Trade tab so drops can tell which save the drag came from.
+    /// </summary>
+    /// <param name="pokemon">The Pokémon being dragged.</param>
+    /// <param name="sourceSaveFile">The save file that owns the source slot.</param>
+    /// <param name="boxNumber">The source box number (null for party or Let's Go storage).</param>
+    /// <param name="slotNumber">The source slot number.</param>
+    /// <param name="isParty">Whether the source is a party slot.</param>
+    void StartDrag(PKM? pokemon, SaveFile? sourceSaveFile, int? boxNumber, int slotNumber, bool isParty);
 
     /// <summary>
     /// Ends the drag operation, indicating a successful drop.

--- a/Pkmds.Rcl/wwwroot/css/app.css
+++ b/Pkmds.Rcl/wwwroot/css/app.css
@@ -124,6 +124,33 @@ body, html {
 .legality-indicator-icon--fishy { background: var(--mud-palette-warning); }
 .legality-indicator-icon--illegal { background: var(--mud-palette-error); }
 
+/* Trade tab: dim the sprite (but not the indicator badges) so the user sees at a glance
+   which Pokémon can't be transferred to the other save, while keeping the legality
+   indicator readable. The .transfer-block-indicator-icon sits in the bottom-left corner
+   opposite the shiny/legality badges. */
+.slot-ineligible-transfer .pkm-sprite,
+.slot-ineligible-transfer .pkm-sprite-hires {
+    opacity: 0.4;
+    filter: grayscale(0.7);
+}
+
+.transfer-block-indicator-icon {
+    position: absolute;
+    bottom: 2px;
+    left: 2px;
+    width: 16px;
+    height: 16px;
+    pointer-events: none;
+    z-index: 10;
+    border-radius: 50%;
+    background: var(--mud-palette-dark);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.5));
+}
+
 .egg-indicator-icon {
     position: absolute;
     bottom: 2px;

--- a/Pkmds.Tests/AdvancedSearchTests.cs
+++ b/Pkmds.Tests/AdvancedSearchTests.cs
@@ -248,6 +248,7 @@ public class AdvancedSearchTests
         public bool ShowIllegalIndicator { get; set; } = true;
         public SaveFile? SaveFileB { get; set; }
         public string? SaveFileNameB { get; set; }
+        public bool HasUnsavedChangesB { get; set; }
         public BoxEdit? BoxEditB => null;
         public int? SelectedBoxNumberB { get; set; }
         public int? SelectedBoxSlotNumberB { get; set; }

--- a/Pkmds.Tests/AppServiceTests.cs
+++ b/Pkmds.Tests/AppServiceTests.cs
@@ -395,6 +395,7 @@ public class AppServiceTests
         public bool ShowIllegalIndicator { get; set; } = true;
         public SaveFile? SaveFileB { get; set; }
         public string? SaveFileNameB { get; set; }
+        public bool HasUnsavedChangesB { get; set; }
         public BoxEdit? BoxEditB => null;
         public int? SelectedBoxNumberB { get; set; }
         public int? SelectedBoxSlotNumberB { get; set; }

--- a/Pkmds.Tests/BoxManagementTests.cs
+++ b/Pkmds.Tests/BoxManagementTests.cs
@@ -109,6 +109,7 @@ public class BoxManagementTests
         public bool ShowIllegalIndicator { get; set; } = true;
         public SaveFile? SaveFileB { get; set; }
         public string? SaveFileNameB { get; set; }
+        public bool HasUnsavedChangesB { get; set; }
         public BoxEdit? BoxEditB => null;
         public int? SelectedBoxNumberB { get; set; }
         public int? SelectedBoxSlotNumberB { get; set; }

--- a/Pkmds.Tests/BunitTestHelpers.cs
+++ b/Pkmds.Tests/BunitTestHelpers.cs
@@ -79,6 +79,7 @@ internal class TestAppState : IAppState
     public bool ShowIllegalIndicator { get; set; } = true;
     public SaveFile? SaveFileB { get; set; }
     public string? SaveFileNameB { get; set; }
+    public bool HasUnsavedChangesB { get; set; }
     public BoxEdit? BoxEditB => null;
     public int? SelectedBoxNumberB { get; set; }
     public int? SelectedBoxSlotNumberB { get; set; }

--- a/Pkmds.Tests/BunitTestHelpers.cs
+++ b/Pkmds.Tests/BunitTestHelpers.cs
@@ -129,12 +129,14 @@ internal class NullDescriptionService : IDescriptionService
 internal class NullDragDropService : IDragDropService
 {
     public PKM? DraggedPokemon { get; set; }
+    public SaveFile? DragSourceSaveFile { get; set; }
     public int? DragSourceBoxNumber { get; set; }
     public int DragSourceSlotNumber { get; set; }
     public bool IsDragSourceParty { get; set; }
     public bool IsDragging => false;
 
     public void StartDrag(PKM? pokemon, int? boxNumber, int slotNumber, bool isParty) { }
+    public void StartDrag(PKM? pokemon, SaveFile? sourceSaveFile, int? boxNumber, int slotNumber, bool isParty) { }
     public void EndDrag() { }
     public void ClearDrag() { }
 }

--- a/Pkmds.Tests/EncounterDatabaseTests.cs
+++ b/Pkmds.Tests/EncounterDatabaseTests.cs
@@ -220,6 +220,7 @@ public class EncounterDatabaseTests
         public bool ShowIllegalIndicator { get; set; } = true;
         public SaveFile? SaveFileB { get; set; }
         public string? SaveFileNameB { get; set; }
+        public bool HasUnsavedChangesB { get; set; }
         public BoxEdit? BoxEditB => null;
         public int? SelectedBoxNumberB { get; set; }
         public int? SelectedBoxSlotNumberB { get; set; }

--- a/Pkmds.Tests/EvolveTests.cs
+++ b/Pkmds.Tests/EvolveTests.cs
@@ -403,6 +403,7 @@ public class EvolveTests
         public bool ShowIllegalIndicator { get; set; } = true;
         public SaveFile? SaveFileB { get; set; }
         public string? SaveFileNameB { get; set; }
+        public bool HasUnsavedChangesB { get; set; }
         public BoxEdit? BoxEditB => null;
         public int? SelectedBoxNumberB { get; set; }
         public int? SelectedBoxSlotNumberB { get; set; }

--- a/Pkmds.Tests/FormEditorTests.cs
+++ b/Pkmds.Tests/FormEditorTests.cs
@@ -111,7 +111,8 @@ public class FormEditorTests
     {
         var pk = new PK6
         {
-            Species = (ushort)Species.Vivillon, Form = 99 // out of range
+            Species = (ushort)Species.Vivillon,
+            Form = 99 // out of range
         };
 
         var la = new LegalityAnalysis(pk);

--- a/Pkmds.Tests/HaXModeTests.cs
+++ b/Pkmds.Tests/HaXModeTests.cs
@@ -173,6 +173,7 @@ public class HaXModeTests
         public bool ShowIllegalIndicator { get; set; } = true;
         public SaveFile? SaveFileB { get; set; }
         public string? SaveFileNameB { get; set; }
+        public bool HasUnsavedChangesB { get; set; }
         public BoxEdit? BoxEditB => null;
         public int? SelectedBoxNumberB { get; set; }
         public int? SelectedBoxSlotNumberB { get; set; }

--- a/Pkmds.Tests/LegalityCheckerTests.cs
+++ b/Pkmds.Tests/LegalityCheckerTests.cs
@@ -251,6 +251,7 @@ public class LegalityCheckerTests
         public bool ShowIllegalIndicator { get; set; } = true;
         public SaveFile? SaveFileB { get; set; }
         public string? SaveFileNameB { get; set; }
+        public bool HasUnsavedChangesB { get; set; }
         public BoxEdit? BoxEditB => null;
         public int? SelectedBoxNumberB { get; set; }
         public int? SelectedBoxSlotNumberB { get; set; }

--- a/Pkmds.Web/AppState.cs
+++ b/Pkmds.Web/AppState.cs
@@ -68,11 +68,16 @@ public record AppState : IAppState
                 SelectedBoxSlotNumberB = null;
                 SelectedPartySlotNumberB = null;
             }
+
+            HasUnsavedChangesB = false;
         }
     }
 
     /// <inheritdoc />
     public string? SaveFileNameB { get; set; }
+
+    /// <inheritdoc />
+    public bool HasUnsavedChangesB { get; set; }
 
     /// <inheritdoc />
     public BoxEdit? BoxEdit { get; private set; }


### PR DESCRIPTION
## Summary

Phase 2 of the Trade tab — single-mon transfer between slot A and slot B, closing #711.

- Drag/drop **and** arrow-button transfer between the two panes, using a `TradeSlotTarget` drop payload to route cross-save vs intra-save moves.
- `EntityConverter.ConvertToType` drives the conversion, with a HaX-mode `AllowIncompatibleAll` fallback (matches `PokemonSlotComponent`). Swaps convert in both directions; `AdaptToSaveFile` runs before commit.
- Post-conversion `LegalityAnalysis` re-run; `Invalid`/`Fishy` results humanised via `LegalityLocalizationContext` and surfaced in a confirm dialog (skipped in HaX mode). Cancel reverts the write.
- Intra-save moves go through a parameterised `MoveWithinSave` helper so slot B gets the same move/swap + Gen 1/2 party-compacting + last-battle-ready safety as `AppService.MovePokemon`.
- Let's Go (SAV7b) rejected outright, matching existing slot-component behaviour.

Closes #711.

## Test plan

- [ ] Slot A → Slot B: drag a Pokémon into an empty slot; verify conversion succeeds and source slot clears.
- [ ] Slot A ↔ Slot B swap: drop onto an occupied slot; both directions should convert; dest and source swap contents.
- [ ] Arrow buttons (A→B, B→A) move the currently-selected Pokémon into the first empty party/box slot when no dest is selected.
- [ ] Legality warning dialog appears for Invalid/Fishy conversions and reverts on cancel (non-HaX mode).
- [ ] HaX mode: `AllowIncompatibleAll` fallback lets otherwise-incompatible transfers through with a warning snackbar.
- [ ] Intra-save drag within slot A still behaves like Party/Box tab; same for slot B (Gen 1/2 party compacting, last-battle-ready guard).
- [ ] Let's Go (SAV7b) on either side shows the unsupported-transfer snackbar instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)