### PR TITLE
feat: legality indicators in Showdown import preview

### DIFF
--- a/Pkmds.Rcl/Components/Dialogs/ShowdownImportDialog.razor
+++ b/Pkmds.Rcl/Components/Dialogs/ShowdownImportDialog.razor
@@ -10,7 +10,7 @@
                           Lines="10"
                           Variant="@Variant.Outlined"
                           Placeholder="Paste Showdown text or a PokePaste URL (https://pokepast.es/...)…"
-                          Disabled="@isFetching"/>
+                          Disabled="@(isFetching || isParsing)"/>
 
             @if (!string.IsNullOrEmpty(fetchError))
             {
@@ -37,7 +37,7 @@
                                Variant="@Variant.Filled"
                                StartIcon="@Icons.Material.Filled.Download"
                                Color="@Color.Primary"
-                               Disabled="@isFetching">
+                               Disabled="@(isFetching || isParsing)">
                         @if (isFetching)
                         {
                             <MudProgressCircular Size="@Size.Small"
@@ -51,34 +51,52 @@
                         }
                     </MudButton>
                 }
-                <MudButton OnClick="@ParseText"
+                <MudButton OnClick="@ParseTextAsync"
                            Variant="@Variant.Filled"
                            StartIcon="@Icons.Material.Filled.Search"
-                           Disabled="@(string.IsNullOrWhiteSpace(inputText) || isFetching)">
-                    Parse
+                           Disabled="@(string.IsNullOrWhiteSpace(inputText) || isFetching || isParsing)">
+                    @if (isParsing)
+                    {
+                        <MudProgressCircular Size="@Size.Small"
+                                             Indeterminate="true"
+                                             Class="mr-2"/>
+                        @:Analyzing…
+                    }
+                    else
+                    {
+                        @:Parse
+                    }
                 </MudButton>
             </MudStack>
 
