### PR TITLE
feat: legality indicators in Showdown import preview

### DIFF
--- a/Pkmds.Rcl/Components/Dialogs/ShowdownImportDialog.razor
+++ b/Pkmds.Rcl/Components/Dialogs/ShowdownImportDialog.razor
@@ -10,7 +10,7 @@
                           Lines="10"
                           Variant="@Variant.Outlined"
                           Placeholder="Paste Showdown text or a PokePaste URL (https://pokepast.es/...)…"
-                          Disabled="@isFetching"/>
+                          Disabled="@(isFetching || isParsing)"/>
 
             @if (!string.IsNullOrEmpty(fetchError))
             {
@@ -37,7 +37,7 @@
                                Variant="@Variant.Filled"
                                StartIcon="@Icons.Material.Filled.Download"
                                Color="@Color.Primary"
-                               Disabled="@isFetching">
+                               Disabled="@(isFetching || isParsing)">
                         @if (isFetching)
                         {
                             <MudProgressCircular Size="@Size.Small"
@@ -51,34 +51,52 @@
                         }
                     </MudButton>
                 }
-                <MudButton OnClick="@ParseText"
+                <MudButton OnClick="@ParseTextAsync"
                            Variant="@Variant.Filled"
                            StartIcon="@Icons.Material.Filled.Search"
-                           Disabled="@(string.IsNullOrWhiteSpace(inputText) || isFetching)">
-                    Parse
+                           Disabled="@(string.IsNullOrWhiteSpace(inputText) || isFetching || isParsing)">
+                    @if (isParsing)
+                    {
+                        <MudProgressCircular Size="@Size.Small"
+                                             Indeterminate="true"
+                                             Class="mr-2"/>
+                        @:Analyzing…
+                    }
+                    else
+                    {
+                        @:Parse
+                    }
                 </MudButton>
             </MudStack>
 
