### PR TITLE
fix: pre-filter Pokédex rows to fix virtualizer scroll reset and cut-off

### DIFF
--- a/Pkmds.Rcl/Components/MainTabPages/Pokedex/PokedexSpeciesGrid.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/Pokedex/PokedexSpeciesGrid.razor
@@ -7,7 +7,8 @@
               Wrap="@Wrap.Wrap"
               Spacing="2"
               Class="mb-2">
-        <MudTextField @bind-Value="searchText"
+        <MudTextField Value="@searchText"
+                      ValueChanged="@((string v) => SetSearchText(v))"
                       Placeholder="Search species…"
                       Immediate
                       AdornmenT="@Adornment.Start"
@@ -18,31 +19,31 @@
             <MudButton Color="@(selectedStatusFilter == DexStatusFilter.All
                                   ? Color.Primary
                                   : Color.Default)"
-                       OnClick="@(() => selectedStatusFilter = DexStatusFilter.All)">
+                       OnClick="@(() => SetStatusFilter(DexStatusFilter.All))">
                 All
             </MudButton>
             <MudButton Color="@(selectedStatusFilter == DexStatusFilter.Seen
                                   ? Color.Primary
                                   : Color.Default)"
-                       OnClick="@(() => selectedStatusFilter = DexStatusFilter.Seen)">
+                       OnClick="@(() => SetStatusFilter(DexStatusFilter.Seen))">
                 Seen
             </MudButton>
             <MudButton Color="@(selectedStatusFilter == DexStatusFilter.Caught
                                   ? Color.Success
                                   : Color.Default)"
-                       OnClick="@(() => selectedStatusFilter = DexStatusFilter.Caught)">
+                       OnClick="@(() => SetStatusFilter(DexStatusFilter.Caught))">
                 Caught
             </MudButton>
             <MudButton Color="@(selectedStatusFilter == DexStatusFilter.Unseen
                                   ? Color.Warning
                                   : Color.Default)"
-                       OnClick="@(() => selectedStatusFilter = DexStatusFilter.Unseen)">
+                       OnClick="@(() => SetStatusFilter(DexStatusFilter.Unseen))">
                 Unseen
             </MudButton>
             <MudButton Color="@(selectedStatusFilter == DexStatusFilter.SeenNotCaught
                                   ? Color.Info
                                   : Color.Default)"
-                       OnClick="@(() => selectedStatusFilter = DexStatusFilter.SeenNotCaught)">
+                       OnClick="@(() => SetStatusFilter(DexStatusFilter.SeenNotCaught))">
                 Seen / Not Caught
             </MudButton>
         </MudButtonGroup>
@@ -53,7 +54,7 @@
                 <MudButton Color="@(selectedRegionalDexFilter == -1
                                       ? Color.Primary
                                       : Color.Default)"
-                           OnClick="@(() => selectedRegionalDexFilter = -1)">
+                           OnClick="@(() => SetRegionalDexFilter(-1))">
                     All Dexes
                 </MudButton>
                 @for (var i = 0; i < regionalDexDefinitions.Count; i++)
@@ -62,7 +63,7 @@
                     <MudButton Color="@(selectedRegionalDexFilter == idx
                                           ? Color.Primary
                                           : Color.Default)"
-                               OnClick="@(() => selectedRegionalDexFilter = idx)">
+                               OnClick="@(() => SetRegionalDexFilter(idx))">
                         @regionalDexDefinitions[idx].Name
                     </MudButton>
                 }
@@ -71,8 +72,7 @@
     </MudStack>
 
     <MudDataGrid T="@PokedexGridRow"
-                 Items="@rows"
-                 QuickFilter="@FilterRow"
+                 Items="@filteredRows"
                  Dense
                  Hover
                  Bordered

--- a/Pkmds.Rcl/Components/MainTabPages/Pokedex/PokedexSpeciesGrid.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/Pokedex/PokedexSpeciesGrid.razor.cs
@@ -10,6 +10,14 @@ public partial class PokedexSpeciesGrid
     private IReadOnlyList<RegionalDexDefinition> regionalDexDefinitions = [];
     private List<PokedexGridRow> rows = [];
 
+    // Pre-filtered view of rows passed directly to MudDataGrid Items so the
+    // virtualizer always has a correct, stable item count.  Rebuilt whenever
+    // rows changes or any filter criterion changes.  This avoids the
+    // QuickFilter delegate-recreation problem where MudDataGrid invalidates its
+    // internal cache every render cycle and the Virtualize component resets the
+    // scroll position back to 0.
+    private List<PokedexGridRow> filteredRows = [];
+
     private string searchText = string.Empty;
     private int selectedRegionalDexFilter = -1; // -1 = All
     private DexStatusFilter selectedStatusFilter = DexStatusFilter.All;
@@ -52,6 +60,7 @@ public partial class PokedexSpeciesGrid
         if (AppState.SaveFile is not { HasPokeDex: true } saveFile)
         {
             rows = [];
+            filteredRows = [];
             return;
         }
 