-            @if (parsedSets.Count > 0)
+            @if (parsedEntries.Count > 0)
             {
                 <MudDivider/>
 
                 <MudText Typo="@Typo.subtitle2">
-                    Preview — @parsedSets.Count Pokémon
+                    Preview — @parsedEntries.Count Pokémon
                 </MudText>
 
-                <MudList T="ShowdownSet"
+                <MudList T="ParsedEntry"
                          Dense="true">
-                    @foreach (var set in parsedSets)
+                    @foreach (var entry in parsedEntries)
                     {
-                        <MudListItem T="ShowdownSet">
+                        <MudListItem T="ParsedEntry">
                             <MudStack Row
                                       AlignItems="@AlignItems.Center"
                                       Spacing="1">
-                                <MudText>@GetSetSummary(set)</MudText>
-                                @if (set.InvalidLines.Count > 0)
+                                @if (entry.Status is { } status)
                                 {
-                                    <MudTooltip Text="@GetWarnings(set)">
+                                    <MudTooltip Text="@GetStatusTooltip(entry)">
+                                        <MudIcon Icon="@GetStatusIcon(status)"
+                                                 Color="@GetStatusColor(status)"
+                                                 Size="@Size.Small"/>
+                                    </MudTooltip>
+                                }
+                                <MudText>@GetSetSummary(entry.Set)</MudText>
+                                @if (entry.Set.InvalidLines.Count > 0)
+                                {
+                                    <MudTooltip Text="@GetWarnings(entry.Set)">
                                         <MudIcon Icon="@Icons.Material.Filled.Warning"
                                                  Color="@Color.Warning"
                                                  Size="@Size.Small"/>
@@ -120,7 +138,7 @@
                    Variant="@Variant.Filled"
                    Color="@Color.Primary"
                    StartIcon="@Icons.Material.Filled.FileUpload"
-                   Disabled="@(parsedSets.Count == 0 || AppState.SaveFile is null)">
+                   Disabled="@(parsedEntries.Count == 0 || isParsing || AppState.SaveFile is null)">
             Import
         </MudButton>
     </DialogActions>

--- a/Pkmds.Rcl/Components/Dialogs/ShowdownImportDialog.razor
+++ b/Pkmds.Rcl/Components/Dialogs/ShowdownImportDialog.razor
@@ -88,8 +88,8 @@
                                 @if (entry.Status is { } status)
                                 {
                                     <MudTooltip Text="@GetStatusTooltip(entry)">
-                                        <MudIcon Icon="@GetStatusIcon(status)"
-                                                 Color="@GetStatusColor(status)"
+                                        <MudIcon Icon="@LegalityUi.GetStatusIcon(status)"
+                                                 Color="@LegalityUi.GetStatusColor(status)"
                                                  Size="@Size.Small"/>
                                     </MudTooltip>
                                 }

--- a/Pkmds.Rcl/Components/Dialogs/ShowdownImportDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/ShowdownImportDialog.razor.cs
@@ -1,3 +1,5 @@
+using PKHexSeverity = PKHeX.Core.Severity;
+
 namespace Pkmds.Rcl.Components.Dialogs;
 
 public partial class ShowdownImportDialog
@@ -7,7 +9,8 @@ public partial class ShowdownImportDialog
 
     private string inputText = string.Empty;
     private bool isFetching;
-    private List<ShowdownSet> parsedSets = [];
+    private bool isParsing;
+    private List<ParsedEntry> parsedEntries = [];
     private string? pasteInfo;
 
     [CascadingParameter]
@@ -18,7 +21,140 @@ public partial class ShowdownImportDialog
 
     private bool IsUrl => PokepasteTeam.IsURL(inputText, out _);
 
-    private void ParseText() => parsedSets = [.. AppService.ParseShowdownText(inputText)];
+    private async Task ParseTextAsync()
+    {
+        if (string.IsNullOrWhiteSpace(inputText))
+        {
+            return;
+        }
+
+        isParsing = true;
+        parsedEntries = [];
+        StateHasChanged();
+
+        // Yield so the spinner paints before per-set conversion + legality analysis runs.
+        // Task.Delay(1) (not Task.Yield) because in Blazor WASM, Yield stays on the same
+        // JS macrotask and never lets the browser paint.
+        await Task.Delay(1);
+
+        var sets = AppService.ParseShowdownText(inputText);
+        var entries = new List<ParsedEntry>(sets.Count);
+        foreach (var set in sets)
+        {
+            var pkm = AppService.ConvertShowdownSetToPkm(set);
+            var (status, firstIssue) = AnalyzeLegality(pkm);
+            entries.Add(new ParsedEntry(set, pkm, status, firstIssue));
+
+            // Inter-entry yield so the browser can process input between conversions,
+            // matching the pattern used by LegalityReportTab's batch legalize sweep.
+            await Task.Delay(1);
+        }
+
+        parsedEntries = entries;
+        isParsing = false;
+        StateHasChanged();
+    }
+
+    private (LegalityStatus? Status, string FirstIssue) AnalyzeLegality(PKM? pkm)
+    {
+        if (pkm is null)
+        {
+            return (null, string.Empty);
+        }
+
+        var la = AppService.GetLegalityAnalysis(pkm);
+        var status = GetStatus(la);
+        var firstIssue = status == LegalityStatus.Legal
+            ? string.Empty
+            : GetFirstIssue(la);
+        return (status, firstIssue);
+    }
+
+    // Mirrors LegalityReportTab.GetStatus — keep these in sync.
+    private static LegalityStatus GetStatus(LegalityAnalysis la)
+    {
+        var hasInvalid = la.Results.Any(r => r.Judgement == PKHexSeverity.Invalid)
+                         || !MoveResult.AllValid(la.Info.Moves)
+                         || !MoveResult.AllValid(la.Info.Relearn);
+
+        if (hasInvalid)
+        {
+            return LegalityStatus.Illegal;
+        }
+
+        var hasFishy = la.Results.Any(r => r.Judgement == PKHexSeverity.Fishy);
+        return hasFishy
+            ? LegalityStatus.Fishy
+            : LegalityStatus.Legal;
+    }
+
+    // Mirrors LegalityReportTab.GetFirstIssue — keep these in sync.
+    private static string GetFirstIssue(LegalityAnalysis la)
+    {
+        var ctx = LegalityLocalizationContext.Create(la);
+
+        // Prefer Invalid over Fishy so the more severe issue wins when both are present.
+        // CheckResult.Valid is true for Fishy judgements, so match on Judgement directly.
+        foreach (var result in la.Results)
+        {
+            if (result.Judgement == PKHexSeverity.Invalid)
+            {
+                return ctx.Humanize(in result);
+            }
+        }
+
+        if (!MoveResult.AllValid(la.Info.Moves))
+        {
+            return "Invalid move detected.";
+        }
+
+        if (!MoveResult.AllValid(la.Info.Relearn))
+        {
+            return "Invalid relearn move detected.";
+        }
+
+        foreach (var result in la.Results)
+        {
+            if (result.Judgement == PKHexSeverity.Fishy)
+            {
+                return ctx.Humanize(in result);
+            }
+        }
+
+        return string.Empty;
+    }
+
+    private static Color GetStatusColor(LegalityStatus status) => status switch
+    {
+        LegalityStatus.Legal => Color.Success,
+        LegalityStatus.Fishy => Color.Warning,
+        LegalityStatus.Illegal => Color.Error,
+        _ => Color.Default
+    };
+
+    private static string GetStatusIcon(LegalityStatus status) => status switch
+    {
+        LegalityStatus.Legal => Icons.Material.Filled.CheckCircle,
+        LegalityStatus.Fishy => Icons.Material.Filled.Warning,
+        LegalityStatus.Illegal => Icons.Material.Filled.Cancel,
+        _ => Icons.Material.Filled.Help
+    };
+
+    private static string GetStatusTooltip(ParsedEntry entry) => entry.Status switch
+    {
+        LegalityStatus.Legal => "Legal",
+        _ => string.IsNullOrEmpty(entry.FirstIssue)
+            ? GetStatusLabel(entry.Status)
+            : entry.FirstIssue
+    };
+
+    private static string GetStatusLabel(LegalityStatus? status) => status switch
+    {
+        LegalityStatus.Legal => "Legal",
+        LegalityStatus.Fishy => "Fishy",
+        LegalityStatus.Illegal => "Illegal",
+        _ => "Unknown"
+    };
 
     private async Task FetchUrlAsync()
     {
@@ -51,17 +187,17 @@ public partial class ShowdownImportDialog
             {
                 inputText = response.Paste;
                 pasteInfo = BuildPasteInfo(response);
-                ParseText();
+                isFetching = false;
+                await ParseTextAsync();
+                return;
             }
         }
         catch (Exception ex)
         {
             fetchError = $"Failed to fetch from PokePaste: {ex.Message}";
         }
-        finally
-        {
-            isFetching = false;
-        }
+
+        isFetching = false;
     }
 
     private static string? BuildPasteInfo(PokePasteResponse response)
@@ -124,19 +260,19 @@ public partial class ShowdownImportDialog
             return;
         }
 
-        // Convert all sets up front so we know exactly what we have.
-        var converted = new List<PKM>(parsedSets.Count);
+        // Reuse the pre-converted PKMs from parsing — no need to re-run the legalization
+        // engine at import time.
+        var converted = new List<PKM>(parsedEntries.Count);
         var conversionFailed = 0;
-        foreach (var set in parsedSets)
+        foreach (var entry in parsedEntries)
         {
-            var pkm = AppService.ConvertShowdownSetToPkm(set);
-            if (pkm is null)
+            if (entry.Pokemon is { } pkm)
             {
-                conversionFailed++;
+                converted.Add(pkm);
             }
             else
             {
-                converted.Add(pkm);
+                conversionFailed++;
             }
         }
 
@@ -228,4 +364,10 @@ public partial class ShowdownImportDialog
     }
 
     private void Cancel() => MudDialog?.Close(DialogResult.Cancel());
