### PR TITLE
Fix #723: external .pk* file drop treated as internal slot move

### DIFF
--- a/Pkmds.Core/Extensions/SaveFileExtensions.cs
+++ b/Pkmds.Core/Extensions/SaveFileExtensions.cs
@@ -1,0 +1,76 @@
+namespace Pkmds.Core.Extensions;
+
+/// <summary>
+/// Extension methods for <see cref="SaveFile"/> that deal with storage-slot layout invariants.
+/// </summary>
+public static class SaveFileExtensions
+{
+    private const int PartySize = 6;
+
+    /// <summary>
+    /// Rewrites the party so all non-blank members are contiguous at indices 0..N-1, with the
+    /// remaining slots blanked. Use after any party write that could have left a gap (e.g. writing
+    /// to an index past <see cref="SaveFile.PartyCount"/> or deleting a middle slot).
+    /// </summary>
+    /// <remarks>
+    /// Mirrors the invariant PKHeX's <c>SlotInfoParty.WriteTo</c> enforces by realigning writes to
+    /// <c>Math.Min(slot, PartyCount)</c> — but applied post-hoc so callers don't need to compute
+    /// the realigned slot themselves.
+    /// </remarks>
+    public static void CompactParty(this SaveFile sav)
+    {
+        var nonBlank = new List<PKM>(PartySize);
+        for (var i = 0; i < PartySize; i++)
+        {
+            var pkm = sav.GetPartySlotAtIndex(i);
+            if (pkm.Species != 0)
+            {
+                nonBlank.Add(pkm);
+            }
+        }
+
+        for (var i = 0; i < nonBlank.Count; i++)
+        {
+            sav.SetPartySlotAtIndex(nonBlank[i], i);
+        }
+
+        for (var i = nonBlank.Count; i < PartySize; i++)
+        {
+            sav.SetPartySlotAtIndex(sav.BlankPKM, i);
+        }
+    }
+
+    /// <summary>
+    /// For Gen 1/2 saves — whose box storage is a packed list, not a grid — collects non-blank
+    /// slots in <paramref name="box"/> and rewrites them contiguously starting at slot 0. No-op
+    /// for other generations, where gaps between box slots are valid.
+    /// </summary>
+    public static void CompactBoxIfGen12(this SaveFile sav, int box)
+    {
+        if (sav.Context is not (EntityContext.Gen1 or EntityContext.Gen2))
+        {
+            return;
+        }
+
+        var slotCount = sav.BoxSlotCount;
+        var nonBlank = new List<PKM>(slotCount);
+        for (var i = 0; i < slotCount; i++)
+        {
+            var pkm = sav.GetBoxSlotAtIndex(box, i);
+            if (pkm.Species != 0)
+            {
+                nonBlank.Add(pkm);
+            }
+        }
+
+        for (var i = 0; i < nonBlank.Count; i++)
+        {
+            sav.SetBoxSlotAtIndex(nonBlank[i], box, i);
+        }
+
+        for (var i = nonBlank.Count; i < slotCount; i++)
+        {
+            sav.SetBoxSlotAtIndex(sav.BlankPKM, box, i);
+        }
+    }
+}

--- a/Pkmds.Rcl/Components/Dialogs/BulkExportDialog.razor
+++ b/Pkmds.Rcl/Components/Dialogs/BulkExportDialog.razor
@@ -10,7 +10,8 @@
             </MudText>
 
             <MudRadioGroup T="BulkExportDialog.BulkExportScope"
-                           @bind-Value="scope">
+                           @bind-Value="scope"
+                           Disabled="@isExporting">
                 <MudRadio T="BulkExportDialog.BulkExportScope"
                           Value="@BulkExportDialog.BulkExportScope.Party"
                           Color="@Color.Primary"
@@ -39,24 +40,39 @@
 
             @if (isExporting)
             {
-                <MudProgressLinear Color="@Color.Primary"
-                                   Indeterminate="true"/>
+                <MudStack Spacing="1">
+                    <MudText Typo="@Typo.body2">@statusText</MudText>
+                    <MudProgressLinear Color="@Color.Primary"
+                                       Value="@progressPercent"
+                                       Max="100"/>
+                </MudStack>
             }
         </MudStack>
     </DialogContent>
     <DialogActions>
-        <MudButton OnClick="@Cancel"
-                   StartIcon="@Icons.Material.Filled.Clear"
-                   Variant="@Variant.Filled"
-                   Disabled="@isExporting">
-            Cancel
-        </MudButton>
-        <MudButton OnClick="@ExportAsync"
-                   Color="@Color.Primary"
-                   StartIcon="@Icons.Material.Filled.Download"
-                   Variant="@Variant.Filled"
-                   Disabled="@(isExporting || GetScopedCount() == 0 || AppState.SaveFile is null)">
-            Export
-        </MudButton>
+        @if (isExporting)
+        {
+            <MudButton OnClick="@CancelExport"
+                       StartIcon="@Icons.Material.Filled.Cancel"
+                       Color="@Color.Error"
+                       Variant="@Variant.Outlined">
+                Cancel
+            </MudButton>
+        }
+        else
+        {
+            <MudButton OnClick="@Cancel"
+                       StartIcon="@Icons.Material.Filled.Clear"
+                       Variant="@Variant.Filled">
+                Cancel
+            </MudButton>
+            <MudButton OnClick="@ExportAsync"
+                       Color="@Color.Primary"
+                       StartIcon="@Icons.Material.Filled.Download"
+                       Variant="@Variant.Filled"
+                       Disabled="@(GetScopedCount() == 0 || AppState.SaveFile is null)">
+                Export
+            </MudButton>
+        }
     </DialogActions>
 </MudDialog>

