### PR TITLE
fix: avoid in-app-browser detection global name collision (#732)

### DIFF
--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
@@ -95,16 +95,26 @@ public partial class MainLayout : IDisposable
 
         // Warn users who are running inside a known in-app browser (e.g. Google Search App,
         // Facebook) whose WebView typically blocks file downloads.
-        var isInAppBrowser = await JSRuntime.InvokeAsync<bool>("isInAppBrowser");
-        if (isInAppBrowser)
+        // The JS call is wrapped defensively because in-app browsers / extensions sometimes
+        // inject a non-function global with the same name, which would otherwise crash the
+        // entire layout init (see issue #732).
+        try
         {
-            Snackbar.Add(
-                new MarkupString(
-                    "You appear to be using an in-app browser, which may not support file exports. " +
-                    "For the best experience, please open this app in <strong>Safari</strong> (iOS) or " +
-                    "<strong>Chrome</strong> (Android)."),
-                Severity.Warning,
-                options => options.RequireInteraction = true);
+            var isInAppBrowser = await JSRuntime.InvokeAsync<bool>("pkmdsIsInAppBrowser");
+            if (isInAppBrowser)
+            {
+                Snackbar.Add(
+                    new MarkupString(
+                        "You appear to be using an in-app browser, which may not support file exports. " +
+                        "For the best experience, please open this app in <strong>Safari</strong> (iOS) or " +
+                        "<strong>Chrome</strong> (Android)."),
+                    Severity.Warning,
+                    options => options.RequireInteraction = true);
+            }
+        }
+        catch (JSException ex)
+        {
+            Logger.LogWarning(ex, "In-app browser detection failed");
         }
 
         // Load all persisted settings (theme, PKHaX, verbose logging, trainer defaults)

--- a/Pkmds.Rcl/wwwroot/js/fileSave.js
+++ b/Pkmds.Rcl/wwwroot/js/fileSave.js
@@ -94,7 +94,9 @@ window.readDroppedFile = async function (index) {
 
 // Returns true if the page is running inside a known in-app browser (e.g. Google Search App,
 // Facebook, Instagram) whose WebView may block file downloads or the File System Access API.
-window.isInAppBrowser = function () {
+// Namespaced under `pkmds` so we don't collide with the non-function `window.isInAppBrowser`
+// boolean that some in-app browsers / extensions inject into the page (see issue #732).
+window.pkmdsIsInAppBrowser = function () {
     const ua = navigator.userAgent || '';
     return (
         /GSA\//.test(ua) ||                    // Google Search App (iOS)


### PR DESCRIPTION
## Summary
- Rename the JS helper from `window.isInAppBrowser` to `window.pkmdsIsInAppBrowser` so an injected non-function global with the same name (extensions or in-app WebViews) can't shadow ours.
- Wrap the JS interop call in `MainLayout.OnAfterRenderAsync` in `try/catch (JSException)` so a detection failure logs a warning instead of crashing layout init (which was blocking theme + settings load).

Closes #732

## Test plan
- [ ] Load app in a normal browser: no warning snackbar, theme/settings load as expected
- [ ] Load app in an in-app browser (e.g. Facebook, GSA): warning snackbar appears
- [ ] Simulate collision via DevTools: `window.isInAppBrowser = true; location.reload()` — app still loads normally with a warning logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)