+
+    private sealed record ParsedEntry(
+        ShowdownSet Set,
+        PKM? Pokemon,
+        LegalityStatus? Status,
+        string FirstIssue);
 }

--- a/Pkmds.Rcl/Components/Dialogs/ShowdownImportDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/ShowdownImportDialog.razor.cs
@@ -202,32 +202,48 @@ public partial class ShowdownImportDialog
         }
 
         // Reuse the pre-converted PKMs from parsing — no need to re-run the legalization
-        // engine at import time.
+        // engine at import time. Drop entries whose species/form isn't even in the target
+        // game: the conversion engine produces a best-effort PKM anyway (e.g. Gen 9 mons
+        // against a Gen 4 save), and silently writing those bytes would mislead the user.
+        // Illegal-but-present entries are still imported — users can legalize them after.
         var converted = new List<PKM>(parsedEntries.Count);
         var conversionFailed = 0;
+        var skippedImpossible = 0;
         foreach (var entry in parsedEntries)
         {
-            if (entry.Pokemon is { } pkm)
-            {
-                converted.Add(pkm);
-            }
-            else
+            if (entry.Pokemon is not { } pkm)
             {
                 conversionFailed++;
+                continue;
             }
+
+            if (!sav.Personal.IsPresentInGame(pkm.Species, pkm.Form))
+            {
+                skippedImpossible++;
+                continue;
+            }
+
+            converted.Add(pkm);
+        }
+
+        if (converted.Count == 0)
+        {
+            ReportResult(0, conversionFailed, skippedImpossible);
+            MudDialog?.Close();
+            return;
         }
 
         if (importToParty)
         {
-            await ImportToPartyAsync(sav, converted, conversionFailed);
+            await ImportToPartyAsync(sav, converted, conversionFailed, skippedImpossible);
         }
         else
         {
-            ImportToBox(converted, conversionFailed);
+            ImportToBox(converted, conversionFailed, skippedImpossible);
         }
     }
 
-    private async Task ImportToPartyAsync(SaveFile sav, List<PKM> converted, int conversionFailed)
+    private async Task ImportToPartyAsync(SaveFile sav, List<PKM> converted, int conversionFailed, int skippedImpossible)
     {
         var emptySlots = 6 - sav.PartyCount;
 
@@ -243,7 +259,7 @@ public partial class ShowdownImportDialog
                 }
             }
 
-            ReportResult(placed, conversionFailed + (converted.Count - placed));
+            ReportResult(placed, conversionFailed + (converted.Count - placed), skippedImpossible);
             MudDialog?.Close();
             return;
         }
@@ -267,11 +283,11 @@ public partial class ShowdownImportDialog
 
         var written = AppService.OverwriteParty(converted);
         var skipped = Math.Max(0, converted.Count - written);
-        ReportResult(written, conversionFailed + skipped);
+        ReportResult(written, conversionFailed + skipped, skippedImpossible);
         MudDialog?.Close();
     }
 
-    private void ImportToBox(List<PKM> converted, int conversionFailed)
+    private void ImportToBox(List<PKM> converted, int conversionFailed, int skippedImpossible)
     {
         var placed = 0;
         foreach (var pkm in converted)
@@ -283,23 +299,35 @@ public partial class ShowdownImportDialog
         }
 
         RefreshService.RefreshBoxState();