--- a/Pkmds.Rcl/Components/Dialogs/BulkExportDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/BulkExportDialog.razor.cs
@@ -147,7 +147,7 @@ public partial class BulkExportDialog : IDisposable
             progressPercent = 100;
             StateHasChanged();
 
-            await WriteZipAsync(zipBytes, fileName);
+            await WriteZipAsync(zipBytes, fileName, ct);
 
             Snackbar.Add($"Exported {pokemonToExport.Count} Pokémon.", Severity.Success);
             MudDialog?.Close();
@@ -266,15 +266,18 @@ public partial class BulkExportDialog : IDisposable
         }
     }
 
-    private async Task WriteZipAsync(byte[] data, string fileName)
+    private async Task WriteZipAsync(byte[] data, string fileName, CancellationToken ct)
     {
         // Mirror MainLayout.WriteFile: prefer File System Access API, fall back to anchor.
+        // Thread `ct` through to both JS calls so Cancel stays responsive through the
+        // "Saving…" phase (e.g. while the File System Access picker is open).
         if (await FileSystemAccessService.IsSupportedAsync())
         {
             try
             {
                 await JSRuntime.InvokeVoidAsync(
                     "showFilePickerAndWrite",
+                    ct,
                     fileName,
                     data,
                     ".zip",
@@ -290,7 +293,7 @@ public partial class BulkExportDialog : IDisposable
             }
         }
 
-        await JSRuntime.InvokeVoidAsync("downloadBlob", fileName, data, "application/zip");
+        await JSRuntime.InvokeVoidAsync("downloadBlob", ct, fileName, data, "application/zip");
     }
 
     private void CancelExport() => cts?.Cancel();

--- a/Pkmds.Rcl/Components/Dialogs/BulkExportDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/BulkExportDialog.razor.cs
@@ -2,7 +2,7 @@ using System.IO.Compression;
 
 namespace Pkmds.Rcl.Components.Dialogs;
 
-public partial class BulkExportDialog
+public partial class BulkExportDialog : IDisposable
 {
     public enum BulkExportScope
     {
@@ -12,14 +12,28 @@ public partial class BulkExportDialog
         Everything
     }
 
+    // Yield cadence inside the zip-build loop. WASM is single-threaded — without periodic
+    // yields the UI freezes for noticeable hitches on large bank dumps.
+    private const int YieldEveryN = 16;
+
     private int currentBoxCount;
+    private CancellationTokenSource? cts;
     private bool isExporting;
     private int partyCount;
+    private double progressPercent;
     private BulkExportScope scope = BulkExportScope.CurrentBox;
+    private string statusText = string.Empty;
     private int totalBoxCount;
 
     [CascadingParameter]
     private IMudDialogInstance? MudDialog { get; set; }
+
+    public void Dispose()
+    {
+        cts?.Cancel();
+        cts?.Dispose();
+        cts = null;
+    }
 
     protected override void OnInitialized()
     {
@@ -106,12 +120,19 @@ public partial class BulkExportDialog
             return;
         }
 
+        cts?.Dispose();
+        cts = new CancellationTokenSource();
+        var ct = cts.Token;
+
         isExporting = true;
+        progressPercent = 0;
+        statusText = $"Building zip ({pokemonToExport.Count} Pokémon)…";
         StateHasChanged();
+        await Task.Yield();
 
         try
         {
-            var zipBytes = BuildZip(pokemonToExport);
+            var zipBytes = await BuildZipAsync(pokemonToExport, ct);
             var fileName = scope switch
             {
                 BulkExportScope.Party => "pokemon_export_party.zip",
@@ -122,10 +143,18 @@ public partial class BulkExportDialog
                 _ => "pokemon_export.zip"
             };
 
+            statusText = "Saving…";
+            progressPercent = 100;
+            StateHasChanged();
+
             await WriteZipAsync(zipBytes, fileName);
 
             Snackbar.Add($"Exported {pokemonToExport.Count} Pokémon.", Severity.Success);
             MudDialog?.Close();
+        }
+        catch (OperationCanceledException)
+        {
+            Snackbar.Add("Export cancelled.", Severity.Info);
         }
         catch (Exception ex)
         {
@@ -134,6 +163,7 @@ public partial class BulkExportDialog
         finally
         {
             isExporting = false;
+            cts = null;
             StateHasChanged();
         }
     }
@@ -176,22 +206,37 @@ public partial class BulkExportDialog
         return result;
     }
 
-    private byte[] BuildZip(IReadOnlyList<PKM> pokemon)
+    private async Task<byte[]> BuildZipAsync(IReadOnlyList<PKM> pokemon, CancellationToken ct)
     {
         using var ms = new MemoryStream();
         using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
         {
             var usedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var pkm in pokemon)
+            for (var i = 0; i < pokemon.Count; i++)
             {
+                ct.ThrowIfCancellationRequested();
+
+                var pkm = pokemon[i];
                 pkm.RefreshChecksum();
                 var bytes = new byte[pkm.SIZE_PARTY];
                 pkm.WriteDecryptedDataParty(bytes);
 
                 var entryName = GetUniqueEntryName(usedNames, AppService.GetCleanFileName(pkm));
                 var entry = zip.CreateEntry(entryName, CompressionLevel.Fastest);
-                using var es = entry.Open();
-                es.Write(bytes);
+                using (var es = entry.Open())
+                {
+                    es.Write(bytes);
+                }
+
+                // Reserve 0→95% for zip building; the final 5% covers the save dialog.
+                progressPercent = (double)(i + 1) / pokemon.Count * 95;
+                statusText = $"Adding {i + 1}/{pokemon.Count}: {entryName}";
+
+                if ((i + 1) % YieldEveryN == 0 || i == pokemon.Count - 1)
+                {
+                    StateHasChanged();
+                    await Task.Delay(1, ct);
+                }
             }
         }
 
@@ -240,13 +285,10 @@ public partial class BulkExportDialog
             }
         }
 