-            @if (parsedSets.Count > 0)
+            @if (parsedEntries.Count > 0)
             {
                 <MudDivider/>
 
                 <MudText Typo="@Typo.subtitle2">
-                    Preview — @parsedSets.Count Pokémon
+                    Preview — @parsedEntries.Count Pokémon
                 </MudText>
 
-                <MudList T="ShowdownSet"
+                <MudList T="ParsedEntry"
                          Dense="true">
-                    @foreach (var set in parsedSets)
+                    @foreach (var entry in parsedEntries)
                     {
-                        <MudListItem T="ShowdownSet">
+                        <MudListItem T="ParsedEntry">
                             <MudStack Row
                                       AlignItems="@AlignItems.Center"
                                       Spacing="1">
-                                <MudText>@GetSetSummary(set)</MudText>
-                                @if (set.InvalidLines.Count > 0)
+                                @if (entry.Status is { } status)
                                 {
-                                    <MudTooltip Text="@GetWarnings(set)">
+                                    <MudTooltip Text="@GetStatusTooltip(entry)">
+                                        <MudIcon Icon="@GetStatusIcon(status)"
+                                                 Color="@GetStatusColor(status)"
+                                                 Size="@Size.Small"/>
+                                    </MudTooltip>
+                                }
+                                <MudText>@GetSetSummary(entry.Set)</MudText>
+                                @if (entry.Set.InvalidLines.Count > 0)
+                                {
+                                    <MudTooltip Text="@GetWarnings(entry.Set)">
                                         <MudIcon Icon="@Icons.Material.Filled.Warning"
                                                  Color="@Color.Warning"
                                                  Size="@Size.Small"/>
@@ -120,7 +138,7 @@
                    Variant="@Variant.Filled"
                    Color="@Color.Primary"
                    StartIcon="@Icons.Material.Filled.FileUpload"
-                   Disabled="@(parsedSets.Count == 0 || AppState.SaveFile is null)">
+                   Disabled="@(parsedEntries.Count == 0 || isParsing || AppState.SaveFile is null)">
             Import
         </MudButton>
     </DialogActions>

--- a/Pkmds.Rcl/Components/Dialogs/ShowdownImportDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/ShowdownImportDialog.razor.cs
@@ -1,3 +1,5 @@
+using PKHexSeverity = PKHeX.Core.Severity;
+
 namespace Pkmds.Rcl.Components.Dialogs;
 
 public partial class ShowdownImportDialog
@@ -7,7 +9,8 @@ public partial class ShowdownImportDialog
 
     private string inputText = string.Empty;
     private bool isFetching;
-    private List<ShowdownSet> parsedSets = [];
+    private bool isParsing;
+    private List<ParsedEntry> parsedEntries = [];
     private string? pasteInfo;
 
     [CascadingParameter]
@@ -18,7 +21,140 @@ public partial class ShowdownImportDialog
 
     private bool IsUrl => PokepasteTeam.IsURL(inputText, out _);
 
-    private void ParseText() => parsedSets = [.. AppService.ParseShowdownText(inputText)];
+    private async Task ParseTextAsync()
+    {
+        if (string.IsNullOrWhiteSpace(inputText))
+        {
+            return;
+        }
+
+        isParsing = true;
+        parsedEntries = [];
+        StateHasChanged();
+
+        // Yield so the spinner paints before per-set conversion + legality analysis runs.
+        // Task.Delay(1) (not Task.Yield) because in Blazor WASM, Yield stays on the same
+        // JS macrotask and never lets the browser paint.
+        await Task.Delay(1);
+
+        var sets = AppService.ParseShowdownText(inputText);
+        var entries = new List<ParsedEntry>(sets.Count);
+        foreach (var set in sets)
+        {
+            var pkm = AppService.ConvertShowdownSetToPkm(set);
+            var (status, firstIssue) = AnalyzeLegality(pkm);
+            entries.Add(new ParsedEntry(set, pkm, status, firstIssue));
+
+            // Inter-entry yield so the browser can process input between conversions,
+            // matching the pattern used by LegalityReportTab's batch legalize sweep.
+            await Task.Delay(1);
+        }
+
+        parsedEntries = entries;
+        isParsing = false;
+        StateHasChanged();
+    }
+
+    private (LegalityStatus? Status, string FirstIssue) AnalyzeLegality(PKM? pkm)
+    {
+        if (pkm is null)
+        {
+            return (null, string.Empty);
+        }
+
+        var la = AppService.GetLegalityAnalysis(pkm);
+        var status = GetStatus(la);
+        var firstIssue = status == LegalityStatus.Legal
+            ? string.Empty
+            : GetFirstIssue(la);
+        return (status, firstIssue);
+    }
+
+    // Mirrors LegalityReportTab.GetStatus — keep these in sync.
+    private static LegalityStatus GetStatus(LegalityAnalysis la)
+    {
+        var hasInvalid = la.Results.Any(r => r.Judgement == PKHexSeverity.Invalid)
+                         || !MoveResult.AllValid(la.Info.Moves)
+                         || !MoveResult.AllValid(la.Info.Relearn);
+
+        if (hasInvalid)
+        {
+            return LegalityStatus.Illegal;
+        }
+
+        var hasFishy = la.Results.Any(r => r.Judgement == PKHexSeverity.Fishy);
+        return hasFishy
+            ? LegalityStatus.Fishy
+            : LegalityStatus.Legal;
+    }
+
+    // Mirrors LegalityReportTab.GetFirstIssue — keep these in sync.
+    private static string GetFirstIssue(LegalityAnalysis la)
+    {
+        var ctx = LegalityLocalizationContext.Create(la);
+
+        // Prefer Invalid over Fishy so the more severe issue wins when both are present.
+        // CheckResult.Valid is true for Fishy judgements, so match on Judgement directly.
+        foreach (var result in la.Results)
+        {
+            if (result.Judgement == PKHexSeverity.Invalid)
+            {
+                return ctx.Humanize(in result);
+            }
+        }
+
+        if (!MoveResult.AllValid(la.Info.Moves))
+        {
+            return "Invalid move detected.";
+        }
+
+        if (!MoveResult.AllValid(la.Info.Relearn))
+        {
+            return "Invalid relearn move detected.";
+        }
+
+        foreach (var result in la.Results)
+        {
+            if (result.Judgement == PKHexSeverity.Fishy)
+            {
+                return ctx.Humanize(in result);
+            }
+        }
+
+        return string.Empty;
+    }
+
+    private static Color GetStatusColor(LegalityStatus status) => status switch
+    {
+        LegalityStatus.Legal => Color.Success,
+        LegalityStatus.Fishy => Color.Warning,
+        LegalityStatus.Illegal => Color.Error,
+        _ => Color.Default
+    };
+
+    private static string GetStatusIcon(LegalityStatus status) => status switch
+    {
+        LegalityStatus.Legal => Icons.Material.Filled.CheckCircle,
+        LegalityStatus.Fishy => Icons.Material.Filled.Warning,
+        LegalityStatus.Illegal => Icons.Material.Filled.Cancel,
+        _ => Icons.Material.Filled.Help
+    };
+
+    private static string GetStatusTooltip(ParsedEntry entry) => entry.Status switch
+    {
+        LegalityStatus.Legal => "Legal",
+        _ => string.IsNullOrEmpty(entry.FirstIssue)
+            ? GetStatusLabel(entry.Status)
+            : entry.FirstIssue
+    };
+
+    private static string GetStatusLabel(LegalityStatus? status) => status switch
+    {
+        LegalityStatus.Legal => "Legal",
+        LegalityStatus.Fishy => "Fishy",
+        LegalityStatus.Illegal => "Illegal",
+        _ => "Unknown"
+    };
 
     private async Task FetchUrlAsync()
     {
@@ -51,17 +187,17 @@ public partial class ShowdownImportDialog
             {
                 inputText = response.Paste;
                 pasteInfo = BuildPasteInfo(response);
-                ParseText();
+                isFetching = false;
+                await ParseTextAsync();
+                return;
             }
         }
         catch (Exception ex)
         {
             fetchError = $"Failed to fetch from PokePaste: {ex.Message}";
         }
-        finally
-        {
-            isFetching = false;
-        }
+
+        isFetching = false;
     }
 
     private static string? BuildPasteInfo(PokePasteResponse response)
@@ -124,19 +260,19 @@ public partial class ShowdownImportDialog
             return;
         }
 
-        // Convert all sets up front so we know exactly what we have.
-        var converted = new List<PKM>(parsedSets.Count);
+        // Reuse the pre-converted PKMs from parsing — no need to re-run the legalization
+        // engine at import time.
+        var converted = new List<PKM>(parsedEntries.Count);
         var conversionFailed = 0;
-        foreach (var set in parsedSets)
+        foreach (var entry in parsedEntries)
         {
-            var pkm = AppService.ConvertShowdownSetToPkm(set);
-            if (pkm is null)
+            if (entry.Pokemon is { } pkm)
             {
-                conversionFailed++;
+                converted.Add(pkm);
             }
             else
             {
-                converted.Add(pkm);
+                conversionFailed++;
             }
         }
 
@@ -228,4 +364,10 @@ public partial class ShowdownImportDialog
     }
 
     private void Cancel() => MudDialog?.Close(DialogResult.Cancel());