-        ReportResult(placed, conversionFailed + (converted.Count - placed));
+        ReportResult(placed, conversionFailed + (converted.Count - placed), skippedImpossible);
         MudDialog?.Close();
     }
 
-    private void ReportResult(int imported, int failed)
+    private void ReportResult(int imported, int failed, int skippedImpossible)
     {
-        if (imported == 0 && failed == 0)
+        if (imported == 0 && failed == 0 && skippedImpossible == 0)
         {
             return;
         }
 
-        var severity = failed == 0
+        var parts = new List<string>(2);
+        if (failed > 0)
+        {
+            parts.Add($"{failed} could not be placed");
+        }
+
+        if (skippedImpossible > 0)
+        {
+            parts.Add($"{skippedImpossible} skipped (not in this game)");
+        }
+
+        var message = parts.Count == 0
+            ? $"Imported {imported} Pokémon."
+            : $"Imported {imported} Pokémon. {string.Join(", ", parts)}.";
+
+        var severity = parts.Count == 0
             ? Severity.Success
             : Severity.Warning;
-        var message = failed == 0
-            ? $"Imported {imported} Pokémon."
-            : $"Imported {imported} Pokémon. {failed} could not be placed.";
 
         Snackbar.Add(message, severity);
     }

--- a/Pkmds.Rcl/Components/Dialogs/ShowdownImportDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/ShowdownImportDialog.razor.cs
@@ -202,10 +202,12 @@ public partial class ShowdownImportDialog
         }
 
         // Reuse the pre-converted PKMs from parsing — no need to re-run the legalization
-        // engine at import time. Drop entries whose species/form isn't even in the target
-        // game: the conversion engine produces a best-effort PKM anyway (e.g. Gen 9 mons
-        // against a Gen 4 save), and silently writing those bytes would mislead the user.
-        // Illegal-but-present entries are still imported — users can legalize them after.
+        // engine at import time. Drop entries whose species/form isn't in the target
+        // game: when the Auto-Legality engine can't produce a valid encounter (e.g. a
+        // Gen 9 species against a Gen 5 save) it silently substitutes a different
+        // species on the PKM, so we can't trust pkm.Species — check the *set's* species,
+        // which preserves the user's original intent. Illegal-but-present entries are
+        // still imported — users can legalize them after.
         var converted = new List<PKM>(parsedEntries.Count);
         var conversionFailed = 0;
         var skippedImpossible = 0;
@@ -217,7 +219,8 @@ public partial class ShowdownImportDialog
                 continue;
             }
 
-            if (!sav.Personal.IsPresentInGame(pkm.Species, pkm.Form))
+            if (entry.Set.Species == 0 ||
+                !sav.Personal.IsPresentInGame(entry.Set.Species, entry.Set.Form))
             {
                 skippedImpossible++;
                 continue;

--- a/Pkmds.Rcl/Components/Dialogs/ShowdownImportDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/ShowdownImportDialog.razor.cs
@@ -1,5 +1,3 @@
-using PKHexSeverity = PKHeX.Core.Severity;
-
 namespace Pkmds.Rcl.Components.Dialogs;
 
 public partial class ShowdownImportDialog
@@ -11,6 +9,7 @@ public partial class ShowdownImportDialog
     private bool isFetching;
     private bool isParsing;
     private List<ParsedEntry> parsedEntries = [];
+    private SaveFile? parsedWithSaveFile;
     private string? pasteInfo;
 
     [CascadingParameter]
@@ -30,29 +29,40 @@ public partial class ShowdownImportDialog
 
         isParsing = true;
         parsedEntries = [];
+        // Record which save the entries are valid for so Import can detect a mismatch
+        // (e.g. the save was swapped between parse and import).
+        parsedWithSaveFile = AppState.SaveFile;
         StateHasChanged();
 
-        // Yield so the spinner paints before per-set conversion + legality analysis runs.
-        // Task.Delay(1) (not Task.Yield) because in Blazor WASM, Yield stays on the same
-        // JS macrotask and never lets the browser paint.
-        await Task.Delay(1);
-
-        var sets = AppService.ParseShowdownText(inputText);
-        var entries = new List<ParsedEntry>(sets.Count);
-        foreach (var set in sets)
+        try
         {
-            var pkm = AppService.ConvertShowdownSetToPkm(set);
-            var (status, firstIssue) = AnalyzeLegality(pkm);
-            entries.Add(new ParsedEntry(set, pkm, status, firstIssue));
-
-            // Inter-entry yield so the browser can process input between conversions,
-            // matching the pattern used by LegalityReportTab's batch legalize sweep.
+            // Yield so the spinner paints before per-set conversion + legality analysis runs.
+            // Task.Delay(1) (not Task.Yield) because in Blazor WASM, Yield stays on the same
+            // JS macrotask and never lets the browser paint.
             await Task.Delay(1);
-        }
 
-        parsedEntries = entries;
-        isParsing = false;
-        StateHasChanged();
+            var sets = AppService.ParseShowdownText(inputText);
+            var entries = new List<ParsedEntry>(sets.Count);
+            foreach (var set in sets)
+            {
+                var pkm = AppService.ConvertShowdownSetToPkm(set);
+                var (status, firstIssue) = AnalyzeLegality(pkm);
+                entries.Add(new ParsedEntry(set, pkm, status, firstIssue));
+
+                // Inter-entry yield so the browser can process input between conversions,
+                // matching the pattern used by LegalityReportTab's batch legalize sweep.
+                await Task.Delay(1);
+            }
+
+            parsedEntries = entries;
+        }
+        finally
+        {
+            // Always clear the spinner / re-enable inputs, even if conversion or analysis
+            // threw — otherwise the dialog can get stuck in "Analyzing…" forever.
+            isParsing = false;
+            StateHasChanged();
+        }
     }
 
     private (LegalityStatus? Status, string FirstIssue) AnalyzeLegality(PKM? pkm)