-        // Legacy fallback: base64 data-URI anchor click.
-        var base64 = Convert.ToBase64String(data);
-        var anchor = await JSRuntime.InvokeAsync<IJSObjectReference>("eval", "document.createElement('a')");
-        await anchor.InvokeVoidAsync("setAttribute", "href", $"data:application/zip;base64,{base64}");
-        await anchor.InvokeVoidAsync("setAttribute", "download", fileName);
-        await anchor.InvokeVoidAsync("click");
+        await JSRuntime.InvokeVoidAsync("downloadBlob", fileName, data, "application/zip");
     }
+
+    private void CancelExport() => cts?.Cancel();
 
     private void Cancel() => MudDialog?.Close(DialogResult.Cancel());
 }

--- a/Pkmds.Rcl/Components/Dialogs/BulkExportDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/BulkExportDialog.razor.cs
@@ -162,8 +162,12 @@ public partial class BulkExportDialog : IDisposable
         }
         finally
         {
-            isExporting = false;
+            // Capture before nulling so a concurrent component Dispose (which also nulls
+            // cts) can't cause us to leak the CTS — exactly one path disposes it.
+            var localCts = cts;
             cts = null;
+            localCts?.Dispose();
+            isExporting = false;
             StateHasChanged();
         }
     }
@@ -280,8 +284,9 @@ public partial class BulkExportDialog : IDisposable
             catch (JSException ex) when (ex.Message.Contains("AbortError", StringComparison.OrdinalIgnoreCase) ||
                                          ex.Message.Contains("aborted a request", StringComparison.OrdinalIgnoreCase))
             {
-                // User dismissed the picker — not an error.
-                return;
+                // User dismissed the picker. Throw so ExportAsync surfaces "cancelled"
+                // rather than reporting a successful export with no file written.
+                throw new OperationCanceledException("Save dialog dismissed.");
             }
         }
 