+
+    private sealed record ParsedEntry(
+        ShowdownSet Set,
+        PKM? Pokemon,
+        LegalityStatus? Status,
+        string FirstIssue);
 }


### PR DESCRIPTION
## Summary

- Parse now converts + runs `LegalityAnalysis` on every Showdown set up front, and the preview list shows a green `CheckCircle` / yellow `Warning` / red `Cancel` indicator next to each entry (tooltip on hover for Fishy/Illegal shows the first issue).
- Classification (`GetStatus` / `GetFirstIssue`) mirrors `LegalityReportTab` so the Import preview and the Legality Report tab stay consistent.
- `ImportAsync` now reuses the PKMs converted during Parse instead of re-running the legalization engine on click.
- Parse button shows an "Analyzing…" spinner and disables inputs while the engine is running, with `Task.Delay(1)` between entries so the UI stays responsive on larger pastes.

Closes #692 — the last remaining checklist item from the ALM roadmap parent (#344).

## Test plan

- [ ] Open Import from Showdown / PokePaste, paste a known-legal team → all entries show green check icons.
- [ ] Paste a team with one obviously illegal set (wrong ability, impossible moves) → that row shows a red Cancel icon with a tooltip describing the issue; legal rows still green.
- [ ] Paste a set that is Valid but Fishy → shows yellow Warning with tooltip.
- [ ] Fetch from a PokePaste URL → indicators populate after fetch completes, no re-conversion happens on Import.
- [ ] Parse with no save file loaded → entries render without icons (conversion returned null); Import button remains disabled.
- [ ] Paste a set with Showdown parser warnings (`InvalidLines`) → existing yellow warning icon still appears alongside the new legality icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)