@@ -63,98 +73,17 @@ public partial class ShowdownImportDialog
         }
 
         var la = AppService.GetLegalityAnalysis(pkm);
-        var status = GetStatus(la);
+        var status = LegalityUi.GetStatus(la);
         var firstIssue = status == LegalityStatus.Legal
             ? string.Empty
-            : GetFirstIssue(la);
+            : LegalityUi.GetFirstIssue(la);
         return (status, firstIssue);
     }
 
-    // Mirrors LegalityReportTab.GetStatus — keep these in sync.
-    private static LegalityStatus GetStatus(LegalityAnalysis la)
-    {
-        var hasInvalid = la.Results.Any(r => r.Judgement == PKHexSeverity.Invalid)
-                         || !MoveResult.AllValid(la.Info.Moves)
-                         || !MoveResult.AllValid(la.Info.Relearn);
-
-        if (hasInvalid)
-        {
-            return LegalityStatus.Illegal;
-        }
-
-        var hasFishy = la.Results.Any(r => r.Judgement == PKHexSeverity.Fishy);
-        return hasFishy
-            ? LegalityStatus.Fishy
-            : LegalityStatus.Legal;
-    }
-
-    // Mirrors LegalityReportTab.GetFirstIssue — keep these in sync.
-    private static string GetFirstIssue(LegalityAnalysis la)
-    {
-        var ctx = LegalityLocalizationContext.Create(la);
-
-        // Prefer Invalid over Fishy so the more severe issue wins when both are present.
-        // CheckResult.Valid is true for Fishy judgements, so match on Judgement directly.
-        foreach (var result in la.Results)
-        {
-            if (result.Judgement == PKHexSeverity.Invalid)
-            {
-                return ctx.Humanize(in result);
-            }
-        }
-
-        if (!MoveResult.AllValid(la.Info.Moves))
-        {
-            return "Invalid move detected.";
-        }
-
-        if (!MoveResult.AllValid(la.Info.Relearn))
-        {
-            return "Invalid relearn move detected.";
-        }
-
-        foreach (var result in la.Results)
-        {
-            if (result.Judgement == PKHexSeverity.Fishy)
-            {
-                return ctx.Humanize(in result);
-            }
-        }
-
-        return string.Empty;
-    }
-
-    private static Color GetStatusColor(LegalityStatus status) => status switch
-    {
-        LegalityStatus.Legal => Color.Success,
-        LegalityStatus.Fishy => Color.Warning,
-        LegalityStatus.Illegal => Color.Error,
-        _ => Color.Default
-    };
-
-    private static string GetStatusIcon(LegalityStatus status) => status switch
-    {
-        LegalityStatus.Legal => Icons.Material.Filled.CheckCircle,
-        LegalityStatus.Fishy => Icons.Material.Filled.Warning,
-        LegalityStatus.Illegal => Icons.Material.Filled.Cancel,
-        _ => Icons.Material.Filled.Help
-    };
-
-    private static string GetStatusTooltip(ParsedEntry entry) => entry.Status switch
-    {
-        LegalityStatus.Legal => "Legal",
-        _ => string.IsNullOrEmpty(entry.FirstIssue)
-            ? GetStatusLabel(entry.Status)
-            : entry.FirstIssue
-    };
-
-    private static string GetStatusLabel(LegalityStatus? status) => status switch
-    {
-        LegalityStatus.Legal => "Legal",
-        LegalityStatus.Fishy => "Fishy",
-        LegalityStatus.Illegal => "Illegal",
-        _ => "Unknown"
-    };
+    private static string GetStatusTooltip(ParsedEntry entry) =>
+        string.IsNullOrEmpty(entry.FirstIssue)
+            ? LegalityUi.GetStatusLabel(entry.Status ?? LegalityStatus.Legal)
+            : entry.FirstIssue;
 
     private async Task FetchUrlAsync()
     {
@@ -257,6 +186,18 @@ public partial class ShowdownImportDialog
         if (AppState.SaveFile is not { } sav)
         {
             Snackbar.Add("No save file loaded.", Severity.Warning);
+            return;
+        }
+
+        // Defensive: the dialog is modal so the save shouldn't change mid-flight, but if
+        // it somehow did (or the user parsed before loading a save), the stored PKMs
+        // belong to a different target and must not be imported.
+        if (!ReferenceEquals(parsedWithSaveFile, sav))
+        {
+            Snackbar.Add("Save file changed since parsing. Please parse again.", Severity.Warning);
+            parsedEntries = [];
+            parsedWithSaveFile = null;
+            StateHasChanged();
             return;
         }
 

--- a/Pkmds.Rcl/Components/MainTabPages/LegalityReportTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/LegalityReportTab.razor
@@ -173,11 +173,11 @@
 
                     <MudTd DataLabel="Status">
                         <MudChip T="@string"
-                                 Color="@GetStatusColor(context.Status)"
+                                 Color="@LegalityUi.GetStatusColor(context.Status)"
                                  Size="@Size.Small"
-                                 Icon="@GetStatusIcon(context.Status)"
+                                 Icon="@LegalityUi.GetStatusIcon(context.Status)"
                                  Variant="@Variant.Filled">
-                            @GetStatusLabel(context.Status)
+                            @LegalityUi.GetStatusLabel(context.Status)
                         </MudChip>
                     </MudTd>
 

--- a/Pkmds.Rcl/Components/MainTabPages/LegalityReportTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/LegalityReportTab.razor.cs
@@ -1,5 +1,3 @@
-using PKHexSeverity = PKHeX.Core.Severity;
-
 namespace Pkmds.Rcl.Components.MainTabPages;
 
 public partial class LegalityReportTab : RefreshAwareComponent
@@ -144,14 +142,14 @@ public partial class LegalityReportTab : RefreshAwareComponent
             // the save now contains — if the round trip mutated the PKM, we'll see the
             // real status here rather than an optimistic pre-write one.
             var storedLa = AppService.GetLegalityAnalysis(storedPk, isParty: entry.IsParty);
-            var newStatus = GetStatus(storedLa);
+            var newStatus = LegalityUi.GetStatus(storedLa);
             var updated = entry with
             {
                 Pokemon = storedPk,
                 Status = newStatus,
                 FirstIssue = newStatus == LegalityStatus.Legal
                     ? string.Empty
-                    : GetFirstIssue(storedLa)
+                    : LegalityUi.GetFirstIssue(storedLa)
             };
             var idx = legalityReportEntries.IndexOf(entry);
             if (idx >= 0)
@@ -314,65 +312,12 @@ public partial class LegalityReportTab : RefreshAwareComponent
             Pokemon = pkm,
             SpeciesName = speciesName,
             Location = location,
-            Status = GetStatus(la),
-            FirstIssue = GetFirstIssue(la),
+            Status = LegalityUi.GetStatus(la),
+            FirstIssue = LegalityUi.GetFirstIssue(la),
             IsParty = isParty,
             BoxNumber = box,
             SlotNumber = slot
         };
