### PR TITLE
feat(bulk): add .pk* batch import/export dialogs

### DIFF
--- a/Pkmds.Rcl/Components/Dialogs/BulkExportDialog.razor
+++ b/Pkmds.Rcl/Components/Dialogs/BulkExportDialog.razor
@@ -1,16 +1,22 @@
 <MudDialog>
     <TitleContent>
-        <MudText Typo="@Typo.h6">Export Box(es) as .pk* Files</MudText>
+        <MudText Typo="@Typo.h6">Export Pokémon as .pk* Files</MudText>
     </TitleContent>
     <DialogContent>
         <MudStack Spacing="3">
             <MudText Typo="@Typo.body2"
                      Color="@Color.Secondary">
-                Downloads a single zip containing a .pk* file for each non-empty box slot.
+                Downloads a single zip containing a .pk* file for each non-empty slot.
             </MudText>
 
             <MudRadioGroup T="BulkExportDialog.BulkExportScope"
                            @bind-Value="scope">
+                <MudRadio T="BulkExportDialog.BulkExportScope"
+                          Value="@BulkExportDialog.BulkExportScope.Party"
+                          Color="@Color.Primary"
+                          Disabled="@(partyCount == 0)">
+                    Party (@partyCount Pokémon)
+                </MudRadio>
                 <MudRadio T="BulkExportDialog.BulkExportScope"
                           Value="@BulkExportDialog.BulkExportScope.CurrentBox"
                           Color="@Color.Primary"
@@ -22,6 +28,12 @@
                           Color="@Color.Primary"
                           Disabled="@(totalBoxCount == 0)">
                     All boxes (@totalBoxCount Pokémon)
+                </MudRadio>
+                <MudRadio T="BulkExportDialog.BulkExportScope"
+                          Value="@BulkExportDialog.BulkExportScope.Everything"
+                          Color="@Color.Primary"
+                          Disabled="@(partyCount + totalBoxCount == 0)">
+                    Party and all boxes (@(partyCount + totalBoxCount) Pokémon)
                 </MudRadio>
             </MudRadioGroup>
 

--- a/Pkmds.Rcl/Components/Dialogs/BulkExportDialog.razor
+++ b/Pkmds.Rcl/Components/Dialogs/BulkExportDialog.razor
@@ -1,0 +1,50 @@
+<MudDialog>
+    <TitleContent>
+        <MudText Typo="@Typo.h6">Export Box(es) as .pk* Files</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudStack Spacing="3">
+            <MudText Typo="@Typo.body2"
+                     Color="@Color.Secondary">
+                Downloads a single zip containing a .pk* file for each non-empty box slot.
+            </MudText>
+
+            <MudRadioGroup T="BulkExportDialog.BulkExportScope"
+                           @bind-Value="scope">
+                <MudRadio T="BulkExportDialog.BulkExportScope"
+                          Value="@BulkExportDialog.BulkExportScope.CurrentBox"
+                          Color="@Color.Primary"
+                          Disabled="@(currentBoxCount == 0)">
+                    Current box (@currentBoxCount Pokémon)
+                </MudRadio>
+                <MudRadio T="BulkExportDialog.BulkExportScope"
+                          Value="@BulkExportDialog.BulkExportScope.AllBoxes"
+                          Color="@Color.Primary"
+                          Disabled="@(totalBoxCount == 0)">
+                    All boxes (@totalBoxCount Pokémon)
+                </MudRadio>
+            </MudRadioGroup>
+
+            @if (isExporting)
+            {
+                <MudProgressLinear Color="@Color.Primary"
+                                   Indeterminate="true"/>
+            }
+        </MudStack>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@Cancel"
+                   StartIcon="@Icons.Material.Filled.Clear"
+                   Variant="@Variant.Filled"
+                   Disabled="@isExporting">
+            Cancel
+        </MudButton>
+        <MudButton OnClick="@ExportAsync"
+                   Color="@Color.Primary"
+                   StartIcon="@Icons.Material.Filled.Download"
+                   Variant="@Variant.Filled"
+                   Disabled="@(isExporting || GetScopedCount() == 0 || AppState.SaveFile is null)">
+            Export
+        </MudButton>
+    </DialogActions>
+</MudDialog>

--- a/Pkmds.Rcl/Components/Dialogs/BulkExportDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/BulkExportDialog.razor.cs
@@ -6,12 +6,15 @@ public partial class BulkExportDialog
 {
     public enum BulkExportScope
     {
+        Party,
         CurrentBox,
-        AllBoxes
+        AllBoxes,
+        Everything
     }
 
     private int currentBoxCount;
     private bool isExporting;
+    private int partyCount;
     private BulkExportScope scope = BulkExportScope.CurrentBox;
     private int totalBoxCount;
 
@@ -35,11 +38,20 @@ public partial class BulkExportDialog
         }
 
         totalBoxCount = total;
+        partyCount = CountParty(sav);
 
-        // If the current box is empty but other boxes have Pokémon, default to All boxes.
-        if (currentBoxCount == 0 && totalBoxCount > 0)
+        // Default scope: prefer current box, then any box, then party.
+        if (currentBoxCount > 0)
+        {
+            scope = BulkExportScope.CurrentBox;
+        }
+        else if (totalBoxCount > 0)
         {
             scope = BulkExportScope.AllBoxes;
+        }
+        else if (partyCount > 0)
+        {
+            scope = BulkExportScope.Party;
         }
     }
 
@@ -57,10 +69,26 @@ public partial class BulkExportDialog
         return count;
     }
 