--- a/Pkmds.Rcl/Components/Dialogs/BulkImportDialog.razor
+++ b/Pkmds.Rcl/Components/Dialogs/BulkImportDialog.razor
@@ -14,7 +14,7 @@
             else
             {
                 <MudFileUpload T="IReadOnlyList<IBrowserFile>"
-                               MaximumFileCount="9999"
+                               MaximumFileCount="MaxBulkImportFiles"
                                Accept="@AcceptList"
                                @bind-Files="selectedFiles">
                     <CustomContent>

--- a/Pkmds.Rcl/Components/Dialogs/BulkImportDialog.razor
+++ b/Pkmds.Rcl/Components/Dialogs/BulkImportDialog.razor
@@ -14,7 +14,7 @@
             else
             {
                 <MudFileUpload T="IReadOnlyList<IBrowserFile>"
-                               MaximumFileCount="MaxBulkImportFiles"
+                               MaximumFileCount="@MaxBulkImportFiles"
                                Accept="@AcceptList"
                                @bind-Files="selectedFiles">
                     <CustomContent>

--- a/Pkmds.Rcl/Components/Dialogs/BulkImportDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/BulkImportDialog.razor.cs
@@ -2,6 +2,14 @@ namespace Pkmds.Rcl.Components.Dialogs;
 
 public partial class BulkImportDialog : IDisposable
 {
+    // MudFileUpload requires an explicit upper bound; this is effectively "unlimited" for
+    // a hand-curated bulk drop. A full Gen 8+ bank dump tops out at ~990 (32 boxes × 30 + party).
+    private const int MaxBulkImportFiles = 9999;
+
+    // Yield cadence inside the placement / legality loops. WASM is single-threaded —
+    // without periodic yields the UI freezes mid-import.
+    private const int YieldEveryN = 8;
+
     private static readonly string AcceptList = BuildAcceptList();
 
     private CancellationTokenSource? cts;
@@ -74,6 +82,11 @@ public partial class BulkImportDialog : IDisposable
 
         var parseSkipped = 0;
         var parsed = new List<PKM>(sources.Count);
+        var placed = new List<PKM>();
+        var overflow = new List<PKM>();
+        var illegal = 0;
+        var overflowToBank = 0;
+        var cancelled = false;
 
         try
         {
@@ -102,31 +115,23 @@ public partial class BulkImportDialog : IDisposable
                 sav.AdaptToSaveFile(converted);
                 parsed.Add(converted);
 
-                if ((i + 1) % 8 == 0)
+                if ((i + 1) % YieldEveryN == 0)
                 {
                     StateHasChanged();
                     await Task.Delay(1, ct);
                 }
             }
 
-            // Placement phase.
-            statusText = $"Placing {parsed.Count} Pokémon…";
-            progressPercent = 50;
-            StateHasChanged();
-            await Task.Yield();
+            // Placement phase: write each PKM, then re-read the stored bytes so legality
+            // analysis runs against what the save actually holds (handler/memory/trainer
+            // fields can change on write). Lists are filled in place so cancellation
+            // mid-loop preserves the partial counts for the summary.
+            await PlacePokemonAsync(sav, parsed, placed, overflow, overwriteExisting, FillBoxesFirst, ct);
 
-            var (placed, overflow) = PlacePokemon(sav, parsed, overwriteExisting, FillBoxesFirst);
-            var illegal = 0;
-            foreach (var pk in placed)
-            {
-                var la = AppService.GetLegalityAnalysis(pk);
-                if (!la.Valid)
-                {
-                    illegal++;
-                }
-            }
+            // Legality phase: counter is updated via callback so cancellation mid-scan
+            // still reports an accurate "checked so far" total in the summary.
+            await CountIllegalAsync(placed, current => illegal = current, ct);
 
-            var overflowToBank = 0;
             if (overflow.Count > 0 && sendOverflowToBank)
             {
                 statusText = $"Sending {overflow.Count} Pokémon to Bank…";
@@ -142,34 +147,32 @@ public partial class BulkImportDialog : IDisposable
 
             progressPercent = 100;
             statusText = "Done.";
-
-            result = new BulkImportResult(
-                Imported: placed.Count,
-                Skipped: parseSkipped,
-                Illegal: illegal,
-                OverflowRemaining: overflow.Count - overflowToBank,
-                OverflowToBank: overflowToBank);
-
-            RefreshService.RefreshBoxAndPartyState();
         }
         catch (OperationCanceledException)
         {
-            result = new BulkImportResult(
-                Imported: 0, Skipped: 0, Illegal: 0, OverflowRemaining: 0, OverflowToBank: 0)
-            { Cancelled = true };
-            RefreshService.RefreshBoxAndPartyState();
+            cancelled = true;
         }
         catch (Exception ex)
         {
             Snackbar.Add($"Import failed: {ex.Message}", Severity.Error);
+            return;
         }
         finally
         {
             isImporting = false;
-            cts?.Dispose();
             cts = null;
             StateHasChanged();
         }
+
+        result = new BulkImportResult(
+            Imported: placed.Count,
+            Skipped: parseSkipped,
+            Illegal: illegal,
+            OverflowRemaining: overflow.Count - overflowToBank,
+            OverflowToBank: overflowToBank)
+        { Cancelled = cancelled };
+
+        RefreshService.RefreshBoxAndPartyState();
     }
 
     private async Task<List<(string FileName, byte[] Data)>> LoadSourcesAsync()
@@ -231,52 +234,118 @@ public partial class BulkImportDialog : IDisposable
         return result.IsSuccess ? converted : null;
     }
 
-    private static (List<PKM> Placed, List<PKM> Overflow) PlacePokemon(
-        SaveFile sav, IReadOnlyList<PKM> candidates, bool overwrite, bool fillBoxesFirst)
+    private async Task PlacePokemonAsync(
+        SaveFile sav,
+        IReadOnlyList<PKM> candidates,
+        List<PKM> placed,
+        List<PKM> overflow,
+        bool overwrite,
+        bool fillBoxesFirst,
+        CancellationToken ct)
     {
-        var placed = new List<PKM>(candidates.Count);
-        var overflow = new List<PKM>();
-
-        foreach (var pkm in candidates)
+        var total = candidates.Count;
+        if (total == 0)
         {
-            if (TryPlaceSequential(sav, pkm, overwrite, fillBoxesFirst))
+            return;
+        }
+
+        statusText = $"Placing {total} Pokémon…";
+        progressPercent = 50;
+        StateHasChanged();
+        await Task.Delay(1, ct);
+
+        for (var i = 0; i < total; i++)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var location = TryPlaceSequential(sav, candidates[i], overwrite, fillBoxesFirst);
+            if (location is { } loc)
             {
-                placed.Add(pkm);
+                // Re-read the stored entity. SetXxxSlotAtIndex can adjust handler/memory/
+                // trainer fields, so the in-memory candidate may diverge from what's saved.
+                var stored = loc.IsParty
+                    ? sav.GetPartySlotAtIndex(loc.PartyIndex)
+                    : sav.GetBoxSlotAtIndex(loc.Box, loc.Slot);
+                placed.Add(stored);
             }
             else
             {
-                overflow.Add(pkm);
+                overflow.Add(candidates[i]);
+            }
+
+            // Reserve 50→70% for placement.
+            progressPercent = 50 + ((double)(i + 1) / total * 20);
+            statusText = $"Placing {i + 1}/{total}…";
+
+            if ((i + 1) % YieldEveryN == 0 || i == total - 1)
+            {
+                StateHasChanged();
+                await Task.Delay(1, ct);
             }
         }
-
-        return (placed, overflow);
     }
 
-    private static bool TryPlaceSequential(SaveFile sav, PKM pkm, bool overwrite, bool fillBoxesFirst)
+    private async Task CountIllegalAsync(IReadOnlyList<PKM> placed, Action<int> updateCount, CancellationToken ct)
     {
-        // Party is never overwritten — `sav.PartyCount < 6` means there's a grow slot,
-        // which matches IAppService.TryPlacePokemonInFirstAvailableSlot. Overwrite only
-        // applies to boxes.
-        if (fillBoxesFirst)
+        if (placed.Count == 0)
         {
-            return TryFillBoxes(sav, pkm, overwrite) || TryFillParty(sav, pkm);
+            return;
         }
 
-        return TryFillParty(sav, pkm) || TryFillBoxes(sav, pkm, overwrite);
+        var illegal = 0;
+        for (var i = 0; i < placed.Count; i++)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var la = AppService.GetLegalityAnalysis(placed[i]);
+            if (!la.Valid)
+            {
+                illegal++;
+            }
+
+            // Push the running count up so the caller's summary reflects partial progress
+            // if the user cancels mid-scan.
+            updateCount(illegal);
+
+            // Reserve 70→85% for legality scan.
+            progressPercent = 70 + ((double)(i + 1) / placed.Count * 15);
+            statusText = $"Checking legality {i + 1}/{placed.Count}…";
+
+            if ((i + 1) % YieldEveryN == 0 || i == placed.Count - 1)
+            {
+                StateHasChanged();
+                await Task.Delay(1, ct);
+            }
+        }
     }
 