-    }
-
-    private static LegalityStatus GetStatus(LegalityAnalysis la)
-    {
-        var hasInvalid = la.Results.Any(r => r.Judgement == PKHexSeverity.Invalid)
-                         || !MoveResult.AllValid(la.Info.Moves)
-                         || !MoveResult.AllValid(la.Info.Relearn);
-
-        if (hasInvalid)
-        {
-            return LegalityStatus.Illegal;
-        }
-
-        var hasFishy = la.Results.Any(r => r.Judgement == PKHexSeverity.Fishy);
-        return hasFishy
-            ? LegalityStatus.Fishy
-            : LegalityStatus.Legal;
-    }
-
-    private static string GetFirstIssue(LegalityAnalysis la)
-    {
-        var ctx = LegalityLocalizationContext.Create(la);
-
-        // Prefer Invalid results over Fishy ones so the more severe issue is shown
-        // when both are present. CheckResult.Valid is true for Fishy judgements,
-        // so we have to match on Judgement directly to surface Fishy reasons at all.
-        foreach (var result in la.Results)
-        {
-            if (result.Judgement == PKHexSeverity.Invalid)
-            {
-                return ctx.Humanize(in result);
-            }
-        }
-
-        if (!MoveResult.AllValid(la.Info.Moves))
-        {
-            return "Invalid move detected.";
-        }
-
-        if (!MoveResult.AllValid(la.Info.Relearn))
-        {
-            return "Invalid relearn move detected.";
-        }
-
-        foreach (var result in la.Results)
-        {
-            if (result.Judgement == PKHexSeverity.Fishy)
-            {
-                return ctx.Humanize(in result);
-            }
-        }
-
-        return string.Empty;
     }
 
     private void SetFilter(LegalityStatus? filter) => statusFilter = filter;
@@ -402,30 +347,6 @@ public partial class LegalityReportTab : RefreshAwareComponent
 
         await OnJumpToPartyBox.InvokeAsync();
     }
