### PR TITLE
fix(ui): restore solid legality icons in box/party views (closes #724)

### DIFF
--- a/Pkmds.Rcl/Components/PokemonSlotComponent.razor
+++ b/Pkmds.Rcl/Components/PokemonSlotComponent.razor
@@ -65,7 +65,12 @@
 
             @if (!AppState.IsHaXEnabled && GetLegalityStatus() is { } status)
             {
-                <div class="legality-indicator-icon"
+                <div class="@($"legality-indicator-icon {status switch
+                            {
+                                LegalityStatus.Legal => "legality-indicator-icon--legal",
+                                LegalityStatus.Fishy => "legality-indicator-icon--fishy",
+                                _ => "legality-indicator-icon--illegal"
+                            }}")"
                      title="@(status switch
                             {
                                 LegalityStatus.Legal => "Legal",
@@ -74,18 +79,11 @@
                             })">
                     <MudIcon Icon="@(status switch
                                    {
-                                       LegalityStatus.Legal => Icons.Material.Filled.CheckCircle,
-                                       LegalityStatus.Fishy => Icons.Material.Filled.Warning,
-                                       _ => Icons.Material.Filled.Cancel
+                                       LegalityStatus.Legal => Icons.Material.Filled.Check,
+                                       LegalityStatus.Fishy => Icons.Material.Filled.PriorityHigh,
+                                       _ => Icons.Material.Filled.Close
                                    })"
-                             Color="@(status switch
-                                    {
-                                        LegalityStatus.Legal => Color.Success,
-                                        LegalityStatus.Fishy => Color.Warning,
-                                        _ => Color.Error
-                                    })"
-                             Class="w-full h-full"
-                             Style="font-size: 16px;"/>
+                             Style="font-size: 14px; color: white;"/>
                 </div>
             }
 


### PR DESCRIPTION
## Summary
- Mirror the Trade tab's solid-glyph + coloured-disc pattern in `PokemonSlotComponent.razor` so box/party legality badges no longer render as transparent cutouts over Pokémon sprites.
- Regression introduced because commit f254c20c only updated `TradeSlot.razor`; the box/party component kept using Filled CheckCircle/Warning/Cancel (cutouts).

## Test plan
- [ ] Load a save and verify the check / warning / X badges on box + party slots render as solid white glyphs on green/amber/red discs.
- [ ] Confirm the Trade tab indicators still look correct (unchanged).
- [ ] Toggle HaX mode off/on — badges hide as expected.

Closes #724.

🤖 Generated with [Claude Code](https://claude.com/claude-code)