-    private static bool TryFillParty(SaveFile sav, PKM pkm)
+    private static PlacedSlot? TryPlaceSequential(SaveFile sav, PKM pkm, bool overwrite, bool fillBoxesFirst)
+    {
+        // Party is never overwritten — `sav.PartyCount < 6` means there's a grow slot,
+        // matching IAppService.TryPlacePokemonInFirstAvailableSlot. The locked-slot guard
+        // in TryFillBoxes is therefore intentionally box-only: party has no battle-team
+        // lock concept (that flag only applies to box storage in Gen 5/6).
+        if (fillBoxesFirst)
+        {
+            return TryFillBoxes(sav, pkm, overwrite) ?? TryFillParty(sav, pkm);
+        }
+
+        return TryFillParty(sav, pkm) ?? TryFillBoxes(sav, pkm, overwrite);
+    }
+
+    private static PlacedSlot? TryFillParty(SaveFile sav, PKM pkm)
     {
         if (sav.PartyCount >= 6)
         {
-            return false;
+            return null;
         }
 
-        sav.SetPartySlotAtIndex(pkm, sav.PartyCount);
-        return true;
+        var index = sav.PartyCount;
+        sav.SetPartySlotAtIndex(pkm, index);
+        return PlacedSlot.ForParty(index);
     }
 
-    private static bool TryFillBoxes(SaveFile sav, PKM pkm, bool overwrite)
+    private static PlacedSlot? TryFillBoxes(SaveFile sav, PKM pkm, bool overwrite)
     {
         for (var box = 0; box < sav.BoxCount; box++)
         {
@@ -292,11 +361,11 @@ public partial class BulkImportDialog : IDisposable
                 }
 
                 sav.SetBoxSlotAtIndex(pkm, box, slot);
-                return true;
+                return PlacedSlot.ForBox(box, slot);
             }
         }
 
-        return false;
+        return null;
     }
 
     // Avoid stomping on locked battle-team slots (Gen 5/6). PKHeX's GetBoxSlotFlags
@@ -305,6 +374,12 @@ public partial class BulkImportDialog : IDisposable
     {
         var flags = sav.GetBoxSlotFlags(box, slot);
         return !flags.HasFlag(StorageSlotSource.Locked);
+    }
+
+    private readonly record struct PlacedSlot(bool IsParty, int Box, int Slot, int PartyIndex)
+    {
+        public static PlacedSlot ForParty(int index) => new(true, 0, 0, index);
+        public static PlacedSlot ForBox(int box, int slot) => new(false, box, slot, 0);
     }
 
     private void CancelImport() => cts?.Cancel();
@@ -324,12 +399,11 @@ public partial class BulkImportDialog : IDisposable
             return string.Empty;
         }
 
-        if (result.Cancelled)
-        {
-            return "Import cancelled.";
-        }
+        var prefix = result.Cancelled
+            ? $"Import cancelled. Imported {result.Imported}"
+            : $"Imported {result.Imported}";
+        var parts = new List<string> { prefix };
 
-        var parts = new List<string> { $"Imported {result.Imported}" };
         if (result.Skipped > 0)
         {
             parts.Add($"skipped {result.Skipped} (incompatible)");

--- a/Pkmds.Rcl/Components/Dialogs/BulkImportDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/BulkImportDialog.razor.cs
@@ -1,3 +1,5 @@
+using PKHexSeverity = PKHeX.Core.Severity;
+
 namespace Pkmds.Rcl.Components.Dialogs;
 
 public partial class BulkImportDialog : IDisposable
@@ -159,8 +161,12 @@ public partial class BulkImportDialog : IDisposable
         }
         finally
         {
-            isImporting = false;
+            // Capture before nulling so a concurrent component Dispose (which also nulls
+            // cts) can't cause us to leak the CTS — exactly one path disposes it.
+            var localCts = cts;
             cts = null;
+            localCts?.Dispose();
+            isImporting = false;
             StateHasChanged();
         }
 
@@ -298,7 +304,7 @@ public partial class BulkImportDialog : IDisposable
             ct.ThrowIfCancellationRequested();
 
             var la = AppService.GetLegalityAnalysis(placed[i]);
-            if (!la.Valid)
+            if (IsIllegal(la))
             {
                 illegal++;
             }
@@ -375,6 +381,14 @@ public partial class BulkImportDialog : IDisposable
         var flags = sav.GetBoxSlotFlags(box, slot);
         return !flags.HasFlag(StorageSlotSource.Locked);
     }
+
+    // Match PokemonStorageComponent.GetStatus / LegalityReportTab.GetStatus so the bulk
+    // summary's illegal count agrees with the box header and the Legality Report tab.
+    // `la.Valid` is also false for Fishy results, which would over-count here.
+    private static bool IsIllegal(LegalityAnalysis la) =>
+        la.Results.Any(r => r.Judgement == PKHexSeverity.Invalid)
+        || !MoveResult.AllValid(la.Info.Moves)
+        || !MoveResult.AllValid(la.Info.Relearn);
 
     private readonly record struct PlacedSlot(bool IsParty, int Box, int Slot, int PartyIndex)
     {

--- a/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor.cs
@@ -814,10 +814,12 @@ public partial class TradeTab : RefreshAwareComponent
         if (isParty)
         {
             save.SetPartySlotAtIndex(pkm, slotNumber);
+            save.CompactParty();
         }
         else if (boxNumber.HasValue)
         {
             save.SetBoxSlotAtIndex(pkm, boxNumber.Value, slotNumber);
+            save.CompactBoxIfGen12(boxNumber.Value);
         }
     }
 
@@ -831,6 +833,7 @@ public partial class TradeTab : RefreshAwareComponent
         else if (boxNumber.HasValue)
         {
             save.SetBoxSlotAtIndex(save.BlankPKM, boxNumber.Value, slotNumber);
+            save.CompactBoxIfGen12(boxNumber.Value);
         }
     }
 