+    private static int CountParty(SaveFile sav)
+    {
+        var count = 0;
+        for (var i = 0; i < sav.PartyCount; i++)
+        {
+            if (sav.GetPartySlotAtIndex(i).Species != 0)
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
     private int GetScopedCount() => scope switch
     {
+        BulkExportScope.Party => partyCount,
         BulkExportScope.CurrentBox => currentBoxCount,
         BulkExportScope.AllBoxes => totalBoxCount,
+        BulkExportScope.Everything => partyCount + totalBoxCount,
         _ => 0
     };
 
@@ -84,9 +112,15 @@ public partial class BulkExportDialog
         try
         {
             var zipBytes = BuildZip(pokemonToExport);
-            var fileName = scope == BulkExportScope.CurrentBox
-                ? $"pokemon_export_box{(AppState.BoxEdit?.CurrentBox ?? sav.CurrentBox) + 1}.zip"
-                : "pokemon_export.zip";
+            var fileName = scope switch
+            {
+                BulkExportScope.Party => "pokemon_export_party.zip",
+                BulkExportScope.CurrentBox =>
+                    $"pokemon_export_box{(AppState.BoxEdit?.CurrentBox ?? sav.CurrentBox) + 1}.zip",
+                BulkExportScope.AllBoxes => "pokemon_export_boxes.zip",
+                BulkExportScope.Everything => "pokemon_export.zip",
+                _ => "pokemon_export.zip"
+            };
 
             await WriteZipAsync(zipBytes, fileName);
 
@@ -106,11 +140,27 @@ public partial class BulkExportDialog
 
     private List<PKM> CollectPokemon(SaveFile sav)
     {
-        var boxes = scope == BulkExportScope.CurrentBox
-            ? new[] { AppState.BoxEdit?.CurrentBox ?? sav.CurrentBox }
-            : Enumerable.Range(0, sav.BoxCount).ToArray();
-
         var result = new List<PKM>();
+
+        if (scope is BulkExportScope.Party or BulkExportScope.Everything)
+        {
+            for (var i = 0; i < sav.PartyCount; i++)
+            {
+                var pkm = sav.GetPartySlotAtIndex(i);
+                if (pkm.Species != 0)
+                {
+                    result.Add(pkm);
+                }
+            }
+        }
+
+        var boxes = scope switch
+        {
+            BulkExportScope.CurrentBox => new[] { AppState.BoxEdit?.CurrentBox ?? sav.CurrentBox },
+            BulkExportScope.AllBoxes or BulkExportScope.Everything => Enumerable.Range(0, sav.BoxCount).ToArray(),
+            _ => []
+        };
+
         foreach (var box in boxes)
         {
             for (var slot = 0; slot < sav.BoxSlotCount; slot++)

--- a/Pkmds.Rcl/Components/Dialogs/BulkExportDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/BulkExportDialog.razor.cs
@@ -1,0 +1,202 @@
+using System.IO.Compression;
+
+namespace Pkmds.Rcl.Components.Dialogs;
+
+public partial class BulkExportDialog
+{
+    public enum BulkExportScope
+    {
+        CurrentBox,
+        AllBoxes
+    }
+
+    private int currentBoxCount;
+    private bool isExporting;
+    private BulkExportScope scope = BulkExportScope.CurrentBox;
+    private int totalBoxCount;
+
+    [CascadingParameter]
+    private IMudDialogInstance? MudDialog { get; set; }
+
+    protected override void OnInitialized()
+    {
+        if (AppState.SaveFile is not { } sav)
+        {
+            return;
+        }
+
+        var currentBox = AppState.BoxEdit?.CurrentBox ?? sav.CurrentBox;
+        currentBoxCount = CountBox(sav, currentBox);
+
+        var total = 0;
+        for (var box = 0; box < sav.BoxCount; box++)
+        {
+            total += CountBox(sav, box);
+        }
+
+        totalBoxCount = total;
+
+        // If the current box is empty but other boxes have Pokémon, default to All boxes.
+        if (currentBoxCount == 0 && totalBoxCount > 0)
+        {
+            scope = BulkExportScope.AllBoxes;
+        }
+    }
+
+    private static int CountBox(SaveFile sav, int box)
+    {
+        var count = 0;
+        for (var slot = 0; slot < sav.BoxSlotCount; slot++)
+        {
+            if (sav.GetBoxSlotAtIndex(box, slot).Species != 0)
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    private int GetScopedCount() => scope switch
+    {
+        BulkExportScope.CurrentBox => currentBoxCount,
+        BulkExportScope.AllBoxes => totalBoxCount,
+        _ => 0
+    };
+
+    private async Task ExportAsync()
+    {
+        if (AppState.SaveFile is not { } sav)
+        {
+            return;
+        }
+
+        var pokemonToExport = CollectPokemon(sav);
+        if (pokemonToExport.Count == 0)
+        {
+            Snackbar.Add("No Pokémon to export.", Severity.Warning);
+            return;
+        }
+
+        isExporting = true;
+        StateHasChanged();
+
+        try
+        {
+            var zipBytes = BuildZip(pokemonToExport);
+            var fileName = scope == BulkExportScope.CurrentBox
+                ? $"pokemon_export_box{(AppState.BoxEdit?.CurrentBox ?? sav.CurrentBox) + 1}.zip"
+                : "pokemon_export.zip";
+
+            await WriteZipAsync(zipBytes, fileName);
+
+            Snackbar.Add($"Exported {pokemonToExport.Count} Pokémon.", Severity.Success);
+            MudDialog?.Close();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Export failed: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            isExporting = false;
+            StateHasChanged();
+        }
+    }
+
+    private List<PKM> CollectPokemon(SaveFile sav)
+    {
+        var boxes = scope == BulkExportScope.CurrentBox
+            ? new[] { AppState.BoxEdit?.CurrentBox ?? sav.CurrentBox }
+            : Enumerable.Range(0, sav.BoxCount).ToArray();
+
+        var result = new List<PKM>();
+        foreach (var box in boxes)
+        {
+            for (var slot = 0; slot < sav.BoxSlotCount; slot++)
+            {
+                var pkm = sav.GetBoxSlotAtIndex(box, slot);
+                if (pkm.Species != 0)
+                {
+                    result.Add(pkm);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private byte[] BuildZip(IReadOnlyList<PKM> pokemon)
+    {
+        using var ms = new MemoryStream();
+        using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var usedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var pkm in pokemon)
+            {
+                pkm.RefreshChecksum();
+                var bytes = new byte[pkm.SIZE_PARTY];
+                pkm.WriteDecryptedDataParty(bytes);
+
+                var entryName = GetUniqueEntryName(usedNames, AppService.GetCleanFileName(pkm));
+                var entry = zip.CreateEntry(entryName, CompressionLevel.Fastest);
+                using var es = entry.Open();
+                es.Write(bytes);
+            }
+        }
+
+        return ms.ToArray();
+    }
+
+    private static string GetUniqueEntryName(HashSet<string> used, string desired)
+    {
+        if (used.Add(desired))
+        {
+            return desired;
+        }
+
+        var ext = Path.GetExtension(desired);
+        var stem = Path.GetFileNameWithoutExtension(desired);
+        for (var i = 2; ; i++)
+        {
+            var candidate = $"{stem}_{i}{ext}";
+            if (used.Add(candidate))
+            {
+                return candidate;
+            }
+        }
+    }
+
+    private async Task WriteZipAsync(byte[] data, string fileName)
+    {
+        // Mirror MainLayout.WriteFile: prefer File System Access API, fall back to anchor.
+        if (await FileSystemAccessService.IsSupportedAsync())
+        {
+            try
+            {
+                await JSRuntime.InvokeVoidAsync(
+                    "showFilePickerAndWrite",
+                    fileName,
+                    data,
+                    ".zip",
+                    "Pokémon Export");
+                return;
+            }
+            catch (JSException ex) when (ex.Message.Contains("AbortError", StringComparison.OrdinalIgnoreCase) ||
+                                         ex.Message.Contains("aborted a request", StringComparison.OrdinalIgnoreCase))
+            {
+                // User dismissed the picker — not an error.
+                return;
+            }
+        }
+
+        // Legacy fallback: base64 data-URI anchor click.
+        var base64 = Convert.ToBase64String(data);
+        var anchor = await JSRuntime.InvokeAsync<IJSObjectReference>("eval", "document.createElement('a')");
+        await anchor.InvokeVoidAsync("setAttribute", "href", $"data:application/zip;base64,{base64}");
+        await anchor.InvokeVoidAsync("setAttribute", "download", fileName);
+        await anchor.InvokeVoidAsync("click");
+    }
+
+    private void Cancel() => MudDialog?.Close(DialogResult.Cancel());
+}

--- a/Pkmds.Rcl/Components/Dialogs/BulkImportDialog.razor
+++ b/Pkmds.Rcl/Components/Dialogs/BulkImportDialog.razor
@@ -1,0 +1,93 @@
+<MudDialog>
+    <TitleContent>
+        <MudText Typo="@Typo.h6">Bulk Import .pk* Files</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudStack Spacing="3">
+
+            @if (HasPreloadedFiles)
+            {
+                <MudText Typo="@Typo.body2">
+                    @PreloadedFiles!.Count .pk* file(s) ready to import.
+                </MudText>
+            }
+            else
+            {
+                <MudFileUpload T="IReadOnlyList<IBrowserFile>"
+                               MaximumFileCount="9999"
+                               Accept="@AcceptList"
+                               @bind-Files="selectedFiles">
+                    <CustomContent>
+                        <MudButton Variant="@Variant.Outlined"
+                                   StartIcon="@Icons.Material.Filled.UploadFile"
+                                   Disabled="@isImporting"
+                                   OnClick="@context.OpenFilePickerAsync">
+                            Choose .pk* Files
+                        </MudButton>
+                    </CustomContent>
+                </MudFileUpload>
+
+                @if (selectedFiles is { Count: > 0 })
+                {
+                    <MudText Typo="@Typo.caption"
+                             Color="@Color.Secondary">
+                        @selectedFiles.Count file(s) selected
+                    </MudText>
+                }
+            }
+
+            <MudSwitch @bind-Value="overwriteExisting"
+                       Color="@Color.Primary"
+                       Label="Overwrite existing slots (otherwise fill only empty slots)"
+                       Disabled="@isImporting"/>
+
+            <MudSwitch @bind-Value="sendOverflowToBank"
+                       Color="@Color.Primary"
+                       Label="Send overflow to Bank when no slots remain"
+                       Disabled="@isImporting"/>
+
+            @if (isImporting)
+            {
+                <MudStack Spacing="1">
+                    <MudText Typo="@Typo.body2">@statusText</MudText>
+                    <MudProgressLinear Color="@Color.Primary"
+                                       Value="@progressPercent"
+                                       Max="100"/>
+                </MudStack>
+            }
+
+            @if (result is not null)
+            {
+                <MudAlert Severity="@GetResultSeverity()">
+                    @GetResultMessage()
+                </MudAlert>
+            }
+        </MudStack>
+    </DialogContent>
+    <DialogActions>
+        @if (isImporting)
+        {
+            <MudButton OnClick="@CancelImport"
+                       StartIcon="@Icons.Material.Filled.Cancel"
+                       Color="@Color.Error"
+                       Variant="@Variant.Outlined">
+                Cancel
+            </MudButton>
+        }
+        else
+        {
+            <MudButton OnClick="@Close"
+                       StartIcon="@Icons.Material.Filled.Clear"
+                       Variant="@Variant.Filled">
+                @(result is null ? "Cancel" : "Close")
+            </MudButton>
+            <MudButton OnClick="@ImportAsync"
+                       Color="@Color.Primary"
+                       StartIcon="@Icons.Material.Filled.Upload"
+                       Variant="@Variant.Filled"
+                       Disabled="@(result is not null || !HasAnyFiles || AppState.SaveFile is null)">
+                Import
+            </MudButton>
+        }
+    </DialogActions>
+</MudDialog>

--- a/Pkmds.Rcl/Components/Dialogs/BulkImportDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/BulkImportDialog.razor.cs
@@ -20,6 +20,14 @@ public partial class BulkImportDialog : IDisposable
     [Parameter]
     public IReadOnlyList<(string FileName, byte[] Data)>? PreloadedFiles { get; set; }
 
+    /// <summary>
+    /// When <see langword="true" /> (the default), the placement scan fills boxes before
+    /// the party. Set to <see langword="false" /> when the import was initiated from a
+    /// party slot drop so the party fills first.
+    /// </summary>
+    [Parameter]
+    public bool FillBoxesFirst { get; set; } = true;
+
     [CascadingParameter]
     private IMudDialogInstance? MudDialog { get; set; }
 
@@ -107,7 +115,7 @@ public partial class BulkImportDialog : IDisposable
             StateHasChanged();
             await Task.Yield();
 
-            var (placed, overflow) = PlacePokemon(sav, parsed, overwriteExisting);
+            var (placed, overflow) = PlacePokemon(sav, parsed, overwriteExisting, FillBoxesFirst);
             var illegal = 0;
             foreach (var pk in placed)
             {
@@ -224,14 +232,14 @@ public partial class BulkImportDialog : IDisposable
     }
 
     private static (List<PKM> Placed, List<PKM> Overflow) PlacePokemon(
-        SaveFile sav, IReadOnlyList<PKM> candidates, bool overwrite)
+        SaveFile sav, IReadOnlyList<PKM> candidates, bool overwrite, bool fillBoxesFirst)
     {
         var placed = new List<PKM>(candidates.Count);
         var overflow = new List<PKM>();
 
         foreach (var pkm in candidates)
         {
-            if (TryPlaceSequential(sav, pkm, overwrite))
+            if (TryPlaceSequential(sav, pkm, overwrite, fillBoxesFirst))
             {
                 placed.Add(pkm);
             }
@@ -244,50 +252,43 @@ public partial class BulkImportDialog : IDisposable
         return (placed, overflow);
     }
 
-    private static bool TryPlaceSequential(SaveFile sav, PKM pkm, bool overwrite)
+    private static bool TryPlaceSequential(SaveFile sav, PKM pkm, bool overwrite, bool fillBoxesFirst)
     {
-        // Party first, then box scan (matches IAppService.TryPlacePokemonInFirstAvailableSlot).
-        if (overwrite)
+        // Party is never overwritten — `sav.PartyCount < 6` means there's a grow slot,
+        // which matches IAppService.TryPlacePokemonInFirstAvailableSlot. Overwrite only
+        // applies to boxes.
+        if (fillBoxesFirst)
         {
-            if (sav.PartyCount < 6)
-            {
-                sav.SetPartySlotAtIndex(pkm, sav.PartyCount);
-                return true;
-            }
+            return TryFillBoxes(sav, pkm, overwrite) || TryFillParty(sav, pkm);
+        }
 
-            // Overwrite mode: fill boxes sequentially, replacing whatever is there.
-            for (var box = 0; box < sav.BoxCount; box++)
-            {
-                for (var slot = 0; slot < sav.BoxSlotCount; slot++)
-                {
-                    var existing = sav.GetBoxSlotAtIndex(box, slot);
-                    if (existing.Species != 0 && !IsSlotEligibleForOverwrite(sav, box, slot))
-                    {
-                        continue;
-                    }
+        return TryFillParty(sav, pkm) || TryFillBoxes(sav, pkm, overwrite);
+    }
 
-                    sav.SetBoxSlotAtIndex(pkm, box, slot);
-                    return true;
-                }
-            }
-
+    private static bool TryFillParty(SaveFile sav, PKM pkm)
+    {
+        if (sav.PartyCount >= 6)
+        {
             return false;
         }
 
-        // Fill empty only.
-        if (sav.PartyCount < 6)
-        {
-            sav.SetPartySlotAtIndex(pkm, sav.PartyCount);
-            return true;
-        }
+        sav.SetPartySlotAtIndex(pkm, sav.PartyCount);
+        return true;
+    }
 
+    private static bool TryFillBoxes(SaveFile sav, PKM pkm, bool overwrite)
+    {
         for (var box = 0; box < sav.BoxCount; box++)
         {
             for (var slot = 0; slot < sav.BoxSlotCount; slot++)
             {
-                if (sav.GetBoxSlotAtIndex(box, slot).Species != 0)
+                var existing = sav.GetBoxSlotAtIndex(box, slot);
+                if (existing.Species != 0)
                 {
-                    continue;
+                    if (!overwrite || !IsSlotEligibleForOverwrite(sav, box, slot))
+                    {
+                        continue;
+                    }
                 }
 
                 sav.SetBoxSlotAtIndex(pkm, box, slot);

--- a/Pkmds.Rcl/Components/Dialogs/BulkImportDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/BulkImportDialog.razor.cs
@@ -1,0 +1,368 @@
+namespace Pkmds.Rcl.Components.Dialogs;
+
+public partial class BulkImportDialog : IDisposable
+{
+    private static readonly string AcceptList = BuildAcceptList();
+
+    private CancellationTokenSource? cts;
+    private bool isImporting;
+    private bool overwriteExisting;
+    private double progressPercent;
+    private BulkImportResult? result;
+    private IReadOnlyList<IBrowserFile>? selectedFiles;
+    private bool sendOverflowToBank = true;
+    private string statusText = string.Empty;
+
+    /// <summary>
+    /// Files supplied up-front (e.g. by a multi-file drop on the box grid). When set,
+    /// the file picker is hidden and these files are imported directly.
+    /// </summary>
+    [Parameter]
+    public IReadOnlyList<(string FileName, byte[] Data)>? PreloadedFiles { get; set; }
+
+    [CascadingParameter]
+    private IMudDialogInstance? MudDialog { get; set; }
+
+    [Inject]
+    private IBankService BankService { get; set; } = null!;
+
+    private bool HasPreloadedFiles => PreloadedFiles is { Count: > 0 };
+    private bool HasAnyFiles => HasPreloadedFiles || selectedFiles is { Count: > 0 };
+
+    public void Dispose()
+    {
+        cts?.Cancel();
+        cts?.Dispose();
+        cts = null;
+    }
+
+    private static string BuildAcceptList() =>
+        string.Join(",", EntityFileExtension.GetExtensionsAll().Select(e => "." + e));
+
+    private async Task ImportAsync()
+    {
+        if (AppState.SaveFile is not { } sav)
+        {
+            Snackbar.Add("No save file loaded.", Severity.Warning);
+            return;
+        }
+
+        var sources = await LoadSourcesAsync();
+        if (sources.Count == 0)
+        {
+            Snackbar.Add("No files to import.", Severity.Warning);
+            return;
+        }
+
+        cts?.Dispose();
+        cts = new CancellationTokenSource();
+        var ct = cts.Token;
+
+        isImporting = true;
+        progressPercent = 0;
+        statusText = $"Parsing {sources.Count} file(s)…";
+        StateHasChanged();
+        await Task.Yield();
+
+        var parseSkipped = 0;
+        var parsed = new List<PKM>(sources.Count);
+
+        try
+        {
+            for (var i = 0; i < sources.Count; i++)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                var (fileName, data) = sources[i];
+                progressPercent = (double)i / sources.Count * 50;
+                statusText = $"Parsing {i + 1}/{sources.Count}: {fileName}";
+
+                var ext = Path.GetExtension(fileName);
+                if (!FileUtil.TryGetPKM(data, out var pkm, ext, sav))
+                {
+                    parseSkipped++;
+                    continue;
+                }
+
+                var converted = ConvertForSave(pkm, sav, AppState.IsHaXEnabled);
+                if (converted is null)
+                {
+                    parseSkipped++;
+                    continue;
+                }
+
+                sav.AdaptToSaveFile(converted);
+                parsed.Add(converted);
+
+                if ((i + 1) % 8 == 0)
+                {
+                    StateHasChanged();
+                    await Task.Delay(1, ct);
+                }
+            }
+
+            // Placement phase.
+            statusText = $"Placing {parsed.Count} Pokémon…";
+            progressPercent = 50;
+            StateHasChanged();
+            await Task.Yield();
+
+            var (placed, overflow) = PlacePokemon(sav, parsed, overwriteExisting);
+            var illegal = 0;
+            foreach (var pk in placed)
+            {
+                var la = AppService.GetLegalityAnalysis(pk);
+                if (!la.Valid)
+                {
+                    illegal++;
+                }
+            }
+
+            var overflowToBank = 0;
+            if (overflow.Count > 0 && sendOverflowToBank)
+            {
+                statusText = $"Sending {overflow.Count} Pokémon to Bank…";
+                progressPercent = 85;
+                StateHasChanged();
+
+                var tid = sav.DisplayTID.ToString(AppService.GetIdFormatString());
+                var gameName = SaveFileNameDisplay.FriendlyGameName(sav.Version);
+                var sourceSave = $"{sav.OT} ({tid}, {gameName})";
+                await BankService.AddRangeAsync(overflow, sourceSave: sourceSave);
+                overflowToBank = overflow.Count;
+            }
+
+            progressPercent = 100;
+            statusText = "Done.";
+
+            result = new BulkImportResult(
+                Imported: placed.Count,
+                Skipped: parseSkipped,
+                Illegal: illegal,
+                OverflowRemaining: overflow.Count - overflowToBank,
+                OverflowToBank: overflowToBank);
+
+            RefreshService.RefreshBoxAndPartyState();
+        }
+        catch (OperationCanceledException)
+        {
+            result = new BulkImportResult(
+                Imported: 0, Skipped: 0, Illegal: 0, OverflowRemaining: 0, OverflowToBank: 0)
+            { Cancelled = true };
+            RefreshService.RefreshBoxAndPartyState();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Import failed: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            isImporting = false;
+            cts?.Dispose();
+            cts = null;
+            StateHasChanged();
+        }
+    }
+
+    private async Task<List<(string FileName, byte[] Data)>> LoadSourcesAsync()
+    {
+        if (HasPreloadedFiles)
+        {
+            return PreloadedFiles!.ToList();
+        }
+
+        if (selectedFiles is null)
+        {
+            return [];
+        }
+
+        var list = new List<(string, byte[])>(selectedFiles.Count);
+        foreach (var file in selectedFiles)
+        {
+            try
+            {
+                await using var stream = file.OpenReadStream(Constants.MaxFileSize);
+                using var ms = new MemoryStream();
+                await stream.CopyToAsync(ms);
+                list.Add((file.Name, ms.ToArray()));
+            }
+            catch
+            {
+                // Treat unreadable files as skipped; let the parse phase report them.
+                list.Add((file.Name, []));
+            }
+        }
+
+        return list;
+    }
+
+    private static PKM? ConvertForSave(PKM pkm, SaveFile sav, bool isHaXEnabled)
+    {
+        var clone = pkm.Clone();
+        if (clone.GetType() == sav.PKMType)
+        {
+            return clone;
+        }
+
+        var converted = EntityConverter.ConvertToType(pkm, sav.PKMType, out var result);
+
+        if ((!result.IsSuccess || converted is null) && isHaXEnabled)
+        {
+            var previous = EntityConverter.AllowIncompatibleConversion;
+            EntityConverter.AllowIncompatibleConversion = EntityCompatibilitySetting.AllowIncompatibleAll;
+            try
+            {
+                converted = EntityConverter.ConvertToType(pkm, sav.PKMType, out result);
+            }
+            finally
+            {
+                EntityConverter.AllowIncompatibleConversion = previous;
+            }
+        }
+
+        return result.IsSuccess ? converted : null;
+    }
+
+    private static (List<PKM> Placed, List<PKM> Overflow) PlacePokemon(
+        SaveFile sav, IReadOnlyList<PKM> candidates, bool overwrite)
+    {
+        var placed = new List<PKM>(candidates.Count);
+        var overflow = new List<PKM>();
+
+        foreach (var pkm in candidates)
+        {
+            if (TryPlaceSequential(sav, pkm, overwrite))
+            {
+                placed.Add(pkm);
+            }
+            else
+            {
+                overflow.Add(pkm);
+            }
+        }
+
+        return (placed, overflow);
+    }
+
+    private static bool TryPlaceSequential(SaveFile sav, PKM pkm, bool overwrite)
+    {
+        // Party first, then box scan (matches IAppService.TryPlacePokemonInFirstAvailableSlot).
+        if (overwrite)
+        {
+            if (sav.PartyCount < 6)
+            {
+                sav.SetPartySlotAtIndex(pkm, sav.PartyCount);
+                return true;
+            }
+
+            // Overwrite mode: fill boxes sequentially, replacing whatever is there.
+            for (var box = 0; box < sav.BoxCount; box++)
+            {
+                for (var slot = 0; slot < sav.BoxSlotCount; slot++)
+                {
+                    var existing = sav.GetBoxSlotAtIndex(box, slot);
+                    if (existing.Species != 0 && !IsSlotEligibleForOverwrite(sav, box, slot))
+                    {
+                        continue;
+                    }
+
+                    sav.SetBoxSlotAtIndex(pkm, box, slot);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        // Fill empty only.
+        if (sav.PartyCount < 6)
+        {
+            sav.SetPartySlotAtIndex(pkm, sav.PartyCount);
+            return true;
+        }
+
+        for (var box = 0; box < sav.BoxCount; box++)
+        {
+            for (var slot = 0; slot < sav.BoxSlotCount; slot++)
+            {
+                if (sav.GetBoxSlotAtIndex(box, slot).Species != 0)
+                {
+                    continue;
+                }
+
+                sav.SetBoxSlotAtIndex(pkm, box, slot);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // Avoid stomping on locked battle-team slots (Gen 5/6). PKHeX's GetBoxSlotFlags
+    // returns a Locked flag for these; treat them as "skip" even in overwrite mode.
+    private static bool IsSlotEligibleForOverwrite(SaveFile sav, int box, int slot)
+    {
+        var flags = sav.GetBoxSlotFlags(box, slot);
+        return !flags.HasFlag(StorageSlotSource.Locked);
+    }
+
+    private void CancelImport() => cts?.Cancel();
+
+    private Severity GetResultSeverity() => result switch
+    {
+        null => Severity.Info,
+        { Cancelled: true } => Severity.Info,
+        { Skipped: 0, Illegal: 0, OverflowRemaining: 0 } => Severity.Success,
+        _ => Severity.Warning
+    };
+
+    private string GetResultMessage()
+    {
+        if (result is null)
+        {
+            return string.Empty;
+        }
+
+        if (result.Cancelled)
+        {
+            return "Import cancelled.";
+        }
+
+        var parts = new List<string> { $"Imported {result.Imported}" };
+        if (result.Skipped > 0)
+        {
+            parts.Add($"skipped {result.Skipped} (incompatible)");
+        }
+
+        if (result.Illegal > 0)
+        {
+            parts.Add($"illegal: {result.Illegal}");
+        }
+
+        if (result.OverflowToBank > 0)
+        {
+            parts.Add($"sent {result.OverflowToBank} to Bank");
+        }
+
+        if (result.OverflowRemaining > 0)
+        {
+            parts.Add($"{result.OverflowRemaining} didn't fit (slots full)");
+        }
+
+        return string.Join(", ", parts) + ".";
+    }
+
+    private void Close() => MudDialog?.Close(result is null
+        ? DialogResult.Cancel()
+        : DialogResult.Ok(result));
+
+    private sealed record BulkImportResult(
+        int Imported,
+        int Skipped,
+        int Illegal,
+        int OverflowRemaining,
+        int OverflowToBank)
+    {
+        public bool Cancelled { get; init; }
+    }
+}

--- a/Pkmds.Rcl/Components/PokemonSlotComponent.razor.cs
+++ b/Pkmds.Rcl/Components/PokemonSlotComponent.razor.cs
@@ -559,7 +559,12 @@ public partial class PokemonSlotComponent : IDisposable
                 return;
             }
 
-            var parameters = new DialogParameters<BulkImportDialog> { { x => x.PreloadedFiles, preloaded } };
+            var parameters = new DialogParameters<BulkImportDialog>
+            {
+                { x => x.PreloadedFiles, preloaded },
+                // Box slot drop → fill boxes first; party slot drop → fill party first.
+                { x => x.FillBoxesFirst, !IsPartySlot }
+            };
             var options = new DialogOptions
             {
                 CloseOnEscapeKey = true,

--- a/Pkmds.Rcl/Components/PokemonSlotComponent.razor.cs
+++ b/Pkmds.Rcl/Components/PokemonSlotComponent.razor.cs
@@ -428,6 +428,15 @@ public partial class PokemonSlotComponent : IDisposable
             return;
         }
 
+        // Multi-file drop: route through BulkImportDialog with the files preloaded.
+        // The first file still lands in the dropped slot via the single-file path below
+        // only when exactly one file is dropped.
+        if (fileNames.Length > 1)
+        {
+            await HandleBulkFileDropAsync(fileNames);
+            return;
+        }
+
         var fileName = fileNames[0];
 
         try
@@ -519,6 +528,54 @@ public partial class PokemonSlotComponent : IDisposable
             Snackbar.Add($"Error importing Pokémon: {ex.Message}", Severity.Error);
             // TODO: Add proper logging with ILogger when available
             await Console.Error.WriteLineAsync($"Error in HandleFileDropAsync: {ex}");
+        }
+        finally
+        {
+            AppState.ShowProgressIndicator = false;
+        }
+    }
+
+    private async Task HandleBulkFileDropAsync(string[] fileNames)
+    {
+        try
+        {
+            AppState.ShowProgressIndicator = true;
+
+            var preloaded = new List<(string FileName, byte[] Data)>(fileNames.Length);
+            for (var i = 0; i < fileNames.Length; i++)
+            {
+                var base64 = await JSRuntime.InvokeAsync<string>("readDroppedFile", i);
+                if (string.IsNullOrEmpty(base64))
+                {
+                    continue;
+                }
+
+                preloaded.Add((fileNames[i], Convert.FromBase64String(base64)));
+            }
+
+            if (preloaded.Count == 0)
+            {
+                Snackbar.Add("Failed to read the dropped files.", Severity.Error);
+                return;
+            }
+
+            var parameters = new DialogParameters<BulkImportDialog> { { x => x.PreloadedFiles, preloaded } };
+            var options = new DialogOptions
+            {
+                CloseOnEscapeKey = true,
+                MaxWidth = MaxWidth.Small,
+                FullWidth = true
+            };
+
+            var dialog = await DialogService.ShowAsync<BulkImportDialog>(
+                "Bulk Import .pk* Files", parameters, options);
+            await dialog.Result;
+            RefreshService.RefreshBoxAndPartyState();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Error importing Pokémon: {ex.Message}", Severity.Error);
+            await Console.Error.WriteLineAsync($"Error in HandleBulkFileDropAsync: {ex}");
         }
         finally
         {

--- a/Pkmds.Rcl/Components/PokemonStorageComponent.razor
+++ b/Pkmds.Rcl/Components/PokemonStorageComponent.razor
@@ -50,7 +50,9 @@
                            Variant="@Variant.Filled"
                            Class="m-1.5 p-1.5">
             </MudIconButton>
+        </div>
 
+        <div class="flex flex-wrap mx-[5px] mb-[5px] px-[5px] items-center">
             <MudIconButton OnClick="@OpenBoxLayoutDialog"
                            title="Edit box layout"
                            ButtonType="@ButtonType.Button"

--- a/Pkmds.Rcl/Components/PokemonStorageComponent.razor
+++ b/Pkmds.Rcl/Components/PokemonStorageComponent.razor
@@ -96,6 +96,23 @@
                 </MudIconButton>
             }
 
+            <MudIconButton OnClick="@OpenBulkImportDialog"
+                           title="Bulk import .pk* files"
+                           ButtonType="@ButtonType.Button"
+                           Icon="@Icons.Material.Filled.Upload"
+                           Variant="@Variant.Filled"
+                           Class="m-1.5 p-1.5">
+            </MudIconButton>
+
+            <MudIconButton OnClick="@OpenBulkExportDialog"
+                           title="Export box(es) as .pk* files"
+                           ButtonType="@ButtonType.Button"
+                           Icon="@Icons.Material.Filled.Download"
+                           Variant="@Variant.Filled"
+                           Disabled="@(!HasAnyBoxPokemon())"
+                           Class="m-1.5 p-1.5">
+            </MudIconButton>
+
             <MudIconButton OnClick="@TogglePinCurrentBox"
                            title="@(AppState.PinnedBoxNumber == boxEdit.CurrentBox
                                       ? "Unpin Box"

--- a/Pkmds.Rcl/Components/PokemonStorageComponent.razor
+++ b/Pkmds.Rcl/Components/PokemonStorageComponent.razor
@@ -105,11 +105,11 @@
             </MudIconButton>
 
             <MudIconButton OnClick="@OpenBulkExportDialog"
-                           title="Export box(es) as .pk* files"
+                           title="Export party or box(es) as .pk* files"
                            ButtonType="@ButtonType.Button"
                            Icon="@Icons.Material.Filled.Download"
                            Variant="@Variant.Filled"
-                           Disabled="@(!HasAnyBoxPokemon())"
+                           Disabled="@(!HasAnyExportablePokemon())"
                            Class="m-1.5 p-1.5">
             </MudIconButton>
 

--- a/Pkmds.Rcl/Components/PokemonStorageComponent.razor.cs
+++ b/Pkmds.Rcl/Components/PokemonStorageComponent.razor.cs
@@ -135,6 +135,45 @@ public partial class PokemonStorageComponent : RefreshAwareComponent
         RefreshService.RefreshBoxState();
     }
 
+    private bool HasAnyBoxPokemon()
+    {
+        if (AppState.SaveFile is not { } sav)
+        {
+            return false;
+        }
+
+        for (var box = 0; box < sav.BoxCount; box++)
+        {
+            for (var slot = 0; slot < sav.BoxSlotCount; slot++)
+            {
+                if (sav.GetBoxSlotAtIndex(box, slot).Species != 0)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private async Task OpenBulkExportDialog()
+    {
+        await DialogService.ShowAsync<BulkExportDialog>(
+            "Export Box(es) as .pk* Files",
+            new DialogOptions { CloseOnEscapeKey = true, MaxWidth = MaxWidth.Small, FullWidth = true });
+    }
+
+    private async Task OpenBulkImportDialog()
+    {
+        var dialog = await DialogService.ShowAsync<BulkImportDialog>(
+            "Bulk Import .pk* Files",
+            new DialogOptions { CloseOnEscapeKey = true, MaxWidth = MaxWidth.Small, FullWidth = true });
+
+        await dialog.Result;
+        InvalidateIllegalCount();
+        RefreshService.RefreshBoxAndPartyState();
+    }
+
     private async Task OpenBoxListDialog()
     {
         var isXs = await BrowserViewportService.GetCurrentBreakpointAsync() == Breakpoint.Xs;

--- a/Pkmds.Rcl/Components/PokemonStorageComponent.razor.cs
+++ b/Pkmds.Rcl/Components/PokemonStorageComponent.razor.cs
@@ -135,11 +135,19 @@ public partial class PokemonStorageComponent : RefreshAwareComponent
         RefreshService.RefreshBoxState();
     }
 
-    private bool HasAnyBoxPokemon()
+    private bool HasAnyExportablePokemon()
     {
         if (AppState.SaveFile is not { } sav)
         {
             return false;
+        }
+
+        for (var i = 0; i < sav.PartyCount; i++)
+        {
+            if (sav.GetPartySlotAtIndex(i).Species != 0)
+            {
+                return true;
+            }
         }
 
         for (var box = 0; box < sav.BoxCount; box++)
@@ -159,7 +167,7 @@ public partial class PokemonStorageComponent : RefreshAwareComponent
     private async Task OpenBulkExportDialog()
     {
         await DialogService.ShowAsync<BulkExportDialog>(
-            "Export Box(es) as .pk* Files",
+            "Export Pokémon as .pk* Files",
             new DialogOptions { CloseOnEscapeKey = true, MaxWidth = MaxWidth.Small, FullWidth = true });
     }
 

--- a/Pkmds.Rcl/wwwroot/css/app.css
+++ b/Pkmds.Rcl/wwwroot/css/app.css
@@ -279,10 +279,19 @@ body, html {
     }
 
     /* Trade tab content: the parent .mud-tab-panel has overflow:hidden, which would
-       clip the last row of box slots when no Pokémon is selected (no info panel to
-       compress the grid into place). Let this scroll so the full content is reachable. */
+       clip the bottom of the grid (and the selected-Pokémon info card when visible).
+       Make the tab panel a flex column so this child can be flex:1 + min-height:0 —
+       which is the pattern that actually resolves to a definite height inside the
+       MudTabs flex chain (height:100% here rendered as auto and the scrollbar never
+       appeared). */
+    .save-file-outer-tabs > .mud-tabs-panels > .mud-tab-panel:has(.trade-tab-content) {
+        display: flex;
+        flex-direction: column;
+    }
+
     .trade-tab-content {
-        height: 100%;
+        flex: 1;
+        min-height: 0;
         overflow-y: auto;
     }
 

--- a/Pkmds.Rcl/wwwroot/css/app.css
+++ b/Pkmds.Rcl/wwwroot/css/app.css
@@ -279,19 +279,10 @@ body, html {
     }
 
     /* Trade tab content: the parent .mud-tab-panel has overflow:hidden, which would
-       clip the bottom of the grid (and the selected-Pokémon info card when visible).
-       Make the tab panel a flex column so this child can be flex:1 + min-height:0 —
-       which is the pattern that actually resolves to a definite height inside the
-       MudTabs flex chain (height:100% here rendered as auto and the scrollbar never
-       appeared). */
-    .save-file-outer-tabs > .mud-tabs-panels > .mud-tab-panel:has(.trade-tab-content) {
-        display: flex;
-        flex-direction: column;
-    }
-
+       clip the last row of box slots when no Pokémon is selected (no info panel to
+       compress the grid into place). Let this scroll so the full content is reachable. */
     .trade-tab-content {
-        flex: 1;
-        min-height: 0;
+        height: 100%;
         overflow-y: auto;
     }
 

--- a/Pkmds.Rcl/wwwroot/css/app.css
+++ b/Pkmds.Rcl/wwwroot/css/app.css
@@ -280,19 +280,15 @@ body, html {
 
     /* Trade tab content: the parent .mud-tab-panel has overflow:hidden, which would
        clip the bottom of the grid (and the selected-Pokémon info card when visible).
-       Make the tab panel a flex column so this child can be flex:1 + min-height:0 —
-       which is the pattern that actually resolves to a definite height inside the
-       MudTabs flex chain (height:100% here rendered as auto and the scrollbar never
-       appeared). */
-    .save-file-outer-tabs > .mud-tabs-panels > .mud-tab-panel:has(.trade-tab-content) {
-        display: flex;
-        flex-direction: column;
-    }
-
+       Give the wrapper an explicit max-height so overflow-y:auto reliably engages —
+       the earlier flex:1 + min-height:0 approach depended on every ancestor in the
+       MudTabs flex chain resolving its height, which isn't guaranteed across all
+       layouts and still left the bottom clipped. The 160px offset matches the space
+       above the tab panel (AppBar + save-file h5 + tab bar + margin). */
     .trade-tab-content {
-        flex: 1;
-        min-height: 0;
+        max-height: calc(100dvh - 160px);
         overflow-y: auto;
+        overflow-x: hidden;
     }
 
     /* Bank tab: the tab panel becomes a flex column so the card grid can

--- a/Pkmds.Rcl/wwwroot/css/app.css
+++ b/Pkmds.Rcl/wwwroot/css/app.css
@@ -280,15 +280,19 @@ body, html {
 
     /* Trade tab content: the parent .mud-tab-panel has overflow:hidden, which would
        clip the bottom of the grid (and the selected-Pokémon info card when visible).
-       Give the wrapper an explicit max-height so overflow-y:auto reliably engages —
-       the earlier flex:1 + min-height:0 approach depended on every ancestor in the
-       MudTabs flex chain resolving its height, which isn't guaranteed across all
-       layouts and still left the bottom clipped. The 160px offset matches the space
-       above the tab panel (AppBar + save-file h5 + tab bar + margin). */
+       Make the tab panel a flex column so this child can be flex:1 + min-height:0 —
+       which is the pattern that actually resolves to a definite height inside the
+       MudTabs flex chain (height:100% here rendered as auto and the scrollbar never
+       appeared). */
+    .save-file-outer-tabs > .mud-tabs-panels > .mud-tab-panel:has(.trade-tab-content) {
+        display: flex;
+        flex-direction: column;
+    }
+
     .trade-tab-content {
-        max-height: calc(100dvh - 160px);
+        flex: 1;
+        min-height: 0;
         overflow-y: auto;
-        overflow-x: hidden;
     }
 
     /* Bank tab: the tab panel becomes a flex column so the card grid can

--- a/Pkmds.Rcl/wwwroot/js/fileSave.js
+++ b/Pkmds.Rcl/wwwroot/js/fileSave.js
@@ -92,6 +92,19 @@ window.readDroppedFile = async function (index) {
     });
 };
 
+// Returns the number of files currently queued from the last drop event.
+window.getDroppedFileCount = function () {
+    return window.droppedFiles ? window.droppedFiles.length : 0;
+};
+
+// Returns the filename of the dropped file at the given index, or null.
+window.getDroppedFileName = function (index) {
+    if (!window.droppedFiles || index >= window.droppedFiles.length) {
+        return null;
+    }
+    return window.droppedFiles[index].name;
+};
+
 // Returns true if the page is running inside a known in-app browser (e.g. Google Search App,
 // Facebook, Instagram) whose WebView may block file downloads or the File System Access API.
 window.isInAppBrowser = function () {


### PR DESCRIPTION
## Summary
- Adds a **Bulk Import** dialog (toolbar Upload button on the box header) that accepts any number of `.pk*` files via file picker, converts them for the active save (with HaX retry for cross-format drops), fills empty slots or overwrites existing ones, and routes anything that doesn't fit to the Bank.
- Adds a **Bulk Export** dialog (toolbar Download button) that zips the current box or all boxes as individual `.pk*` files, deduping collisions with numeric suffixes.
- Extends slot-level drag-and-drop: dropping multiple files on any box slot now opens the Bulk Import dialog with the dropped files preloaded instead of only taking the first.

Closes #61.

## Test plan
- [ ] Open a save, drop 10+ `.pk*` files on a box slot — bulk import dialog appears preloaded with them.
- [ ] Toggle "Overwrite existing slots" and confirm slots fill from the start vs. only filling empties.
- [ ] Toggle "Send overflow to Bank" and confirm leftover Pokémon land in the Bank tab (with the source-save label set).
- [ ] Cancel mid-import and confirm partial results / no crash.
- [ ] Export the current box as a zip; re-import it and verify slot contents match.
- [ ] Export all boxes as a zip and confirm file count matches total occupied slots.
- [ ] Confirm legality counter on the box header refreshes after import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)