### PR TITLE
feat: snackbar confirms Manic EMU ZIP detection on save load

### DIFF
--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
@@ -434,6 +434,9 @@ public partial class MainLayout : IDisposable
 
                 manicEmuSaveContext = manicContext;
                 Logger.LogInformation("Loaded save from Manic EMU .3ds.sav/.3ds.save archive; entry: {EntryPath}", manicContext.SaveEntryPath);
+                Snackbar.Add(
+                    "Manic EMU save archive detected — export will rebuild the ZIP for seamless re-import.",
+                    Severity.Info);
                 FinishLoadingSaveFile(saveFile, selectedFile.Name);
             }
             else


### PR DESCRIPTION
## Summary
- When `ManicEmuSaveHelper.TryExtractSaveFromZip` succeeds on save upload, show an Info snackbar (\"Manic EMU save archive detected — export will rebuild the ZIP for seamless re-import.\") so users get explicit confirmation their upload was recognised as a Manic EMU archive.
- Addresses the top suspect from the #669 investigation and directly targets the recurring report in #746, where reporters upload a raw `.sav` (not the `.3ds.save` ZIP), get a raw `.sav` back from PKMDS, and then can't re-import it into Manic EMU. With no UI feedback today, users can't tell whether PKMDS saw their upload as a Manic EMU archive or a bare save.

## Test plan
- [ ] Load a Manic EMU `.3ds.sav` / `.3ds.save` ZIP: snackbar appears on success.
- [ ] Load a raw `.sav` (e.g. Omega Ruby): no snackbar (unchanged behaviour).
- [ ] Load an unsupported ZIP / non-save: error dialog as before, no snackbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)