@@ -982,6 +985,7 @@ public partial class TradeTab : RefreshAwareComponent
             if (destBox.HasValue)
             {
                 save.SetBoxSlotAtIndex(source, destBox.Value, destSlot);
+                save.CompactBoxIfGen12(destBox.Value);
             }
             save.DeletePartySlot(srcSlot);
             return true;
@@ -992,9 +996,11 @@ public partial class TradeTab : RefreshAwareComponent
             if (srcBox.HasValue)
             {
                 save.SetBoxSlotAtIndex(save.BlankPKM, srcBox.Value, srcSlot);
+                save.CompactBoxIfGen12(srcBox.Value);
             }
             var target = destSlot >= save.PartyCount ? save.PartyCount : destSlot;
             save.SetPartySlotAtIndex(source, target);
+            save.CompactParty();
             return true;
         }
 

--- a/Pkmds.Rcl/Components/PokemonSlotComponent.razor.cs
+++ b/Pkmds.Rcl/Components/PokemonSlotComponent.razor.cs
@@ -379,6 +379,11 @@ public partial class PokemonSlotComponent : IDisposable
         if (e.DataTransfer.Files.Length > 0)
         {
             DragDropService.ClearDrag();
+            // Render now so the slot's external-drop highlight (driven by
+            // isDragOverWithExternalFile above) clears before the potentially
+            // long-running import; otherwise the next render only happens after
+            // HandleFileDropAsync completes, leaving the highlight on during it.
+            StateHasChanged();
             await HandleFileDropAsync(e.DataTransfer.Files);
             return;
         }

--- a/Pkmds.Rcl/Components/PokemonSlotComponent.razor.cs
+++ b/Pkmds.Rcl/Components/PokemonSlotComponent.razor.cs
@@ -515,15 +515,20 @@ public partial class PokemonSlotComponent : IDisposable
 
             saveFile.AdaptToSaveFile(pokemon);
 
-            // Place the Pokemon in the dropped slot
+            // Place the Pokemon in the dropped slot. Party is always a packed list in every
+            // generation, and Gen 1/2 boxes are packed lists too — compact after the write so
+            // dropping past the last filled slot collapses into the next free slot instead of
+            // leaving a gap.
             if (IsPartySlot)
             {
                 saveFile.SetPartySlotAtIndex(pokemon, SlotNumber);
+                saveFile.CompactParty();
                 RefreshService.RefreshPartyState();
             }
             else if (BoxNumber.HasValue)
             {
                 saveFile.SetBoxSlotAtIndex(pokemon, BoxNumber.Value, SlotNumber);
+                saveFile.CompactBoxIfGen12(BoxNumber.Value);
                 RefreshService.RefreshBoxState();
             }
             else // LetsGo storage