-
-    private static Color GetStatusColor(LegalityStatus status) => status switch
-    {
-        LegalityStatus.Legal => Color.Success,
-        LegalityStatus.Fishy => Color.Warning,
-        LegalityStatus.Illegal => Color.Error,
-        _ => Color.Default
-    };
-
-    private static string GetStatusIcon(LegalityStatus status) => status switch
-    {
-        LegalityStatus.Legal => Icons.Material.Filled.CheckCircle,
-        LegalityStatus.Fishy => Icons.Material.Filled.Warning,
-        LegalityStatus.Illegal => Icons.Material.Filled.Cancel,
-        _ => Icons.Material.Filled.Help
-    };
-
-    private static string GetStatusLabel(LegalityStatus status) => status switch
-    {
-        LegalityStatus.Legal => "Legal",
-        LegalityStatus.Fishy => "Fishy",
-        LegalityStatus.Illegal => "Illegal",
-        _ => "Unknown"
-    };
 
     private bool TableFilterFunction(LegalityReportEntry legalityReportEntry) =>
         statusFilter is null || legalityReportEntry.Status == statusFilter;

--- a/Pkmds.Rcl/Components/PokemonSlotComponent.razor.cs
+++ b/Pkmds.Rcl/Components/PokemonSlotComponent.razor.cs
@@ -167,19 +167,7 @@ public partial class PokemonSlotComponent : IDisposable
         }
 
         var la = AppService.GetLegalityAnalysis(Pokemon, isParty: IsPartySlot);
-        var hasInvalid = la.Results.Any(r => r.Judgement == PKHeX.Core.Severity.Invalid)
-                         || !MoveResult.AllValid(la.Info.Moves)
-                         || !MoveResult.AllValid(la.Info.Relearn);
-        if (hasInvalid)
-        {
-            legalityStatus = LegalityStatus.Illegal;
-            return;
-        }
-
-        var hasFishy = la.Results.Any(r => r.Judgement == PKHeX.Core.Severity.Fishy);
-        legalityStatus = hasFishy
-            ? LegalityStatus.Fishy
-            : LegalityStatus.Legal;
+        legalityStatus = LegalityUi.GetStatus(la);
     }
 
     private string GetPokemonTitle() => Pokemon is { Species: > 0 }

--- a/Pkmds.Rcl/Components/PokemonStorageComponent.razor.cs
+++ b/Pkmds.Rcl/Components/PokemonStorageComponent.razor.cs
@@ -1,5 +1,3 @@
-using PKHexSeverity = PKHeX.Core.Severity;
-
 namespace Pkmds.Rcl.Components;
 
 public partial class PokemonStorageComponent : RefreshAwareComponent
@@ -47,7 +45,7 @@ public partial class PokemonStorageComponent : RefreshAwareComponent
             }
 
             var la = AppService.GetLegalityAnalysis(pkm);
-            if (GetStatus(la) == LegalityStatus.Illegal)
+            if (LegalityUi.GetStatus(la) == LegalityStatus.Illegal)
             {
                 count++;
             }
@@ -221,7 +219,7 @@ public partial class PokemonStorageComponent : RefreshAwareComponent
             // Only target Illegal entries. Fishy is Valid per PKHeX — users expect the
             // box-level action to leave those alone. (The Legality Report tab still
             // lets users opt in to running Fishy through the engine.)
-            if (GetStatus(la) != LegalityStatus.Illegal)
+            if (LegalityUi.GetStatus(la) != LegalityStatus.Illegal)
             {
                 continue;
             }
@@ -322,7 +320,7 @@ public partial class PokemonStorageComponent : RefreshAwareComponent
             // Re-analyse the stored bytes so the counters match what the save actually holds.
             var storedPk = saveFile.GetBoxSlotAtIndex(box, slot);
             var storedLa = AppService.GetLegalityAnalysis(storedPk);
-            switch (GetStatus(storedLa))
+            switch (LegalityUi.GetStatus(storedLa))
             {
                 case LegalityStatus.Legal:
                     successCount++;
@@ -353,23 +351,6 @@ public partial class PokemonStorageComponent : RefreshAwareComponent
     }
 
     private void CancelLegalizeBox() => legalizeBoxCts?.Cancel();