@@ -79,6 +88,30 @@ public partial class PokedexSpeciesGrid
         hasDetailedEditor = saveFile is SAV4 or SAV5 or SAV6XY or SAV6AO or SAV7 or SAV7b
             or SAV8SWSH or SAV8LA or SAV8BS or SAV9SV or SAV9ZA;
         selectedStatusFilter = DexStatusFilter.All;
+        ApplyFilter();
+    }
+
+    // Rebuilds filteredRows from the full rows list using the current filter
+    // state.  Always call this after changing rows, searchText,
+    // selectedStatusFilter, or selectedRegionalDexFilter.
+    private void ApplyFilter() => filteredRows = [.. rows.Where(FilterRow)];
+
+    private void SetSearchText(string value)
+    {
+        searchText = value;
+        ApplyFilter();
+    }
+
+    private void SetStatusFilter(DexStatusFilter filter)
+    {
+        selectedStatusFilter = filter;
+        ApplyFilter();
+    }
+
+    private void SetRegionalDexFilter(int filter)
+    {
+        selectedRegionalDexFilter = filter;
+        ApplyFilter();
     }
 
     // Delegates to the shared PokedexHelpers.IsSpeciesInDex so the grid and the
@@ -254,10 +287,20 @@ public partial class PokedexSpeciesGrid
             return;
         }
 
-        // Build a new list so MudDataGrid's virtualizer detects the Items reference
-        // change and re-renders visible rows with the updated Seen/Caught state.
-        var newRows = new List<PokedexGridRow>(rows) { [idx] = row with { IsSeen = saveFile.GetSeen(row.SpeciesId), IsCaught = saveFile.GetCaught(row.SpeciesId) } };
-        rows = newRows;
+        rows = new List<PokedexGridRow>(rows)
+        {
+            [idx] = row with
+            {
+                IsSeen = saveFile.GetSeen(row.SpeciesId),
+                IsCaught = saveFile.GetCaught(row.SpeciesId),
+            },
+        };
+
+        // Rebuild filteredRows so MudDataGrid's virtualizer detects the Items
+        // reference change and re-renders visible rows with updated Seen/Caught
+        // state.  Also handles the case where a status-filter is active and the
+        // row's visibility changes (e.g. unchecking Seen while "Seen" filter is on).
+        ApplyFilter();
     }
 
     private async Task OpenDetails(PokedexGridRow row)

--- a/Pkmds.Rcl/wwwroot/css/app.css
+++ b/Pkmds.Rcl/wwwroot/css/app.css
@@ -315,34 +315,6 @@ body, html {
         overflow-y: auto;
     }
 
-    /* Pokédex tab content: inner MudDataGrid owns its scroll (FixedHeader + Virtualize),
-       so the outer container must not add a second scrollbar. */
-    .pokedex-tab-content {
-        height: 100%;
-        overflow: hidden;
-    }
-
-    .pokedex-grid-wrapper {
-        flex: 1;
-        min-height: 0;
-        overflow: hidden;
-        display: flex;
-        flex-direction: column;
-    }
-
-    .pokedex-grid-wrapper .pokedex-species-grid {
-        flex: 1;
-        min-height: 0;
-        display: flex;
-        flex-direction: column;
-    }
-
-    .pokedex-grid-wrapper .pokedex-species-grid > .mud-table-container {
-        flex: 1;
-        min-height: 0;
-        overflow-y: auto;
-    }
-
     /* Teams tab content: simple vertical scroll for team cards */
     .teams-tab-content {
         height: 100%;
@@ -479,6 +451,16 @@ body, html {
         overflow-y: auto;
         overflow-x: hidden;
     }
+
+    /* Pokédex panel owns its own scroll via the inner virtualized table; suppress the
+       outer panel scrollbar so the table-container has a definite, viewport-bounded
+       height to size against (otherwise the Virtualize component cuts the list off
+       at whatever fits in its initial computed height — ~106 rows on phone portrait). */
+    .save-file-outer-tabs > .mud-tabs-panels > .mud-tab-panel:has(.pokedex-tab-content) {
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+    }
 }
 
 /* Tablet (md–lg): edit form inner tab panels also scroll independently */
@@ -486,6 +468,34 @@ body, html {
     .edit-form-tabs .mud-tabs-panels {
         overflow-y: auto;
     }
+}
+
+/* Pokédex grid flex cascade — applies on every viewport so the inner MudDataGrid's
+   .mud-table-container always has a definite height for Virtualize to size against. */
+.pokedex-tab-content {
+    height: 100%;
+    overflow: hidden;
+}
+
+.pokedex-grid-wrapper {
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.pokedex-grid-wrapper .pokedex-species-grid {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+.pokedex-grid-wrapper .pokedex-species-grid > .mud-table-container {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
 }
 
 .square-slot {


### PR DESCRIPTION
Fixes #743

Replaces `QuickFilter="@FilterRow"` on MudDataGrid with a pre-computed `filteredRows` list. QuickFilter was creating a new delegate object on every render, causing MudDataGrid to invalidate its filtered-items cache each cycle. This made the Virtualize component recalculate the total item count incorrectly and reset the scroll position to 0, cutting off the visible list (~106 rows in Gen 2) and jumping back to the top whenever the user scrolled down.

Generated with [Claude Code](https://claude.ai/code)