--- a/Pkmds.Rcl/Components/PokemonSlotComponent.razor.cs
+++ b/Pkmds.Rcl/Components/PokemonSlotComponent.razor.cs
@@ -342,9 +342,11 @@ public partial class PokemonSlotComponent : IDisposable
 
     private void HandleDragEnter(DragEventArgs e)
     {
-        // Show visual feedback when an external file is dragged over the slot
-        if (DragDropService.IsDragging ||
-            !e.DataTransfer.Types.Any(t => t.Equals("Files", StringComparison.OrdinalIgnoreCase)))
+        // Show visual feedback when an external file is dragged over the slot.
+        // Internal drags never include "Files" in DataTransfer.Types, so this check
+        // is authoritative — don't gate on DragDropService.IsDragging, because that
+        // state can be stale after a drag-out-to-OS where `dragend` didn't fire.
+        if (!e.DataTransfer.Types.Any(t => t.Equals("Files", StringComparison.OrdinalIgnoreCase)))
         {
             return;
         }
@@ -368,51 +370,57 @@ public partial class PokemonSlotComponent : IDisposable
     {
         isDragOverWithExternalFile = false;
 
-        // Check for internal drag first - this takes priority over file drops
-        if (DragDropService.IsDragging)
+        // Prefer external file drops over the internal-drag state. After a successful
+        // drag-out-to-OS, Chrome's DownloadURL transfer doesn't always fire `dragend`
+        // on the source slot (the drop is consumed by the OS), so DragDropService can
+        // still report IsDragging when the user drags the resulting file back in. If
+        // we see real files on this drop, treat it as an import and clear any stale
+        // internal drag state so the next interaction starts clean.
+        if (e.DataTransfer.Files.Length > 0)
         {
-            // Don't drop onto the same slot
-            if (DragDropService.IsDragSourceParty == IsPartySlot &&
-                DragDropService.DragSourceBoxNumber == BoxNumber &&
-                DragDropService.DragSourceSlotNumber == SlotNumber)
-            {
-                DragDropService.ClearDrag();
-                StateHasChanged();
-                return;
-            }
+            DragDropService.ClearDrag();
+            await HandleFileDropAsync(e.DataTransfer.Files);
+            return;
+        }
 
-            // Drag and drop is not supported for Let's Go games
-            if (AppState.SaveFile is SAV7b)
-            {
-                DragDropService.ClearDrag();
-                StateHasChanged();
-                return;
-            }
+        if (!DragDropService.IsDragging)
+        {
+            return;
+        }
 
-            // Move the Pokémon
-            AppService.MovePokemon(
-                DragDropService.DragSourceBoxNumber,
-                DragDropService.DragSourceSlotNumber,
-                DragDropService.IsDragSourceParty,
-                BoxNumber,
-                SlotNumber,
-                IsPartySlot
-            );
-
-            // Clear the selection so the editor panel closes after the move
-            AppService.ClearSelection();
-
+        // Don't drop onto the same slot
+        if (DragDropService.IsDragSourceParty == IsPartySlot &&
+            DragDropService.DragSourceBoxNumber == BoxNumber &&
+            DragDropService.DragSourceSlotNumber == SlotNumber)
+        {
             DragDropService.ClearDrag();
             StateHasChanged();
             return;
         }
 
-        // Check if this is a file drop from external source
-        // Only process if we're not in an internal drag operation
-        if (e.DataTransfer.Files.Length > 0)
+        // Drag and drop is not supported for Let's Go games
+        if (AppState.SaveFile is SAV7b)
         {
-            await HandleFileDropAsync(e.DataTransfer.Files);
+            DragDropService.ClearDrag();
+            StateHasChanged();
+            return;
         }
+
+        // Move the Pokémon
+        AppService.MovePokemon(
+            DragDropService.DragSourceBoxNumber,
+            DragDropService.DragSourceSlotNumber,
+            DragDropService.IsDragSourceParty,
+            BoxNumber,
+            SlotNumber,
+            IsPartySlot
+        );
+
+        // Clear the selection so the editor panel closes after the move
+        AppService.ClearSelection();
+
+        DragDropService.ClearDrag();
+        StateHasChanged();
     }
 
     private async Task HandleFileDropAsync(string[] fileNames)

--- a/Pkmds.Rcl/Services/AppService.cs
+++ b/Pkmds.Rcl/Services/AppService.cs
@@ -217,6 +217,9 @@ public class AppService(IAppState appState, IRefreshService refreshService, ILeg
         {
             case SelectedPokemonType.Party:
                 AppState.SaveFile.SetPartySlotAtIndex(pokemon, partySlot);
+                // If the edited slot was past PartyCount (e.g. HaX mode editing an empty slot)
+                // the write would leave a gap; party is always a packed list, so compact.
+                AppState.SaveFile.CompactParty();
 
                 // Let's Go games store Pokémon in a unified storage system
                 // Changes to party affect box display, so refresh both
@@ -232,6 +235,7 @@ public class AppService(IAppState appState, IRefreshService refreshService, ILeg
                 break;
             case SelectedPokemonType.Box:
                 AppState.SaveFile.SetBoxSlotAtIndex(pokemon, boxNumber, boxSlot);
+                AppState.SaveFile.CompactBoxIfGen12(boxNumber);
                 RefreshService.RefreshBoxState();
                 break;
             case SelectedPokemonType.None when AppState.SaveFile is SAV7b:
@@ -804,11 +808,7 @@ public class AppService(IAppState appState, IRefreshService refreshService, ILeg
                     {
                         saveFile.SetBoxSlotAtIndex(sourcePokemon, destBoxNumber.Value, destSlotNumber);
 
-                        // Gen 1 and Gen 2 boxes should be compacted like party (they were lists, not grids)
-                        if (saveFile.Context is EntityContext.Gen1 or EntityContext.Gen2)
-                        {
-                            CompactBox(saveFile, destBoxNumber.Value);
-                        }
+                        saveFile.CompactBoxIfGen12(destBoxNumber.Value);
                     }
                     else // LetsGo storage
                     {
@@ -827,29 +827,23 @@ public class AppService(IAppState appState, IRefreshService refreshService, ILeg
                     {
                         saveFile.SetBoxSlotAtIndex(saveFile.BlankPKM, sourceBoxNumber.Value, sourceSlotNumber);
 
-                        // Gen 1 and Gen 2 boxes should be compacted like party (they were lists, not grids)
-                        if (saveFile.Context is EntityContext.Gen1 or EntityContext.Gen2)
-                        {
-                            CompactBox(saveFile, sourceBoxNumber.Value);
-                        }
+                        saveFile.CompactBoxIfGen12(sourceBoxNumber.Value);
                     }
                     else // LetsGo storage
                     {
                         saveFile.SetBoxSlotAtIndex(saveFile.BlankPKM, sourceSlotNumber);
                     }
 
-                    // Add to party at the first available empty slot (or the specified slot if within PartyCount)
-                    // PKHeX.Core's party is kept compact, so we should add at PartyCount position
-                    // unless the user explicitly dropped on an occupied slot (which would be a swap)
-                    // or on an empty slot within the current party range
-                    var targetSlot = destSlotNumber;
-                    if (destSlotNumber >= saveFile.PartyCount)
-                    {
-                        // User dropped beyond current party - add at end of party (PartyCount position)
-                        targetSlot = saveFile.PartyCount;
-                    }
+                    // Realign beyond-PartyCount drops to the append position so dropping on slot
+                    // 5 with only 1 party member lands at slot 1, not slot 5 (mirrors PKHeX's
+                    // SlotInfoParty.WriteTo). CompactParty is a safety net in case an upstream
+                    // state was already inconsistent.
+                    var targetSlot = destSlotNumber >= saveFile.PartyCount
+                        ? saveFile.PartyCount
+                        : destSlotNumber;
 
                     saveFile.SetPartySlotAtIndex(sourcePokemon, targetSlot);
+                    saveFile.CompactParty();
                     break;
                 }
             default:
@@ -910,28 +904,24 @@ public class AppService(IAppState appState, IRefreshService refreshService, ILeg
                         else if (sourceBoxNumber.HasValue)
                         {
                             saveFile.SetBoxSlotAtIndex(saveFile.BlankPKM, sourceBoxNumber.Value, sourceSlotNumber);
-
-                            // Gen 1 and Gen 2 boxes should be compacted like party (they were lists, not grids)
-                            if (saveFile.Context is EntityContext.Gen1 or EntityContext.Gen2)
-                            {
-                                CompactBox(saveFile, sourceBoxNumber.Value);
-                            }
+                            saveFile.CompactBoxIfGen12(sourceBoxNumber.Value);
                         }
                         else // LetsGo storage
                         {
                             saveFile.SetBoxSlotAtIndex(saveFile.BlankPKM, sourceSlotNumber);
                         }
 
-                        // For Gen 1/2: If we just moved within the same box or moved into a box, compact the destination box too
-                        if (saveFile.Context is EntityContext.Gen1 or EntityContext.Gen2 && !isDestParty &&
-                            destBoxNumber.HasValue)
+                        // Compact the destination too: dropping past the last filled slot (party
+                        // in any gen, or a Gen 1/2 box) otherwise leaves a gap. For party→party
+                        // moves, DeletePartySlot above can additionally leave PartyCount in an
+                        // inconsistent state when the drop target was past the original count.
+                        if (isDestParty)
                         {
-                            // Check if destination box differs from source box, or if we're moving within same box
-                            // Either way, compact the destination box to ensure proper list format
-                            if (!isSourceParty)
-                            {
-                                CompactBox(saveFile, destBoxNumber.Value);
-                            }
+                            saveFile.CompactParty();
+                        }
+                        else if (destBoxNumber.HasValue)
+                        {
+                            saveFile.CompactBoxIfGen12(destBoxNumber.Value);
                         }
                     }
 
@@ -1942,35 +1932,6 @@ public class AppService(IAppState appState, IRefreshService refreshService, ILeg
     /// Compacts a box by shifting all Pokémon left to fill gaps (for Gen 1 and Gen 2 games).
     /// In these generations, boxes were lists, not grids, so they should have no gaps.
     /// </summary>
-    private static void CompactBox(SaveFile saveFile, int boxNumber)
-    {
-        var boxSlotCount = saveFile.BoxSlotCount;
-        var compacted = new PKM[boxSlotCount];
-        var writeIndex = 0;
-
-        // Collect all non-blank Pokémon
-        for (var i = 0; i < boxSlotCount; i++)
-        {
-            var pkm = saveFile.GetBoxSlotAtIndex(boxNumber, i);
-            if (pkm.Species > 0)
-            {
-                compacted[writeIndex++] = pkm;
-            }
-        }
-
-        // Fill remaining slots with blank Pokémon
-        for (var i = writeIndex; i < boxSlotCount; i++)
-        {
-            compacted[i] = saveFile.BlankPKM;
-        }
-
-        // Write the compacted box back
-        for (var i = 0; i < boxSlotCount; i++)
-        {
-            saveFile.SetBoxSlotAtIndex(compacted[i], boxNumber, i);
-        }
-    }
-
     private EncounterSearchResult BuildEncounterResult(IEncounterable enc)
     {
         var speciesName = GetPokemonSpeciesName(enc.Species);

--- a/Pkmds.Rcl/wwwroot/js/fileSave.js
+++ b/Pkmds.Rcl/wwwroot/js/fileSave.js
@@ -92,19 +92,6 @@ window.readDroppedFile = async function (index) {
     });
 };
 
-// Returns the number of files currently queued from the last drop event.
-window.getDroppedFileCount = function () {
-    return window.droppedFiles ? window.droppedFiles.length : 0;
-};
-
-// Returns the filename of the dropped file at the given index, or null.
-window.getDroppedFileName = function (index) {
-    if (!window.droppedFiles || index >= window.droppedFiles.length) {
-        return null;
-    }
-    return window.droppedFiles[index].name;
-};
-
 // Returns true if the page is running inside a known in-app browser (e.g. Google Search App,
 // Facebook, Instagram) whose WebView may block file downloads or the File System Access API.
 window.isInAppBrowser = function () {
@@ -224,4 +211,23 @@ window.showFilePickerAndWrite = async function (fileName, byteArray, extension, 
         console.error('[showFilePickerAndWrite] Error:', ex);
         throw ex;
     }
+};
+
+// Anchor-based blob download. Used as a fallback when the File System Access API isn't
+// available (or the user dismissed it). Avoids the ~33% base64 inflation of a data: URI
+// and works around URL-length limits on older engines.
+window.downloadBlob = function (fileName, byteArray, mimeType) {
+    if (!byteArray) return;
+    const uint8 = byteArray instanceof Uint8Array ? byteArray : new Uint8Array(byteArray);
+    const blob = new Blob([uint8], { type: mimeType || 'application/octet-stream' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = fileName;
+    document.body.appendChild(a);
+    a.click();
+    setTimeout(() => {
+        URL.revokeObjectURL(url);
+        a.remove();
+    }, 0);
 };


### PR DESCRIPTION
## Summary

- **Fixes #723**: After dragging a `.pk*` out of a slot to the OS desktop and dragging it back into the same save, the original Pokémon was being relocated instead of imported. Chrome's DownloadURL transfer is consumed by the OS, so `dragend` doesn't reliably fire on the source slot — leaving `DragDropService.IsDragging` set. The drop handler then took the internal-move branch first.
- `HandleDrop` now treats a non-empty `DataTransfer.Files` as authoritative and clears any stale internal-drag state before importing.
- `HandleDragEnter` no longer gates the file-drop visual on `IsDragging` — the `"Files"` entry in `DataTransfer.Types` is the authoritative signal for an external file drag.

Also rolls up the previously-merged bulk import/export follow-ups from #729 (and #728 cleanup) that landed on `dev` after the last `main` merge.

## Notes

- Issue #723 also mentioned that Gen 1/2 box clamping "didn't happen" when the file was successfully imported on the second drop. Tracked separately in #731 — needs a more specific repro before changing behavior.

## Test plan

- [x] Load a Gen 1 (Blue) save.
- [x] Drag a Pokémon from a box slot out to the OS desktop — confirm the `.pk1` file lands and the source slot is unchanged.
- [x] Drag that file back into a different slot in the same save — confirm it imports as a new Pokémon (clone), and the original slot is unchanged.
- [ ] Repeat against Gen 6+ saves to confirm no regression in the normal external-file import path.
- [ ] Sanity-check internal slot-to-slot moves (drag within the box, party↔box) still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)