-
-    private static LegalityStatus GetStatus(LegalityAnalysis la)
-    {
-        var hasInvalid = la.Results.Any(r => r.Judgement == PKHexSeverity.Invalid)
-                         || !MoveResult.AllValid(la.Info.Moves)
-                         || !MoveResult.AllValid(la.Info.Relearn);
-
-        if (hasInvalid)
-        {
-            return LegalityStatus.Illegal;
-        }
-
-        var hasFishy = la.Results.Any(r => r.Judgement == PKHexSeverity.Fishy);
-        return hasFishy
-            ? LegalityStatus.Fishy
-            : LegalityStatus.Legal;
-    }
 
     private static (string Message, Severity Severity) BuildLegalizeSummary(
         int targetCount,

--- a/Pkmds.Rcl/LegalityUi.cs
+++ b/Pkmds.Rcl/LegalityUi.cs
@@ -1,0 +1,88 @@
+using PKHexSeverity = PKHeX.Core.Severity;
+
+namespace Pkmds.Rcl;
+
+/// <summary>
+/// Shared helpers for rendering tri-state legality status (Legal / Fishy / Illegal)
+/// consistently across the app. Call sites: <c>LegalityReportTab</c>,
+/// <c>ShowdownImportDialog</c>, <c>PokemonStorageComponent</c>,
+/// <c>PokemonSlotComponent</c>.
+/// </summary>
+public static class LegalityUi
+{
+    public static LegalityStatus GetStatus(LegalityAnalysis la)
+    {
+        var hasInvalid = la.Results.Any(r => r.Judgement == PKHexSeverity.Invalid)
+                         || !MoveResult.AllValid(la.Info.Moves)
+                         || !MoveResult.AllValid(la.Info.Relearn);
+
+        if (hasInvalid)
+        {
+            return LegalityStatus.Illegal;
+        }
+
+        var hasFishy = la.Results.Any(r => r.Judgement == PKHexSeverity.Fishy);
+        return hasFishy
+            ? LegalityStatus.Fishy
+            : LegalityStatus.Legal;
+    }
+
+    public static string GetFirstIssue(LegalityAnalysis la)
+    {
+        var ctx = LegalityLocalizationContext.Create(la);
+
+        // Prefer Invalid over Fishy so the more severe issue wins when both are present.
+        // CheckResult.Valid is true for Fishy judgements, so match on Judgement directly.
+        foreach (var result in la.Results)
+        {
+            if (result.Judgement == PKHexSeverity.Invalid)
+            {
+                return ctx.Humanize(in result);
+            }
+        }
+
+        if (!MoveResult.AllValid(la.Info.Moves))
+        {
+            return "Invalid move detected.";
+        }
+
+        if (!MoveResult.AllValid(la.Info.Relearn))
+        {
+            return "Invalid relearn move detected.";
+        }
+
+        foreach (var result in la.Results)
+        {
+            if (result.Judgement == PKHexSeverity.Fishy)
+            {
+                return ctx.Humanize(in result);
+            }
+        }
+
+        return string.Empty;
+    }
+
+    public static Color GetStatusColor(LegalityStatus status) => status switch
+    {
+        LegalityStatus.Legal => Color.Success,
+        LegalityStatus.Fishy => Color.Warning,
+        LegalityStatus.Illegal => Color.Error,
+        _ => Color.Default
+    };
+
+    public static string GetStatusIcon(LegalityStatus status) => status switch
+    {
+        LegalityStatus.Legal => Icons.Material.Filled.CheckCircle,
+        LegalityStatus.Fishy => Icons.Material.Filled.Warning,
+        LegalityStatus.Illegal => Icons.Material.Filled.Cancel,
+        _ => Icons.Material.Filled.Help
+    };
+
+    public static string GetStatusLabel(LegalityStatus status) => status switch
+    {
+        LegalityStatus.Legal => "Legal",
+        LegalityStatus.Fishy => "Fishy",
+        LegalityStatus.Illegal => "Illegal",
+        _ => "Unknown"
+    };
+}


### PR DESCRIPTION
## Summary

Ships the final phase of the Auto-Legality Mod roadmap (#344): the Showdown / PokePaste Import dialog now runs `LegalityAnalysis` on each converted set during Parse and renders a tri-state status icon next to every preview row so users see legality *before* clicking Import.

- Green `CheckCircle` — legal
- Yellow `Warning` — Valid but Fishy (tooltip with first fishy reason)
- Red `Cancel` — Illegal (tooltip with first invalid reason)
- Parse now shows an "Analyzing…" spinner while the engine runs, with `Task.Delay(1)` between entries so the UI stays responsive on larger pastes (same pattern used by the Legality Report batch legalize).
- `ImportAsync` reuses the PKMs converted during Parse instead of re-running the engine on click.
- Classification (`GetStatus` / `GetFirstIssue`) mirrors `LegalityReportTab` so indicators stay consistent with the Legality Report tab.

With this landed, every checklist item from #344's Phase-1 "remaining phases" comment is complete (#690 batch legalize, #691 Showdown integration, #693 box-level legalize, #692 import preview indicators). #702 (web worker) and #703 (finer cancellation) remain as independent follow-ups and are explicitly framed as non-blocking.

Closes #344
Closes #692

## Test plan

- [ ] Paste a known-legal team → all rows show green check icons.
- [ ] Paste a team with a clearly illegal set (wrong ability / impossible moves) → that row shows a red Cancel icon with a first-issue tooltip; legal rows still green.
- [ ] Paste a set that is Valid but Fishy → yellow Warning icon with tooltip.
- [ ] Fetch from a PokePaste URL → indicators populate after fetch; Import uses pre-converted PKMs (no second delay).
- [ ] Open Import with no save loaded → sets render without indicators; Import button stays disabled.
- [ ] Paste a set with Showdown parser warnings (`InvalidLines`) → existing yellow warning icon still appears alongside the new legality icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)