### PR TITLE
chore: explicit keepExistingData: false in createWritable

### DIFF
--- a/Pkmds.Rcl/wwwroot/js/fileSave.js
+++ b/Pkmds.Rcl/wwwroot/js/fileSave.js
@@ -197,7 +197,7 @@ window.showFilePickerAndWrite = async function (fileName, byteArray, extension, 
 
         // Must be called during a user gesture on some platforms.
         const handle = await window.showSaveFilePicker(opts);
-        const writable = await handle.createWritable();
+        const writable = await handle.createWritable({ keepExistingData: false });
 
         const uint8 = byteArray instanceof Uint8Array ? byteArray : new Uint8Array(byteArray);
 


### PR DESCRIPTION
Makes the intent of the `createWritable` call explicit by passing `{ keepExistingData: false }`, guarding against non-conforming browser implementations that might not default to truncating the file.

Related to #742.

Generated with [Claude Code](https://claude.ai/code)