### PR TITLE
fix: preserve Manic EMU ZIP wrapper across load, export, backup, bug report

### DIFF
--- a/Pkmds.Core/Utilities/ManicEmuSaveHelper.cs
+++ b/Pkmds.Core/Utilities/ManicEmuSaveHelper.cs
@@ -181,9 +181,12 @@ public static class ManicEmuSaveHelper
 
     /// <summary>
     /// Rebuilds the original <c>.3ds.sav</c> ZIP archive, replacing the save file entry
-    /// with <paramref name="newSaveBytes" />.  All other entries are re-compressed at
-    /// <see cref="CompressionLevel.Optimal" />; timestamps are preserved but other per-entry
-    /// metadata (compression method, extra fields) may differ from the original.
+    /// with <paramref name="newSaveBytes" />. Entries are written with
+    /// <see cref="CompressionLevel.NoCompression" /> (store method) to match what Manic EMU's
+    /// own <c>ShareManager.create3DSGameSave</c> produces. Deflate-method rebuilds have been
+    /// observed to be rejected by Manic EMU on iOS even though the archive is structurally
+    /// valid (see issue #751 follow-up: a 483 kB ORAS save deflated to 9 kB failed to import,
+    /// while the same content store-method at ~483 kB worked). Timestamps are preserved.
     /// </summary>
     /// <param name="context">The context returned by <see cref="TryExtractSaveFromZip" />.</param>
     /// <param name="newSaveBytes">The edited save data to embed.</param>
@@ -199,7 +202,7 @@ public static class ManicEmuSaveHelper
 
             foreach (var entry in origArchive.Entries)
             {
-                var newEntry = newArchive.CreateEntry(entry.FullName, CompressionLevel.Optimal);
+                var newEntry = newArchive.CreateEntry(entry.FullName, CompressionLevel.NoCompression);
                 newEntry.LastWriteTime = entry.LastWriteTime;
 
                 using var dest = newEntry.Open();

--- a/Pkmds.Core/Utilities/ManicEmuSaveHelper.cs
+++ b/Pkmds.Core/Utilities/ManicEmuSaveHelper.cs
@@ -4,20 +4,27 @@ using System.IO.Compression;
 namespace Pkmds.Core.Utilities;
 
 /// <summary>
-/// Helpers for importing and exporting 3DS save files in the Manic EMU
-/// <c>.3ds.sav</c> / <c>.3ds.save</c> ZIP format.
+/// Helpers for importing and exporting 3DS save files in the Manic EMU <c>.3ds.sav</c> ZIP format.
 /// </summary>
 /// <remarks>
-/// Manic EMU exports 3DS saves as a ZIP archive. The filename extension varies by
-/// platform: most versions use <c>GameTitle.3ds.sav</c>; iOS uses <c>GameTitle.3ds.save</c>.
+/// Manic EMU exports 3DS saves as a ZIP archive. The canonical extension is
+/// <c>GameTitle.3ds.sav</c> on every platform — the iOS build uses the same suffix as
+/// desktop (see <c>ManicEmu/Sources/Tools/Cores/ThreeDS.swift</c> and
+/// <c>ManicEmu/Sources/Tools/Others/ShareManager.swift</c> in the upstream repo).
+/// We still *accept* <c>.3ds.save</c> (with a trailing <c>e</c>) defensively — users
+/// sometimes rename manually, and iOS Safari has been observed mangling compound
+/// extensions on blob-URL downloads — but PKMDS should never produce it when round-tripping
+/// a <c>.3ds.sav</c> upload. Manic EMU's own importer matches <c>url.path.contains(".3ds.sav")</c>
+/// as a substring check, so <c>.3ds.save</c> happens to re-import successfully too.
+/// <para>
 /// The ZIP contains the full <c>sdmc/</c> directory tree from Citra's virtual SD card,
-/// e.g. <c>sdmc/Nintendo 3DS/…/title/00040000/00055d00/data/00000001/&lt;savefile&gt;</c>.
-/// The actual PKHeX-compatible save bytes are stored as a single binary file entry
-/// inside that directory structure.
-/// To round-trip a save through PKMDS:
+/// e.g. <c>sdmc/Nintendo 3DS/…/title/00040000/00055d00/data/00000001/main</c>. The
+/// PKHeX-compatible save bytes are stored as a single binary file entry inside that
+/// structure. To round-trip a save through PKMDS:
+/// </para>
 /// <list type="number">
-/// <item>User exports <c>.3ds.sav</c> or <c>.3ds.save</c> from Manic EMU.</item>
-/// <item>PKMDS detects the ZIP, finds the save entry, and loads it.</item>
+/// <item>User exports <c>.3ds.sav</c> from Manic EMU.</item>
+/// <item>PKMDS detects the ZIP, finds the save entry, and loads it (see <see cref="SaveFileLoader" />).</item>
 /// <item>User edits the save in PKMDS.</item>
 /// <item>
 /// PKMDS rebuilds the ZIP with the edited save bytes and offers it for download
@@ -25,17 +32,12 @@ namespace Pkmds.Core.Utilities;
 /// </item>
 /// </list>
 /// <para>
-/// Troubleshooting "save is always corrupted in Manic EMU" reports (see issue #669):
-/// the round-trip only works if the user uploads the original <c>.3ds.sav</c> /
-/// <c>.3ds.save</c> ZIP — uploading raw save bytes causes PKMDS to export raw bytes
-/// on save, which Manic EMU cannot import. The three known suspects are:
-/// (1) user uploaded the wrong file type — there is no UI feedback confirming a
-/// Manic EMU ZIP was detected on load; (2) iOS Safari may mangle or strip the
-/// compound <c>.3ds.save</c> extension when downloading via blob URL (see
-/// <c>fileSave.js</c>); (3) no test currently round-trips a Manic EMU ZIP
-/// <em>with modifications</em> and re-validates checksums. If a similar report
-/// comes in, ask the reporter which file they uploaded, whether the exported
-/// filename is intact, and whether the failure occurs even with no edits.
+/// Load-path ordering matters: PKHeX.Core ships its own <c>ZipReader</c> that recognises
+/// any ZIP with a <c>main</c> or <c>SaveData.bin</c> entry inside and unwraps it invisibly.
+/// If the Manic EMU ZIP detection runs <em>after</em> <c>SaveUtil.TryGetSaveFile</c>, PKHeX
+/// swallows the archive, we never see it as a ZIP, <see cref="ManicEmuSaveContext" /> is never
+/// set, and export silently produces raw bytes that Manic EMU can't re-import (see issue #750
+/// for the regression caused by missing this ordering). Always run ZIP detection first.
 /// </para>
 /// </remarks>
 public static class ManicEmuSaveHelper
@@ -240,9 +242,10 @@ public static class ManicEmuSaveHelper
     /// Original filename of the loaded archive (may be <see langword="null" />).
     /// </param>
     /// <returns>
-    /// A tuple of the full export filename and its compound extension.
-    /// For example, <c>("AlphaSapphire.3ds.save", ".3ds.save")</c> for an iOS archive
-    /// or <c>("AlphaSapphire.3ds.sav", ".3ds.sav")</c> for other platforms.
+    /// A tuple of the full export filename and its compound extension. Normally the canonical
+    /// <c>.3ds.sav</c> suffix, e.g. <c>("AlphaSapphire.3ds.sav", ".3ds.sav")</c>. If the user
+    /// uploaded a file whose name already ends in <c>.3ds.save</c> (manual rename or iOS-side
+    /// extension mangling), we echo that back so the round-trip is bit-for-bit transparent.
     /// </returns>
     public static (string ExportName, string CompoundExtension) GetExportFileName(string? originalName)
     {
@@ -254,7 +257,7 @@ public static class ManicEmuSaveHelper
             return ("save" + savExt, savExt);
         }
 
-        // iOS Manic EMU uses .3ds.save; check this first since it is the more specific suffix.
+        // Check .3ds.save first — it's the more specific suffix (ends in .3ds.sav also matches it).
         if (originalName.EndsWith(saveExt, StringComparison.OrdinalIgnoreCase))
         {
             var stem = originalName[..^saveExt.Length];

--- a/Pkmds.Core/Utilities/ManicEmuSaveHelper.cs
+++ b/Pkmds.Core/Utilities/ManicEmuSaveHelper.cs
@@ -236,26 +236,30 @@ public static class ManicEmuSaveHelper
         }
 
         var bytes = resultStream.ToArray();
-        SetUtf8PathEncodingFlag(bytes);
+        NormalizeZipHeadersForZipFoundation(bytes);
         return bytes;
     }
 
     /// <summary>
-    /// Sets general-purpose bit 11 (UTF-8 path encoding) on every local file header and central
-    /// directory file header in <paramref name="zipBytes" />. .NET's <see cref="ZipArchive" />
-    /// only sets this flag when a path contains non-ASCII characters, but ZIPFoundation on iOS
-    /// sets it unconditionally and has been observed rejecting archives that omit it. Matching
-    /// ZIPFoundation's behaviour makes our rebuilt archive byte-level compatible with Manic EMU's
-    /// own output.
+    /// Rewrites a few header fields in the rebuilt ZIP so our output matches what ZIPFoundation
+    /// (the library Manic EMU uses on iOS) would have written:
+    /// <list type="bullet">
+    ///   <item>Sets general-purpose bit 11 (UTF-8 path encoding) on every local and central
+    ///   directory file header. .NET's <see cref="ZipArchive" /> only sets bit 11 when a path
+    ///   contains non-ASCII characters, but ZIPFoundation sets it unconditionally (see
+    ///   <c>Archive+Helpers.writeLocalFileHeader</c>).</item>
+    ///   <item>Bumps <c>versionMadeBy</c> from the .NET default (2.0) to ZIPFoundation's
+    ///   2.1 (<c>0x0315</c>) on every central directory header, matching the original Manic
+    ///   EMU archive exactly in the non-data region.</item>
+    /// </list>
     /// </summary>
-    private static void SetUtf8PathEncodingFlag(byte[] zipBytes)
+    private static void NormalizeZipHeadersForZipFoundation(byte[] zipBytes)
     {
         const int lfhSignature = 0x04034B50;  // "PK\x03\x04"
         const int cdfhSignature = 0x02014B50; // "PK\x01\x02"
         const ushort utf8Flag = 0x0800;
+        const ushort zipFoundationVersionMadeBy = 0x0315; // Unix (0x03) + ZIP spec 2.1 (0x15)
 
-        // Locate the End of Central Directory record so we know where local headers end
-        // and the central directory begins.
         var eocdOffset = FindEndOfCentralDirectory(zipBytes);
         if (eocdOffset < 0)
         {
@@ -266,7 +270,7 @@ public static class ManicEmuSaveHelper
         var cdSize = BitConverter.ToInt32(zipBytes, eocdOffset + 12);
         var entryCount = BitConverter.ToUInt16(zipBytes, eocdOffset + 10);
 
-        // Patch each local file header's flags (offset 6 from LFH start).
+        // Patch every local file header's flags (offset 6 from LFH start).
         var pos = 0;
         for (var i = 0; i < entryCount && pos + 30 <= cdOffset; i++)
         {
@@ -283,7 +287,8 @@ public static class ManicEmuSaveHelper
             pos += 30 + nameLen + extraLen + (int)compSize;
         }
 
-        // Patch each central directory file header's flags (offset 8 from CDFH start).
+        // Patch every central directory file header's flags (offset 8) and versionMadeBy
+        // (offset 4).
         pos = cdOffset;
         for (var i = 0; i < entryCount && pos + 46 <= cdOffset + cdSize; i++)
         {
@@ -293,6 +298,7 @@ public static class ManicEmuSaveHelper
             }
 
             SetFlagBits(zipBytes, pos + 8, utf8Flag);
+            WriteUInt16(zipBytes, pos + 4, zipFoundationVersionMadeBy);
 
             var nameLen = BitConverter.ToUInt16(zipBytes, pos + 28);
             var extraLen = BitConverter.ToUInt16(zipBytes, pos + 30);
@@ -327,6 +333,12 @@ public static class ManicEmuSaveHelper
         var updated = (ushort)(current | mask);
         zipBytes[flagsOffset] = (byte)(updated & 0xFF);
         zipBytes[flagsOffset + 1] = (byte)((updated >> 8) & 0xFF);
+    }
+
+    private static void WriteUInt16(byte[] zipBytes, int offset, ushort value)
+    {
+        zipBytes[offset] = (byte)(value & 0xFF);
+        zipBytes[offset + 1] = (byte)((value >> 8) & 0xFF);
     }
 
     /// <summary>

--- a/Pkmds.Core/Utilities/ManicEmuSaveHelper.cs
+++ b/Pkmds.Core/Utilities/ManicEmuSaveHelper.cs
@@ -183,10 +183,11 @@ public static class ManicEmuSaveHelper
     /// Rebuilds the original <c>.3ds.sav</c> ZIP archive, replacing the save file entry
     /// with <paramref name="newSaveBytes" />. Entries are written with
     /// <see cref="CompressionLevel.NoCompression" /> (store method) to match what Manic EMU's
-    /// own <c>ShareManager.create3DSGameSave</c> produces. Deflate-method rebuilds have been
-    /// observed to be rejected by Manic EMU on iOS even though the archive is structurally
-    /// valid (see issue #751 follow-up: a 483 kB ORAS save deflated to 9 kB failed to import,
-    /// while the same content store-method at ~483 kB worked). Timestamps are preserved.
+    /// own <c>ShareManager.create3DSGameSave</c> produces via ZIPFoundation; the general-purpose
+    /// bit 11 (UTF-8 path encoding) is also set on every entry in a post-write pass, again
+    /// matching ZIPFoundation's writer (<c>Archive+Helpers.writeLocalFileHeader</c>). Without
+    /// that flag ZIPFoundation on iOS has been observed rejecting the archive even though
+    /// all paths are pure ASCII — see issue #751 follow-up.
     /// </summary>
     /// <param name="context">The context returned by <see cref="TryExtractSaveFromZip" />.</param>
     /// <param name="newSaveBytes">The edited save data to embed.</param>
@@ -234,7 +235,98 @@ public static class ManicEmuSaveHelper
             }
         }
 
-        return resultStream.ToArray();
+        var bytes = resultStream.ToArray();
+        SetUtf8PathEncodingFlag(bytes);
+        return bytes;
+    }
+
+    /// <summary>
+    /// Sets general-purpose bit 11 (UTF-8 path encoding) on every local file header and central
+    /// directory file header in <paramref name="zipBytes" />. .NET's <see cref="ZipArchive" />
+    /// only sets this flag when a path contains non-ASCII characters, but ZIPFoundation on iOS
+    /// sets it unconditionally and has been observed rejecting archives that omit it. Matching
+    /// ZIPFoundation's behaviour makes our rebuilt archive byte-level compatible with Manic EMU's
+    /// own output.
+    /// </summary>
+    private static void SetUtf8PathEncodingFlag(byte[] zipBytes)
+    {
+        const int lfhSignature = 0x04034B50;  // "PK\x03\x04"
+        const int cdfhSignature = 0x02014B50; // "PK\x01\x02"
+        const ushort utf8Flag = 0x0800;
+
+        // Locate the End of Central Directory record so we know where local headers end
+        // and the central directory begins.
+        var eocdOffset = FindEndOfCentralDirectory(zipBytes);
+        if (eocdOffset < 0)
+        {
+            return;
+        }
+
+        var cdOffset = BitConverter.ToInt32(zipBytes, eocdOffset + 16);
+        var cdSize = BitConverter.ToInt32(zipBytes, eocdOffset + 12);
+        var entryCount = BitConverter.ToUInt16(zipBytes, eocdOffset + 10);
+
+        // Patch each local file header's flags (offset 6 from LFH start).
+        var pos = 0;
+        for (var i = 0; i < entryCount && pos + 30 <= cdOffset; i++)
+        {
+            if (BitConverter.ToInt32(zipBytes, pos) != lfhSignature)
+            {
+                break;
+            }
+
+            SetFlagBits(zipBytes, pos + 6, utf8Flag);
+
+            var nameLen = BitConverter.ToUInt16(zipBytes, pos + 26);
+            var extraLen = BitConverter.ToUInt16(zipBytes, pos + 28);
+            var compSize = BitConverter.ToUInt32(zipBytes, pos + 18);
+            pos += 30 + nameLen + extraLen + (int)compSize;
+        }
+
+        // Patch each central directory file header's flags (offset 8 from CDFH start).
+        pos = cdOffset;
+        for (var i = 0; i < entryCount && pos + 46 <= cdOffset + cdSize; i++)
+        {
+            if (BitConverter.ToInt32(zipBytes, pos) != cdfhSignature)
+            {
+                break;
+            }
+
+            SetFlagBits(zipBytes, pos + 8, utf8Flag);
+
+            var nameLen = BitConverter.ToUInt16(zipBytes, pos + 28);
+            var extraLen = BitConverter.ToUInt16(zipBytes, pos + 30);
+            var commentLen = BitConverter.ToUInt16(zipBytes, pos + 32);
+            pos += 46 + nameLen + extraLen + commentLen;
+        }
+    }
+
+    private static int FindEndOfCentralDirectory(byte[] zipBytes)
+    {
+        // EOCD signature is PK\x05\x06; scan backward from the end since the record has a
+        // variable-length comment field suffix.
+        const int eocdSignature = 0x06054B50;
+        const int eocdMinSize = 22;
+        const int eocdMaxCommentLen = 65535;
+
+        var searchStart = Math.Max(0, zipBytes.Length - eocdMinSize - eocdMaxCommentLen);
+        for (var i = zipBytes.Length - eocdMinSize; i >= searchStart; i--)
+        {
+            if (BitConverter.ToInt32(zipBytes, i) == eocdSignature)
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private static void SetFlagBits(byte[] zipBytes, int flagsOffset, ushort mask)
+    {
+        var current = BitConverter.ToUInt16(zipBytes, flagsOffset);
+        var updated = (ushort)(current | mask);
+        zipBytes[flagsOffset] = (byte)(updated & 0xFF);
+        zipBytes[flagsOffset + 1] = (byte)((updated >> 8) & 0xFF);
     }
 
     /// <summary>

--- a/Pkmds.Core/Utilities/ManicEmuSaveHelper.cs
+++ b/Pkmds.Core/Utilities/ManicEmuSaveHelper.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.IO.Compression;
 
 namespace Pkmds.Core.Utilities;
@@ -38,6 +39,17 @@ namespace Pkmds.Core.Utilities;
 /// swallows the archive, we never see it as a ZIP, <see cref="ManicEmuSaveContext" /> is never
 /// set, and export silently produces raw bytes that Manic EMU can't re-import (see issue #750
 /// for the regression caused by missing this ordering). Always run ZIP detection first.
+/// </para>
+/// <para>
+/// Known-upstream caveat: early in PR #751's debugging, a sequence of broken exports
+/// (pre-fix deflate-compressed 9 kB archives with the inner save replaced by the PKHeX
+/// default) caused Manic EMU / Citra to reject every subsequent save as "corrupted"
+/// in-game — even after switching back to byte-identical valid archives. Recovery required
+/// deleting the Manic EMU app and re-importing the ROM. The present implementation
+/// produces ZIPs byte-level compatible with ZIPFoundation's own output (store compression,
+/// bit 11 set, <c>versionMadeBy = 0x0315</c>), so a fresh round-trip on a healthy Manic EMU
+/// install is fine; the warning exists only for users who hit the issue with an older build
+/// and may need the clean reinstall to clear the accumulated state.
 /// </para>
 /// </remarks>
 public static class ManicEmuSaveHelper
@@ -343,49 +355,78 @@ public static class ManicEmuSaveHelper
 
     /// <summary>
     /// Computes the export filename and compound extension for a Manic EMU save archive,
-    /// preserving the original compound extension for round-trip compatibility.
+    /// preserving the original compound extension for round-trip compatibility and appending a
+    /// UTC timestamp suffix to the stem to prevent iOS's "filename-already-exists" auto-rename
+    /// (which inserts a space — e.g. <c>.3ds 2.sav</c> — that breaks Manic EMU's
+    /// <c>url.path.contains(".3ds.sav")</c> substring check on re-import).
     /// </summary>
     /// <param name="originalName">
     /// Original filename of the loaded archive (may be <see langword="null" />).
     /// </param>
+    /// <param name="timestamp">
+    /// Timestamp to embed in the export name. Defaults to <see cref="DateTime.UtcNow" />.
+    /// An existing <c>-yyyyMMddTHHmmss</c> suffix on the stem is stripped first, so
+    /// the name doesn't accumulate timestamps across multiple round-trips.
+    /// </param>
     /// <returns>
     /// A tuple of the full export filename and its compound extension. Normally the canonical
-    /// <c>.3ds.sav</c> suffix, e.g. <c>("AlphaSapphire.3ds.sav", ".3ds.sav")</c>. If the user
-    /// uploaded a file whose name already ends in <c>.3ds.save</c> (manual rename or iOS-side
-    /// extension mangling), we echo that back so the round-trip is bit-for-bit transparent.
+    /// <c>.3ds.sav</c> suffix, e.g. <c>("AlphaSapphire-20260420T174612.3ds.sav", ".3ds.sav")</c>.
+    /// If the user uploaded a file whose name already ends in <c>.3ds.save</c> (manual rename
+    /// or iOS-side extension mangling), we echo that back so the round-trip is bit-for-bit
+    /// transparent.
     /// </returns>
-    public static (string ExportName, string CompoundExtension) GetExportFileName(string? originalName)
+    public static (string ExportName, string CompoundExtension) GetExportFileName(string? originalName, DateTime? timestamp = null)
     {
         const string savExt = ".3ds.sav";
         const string saveExt = ".3ds.save";
 
+        var suffix = "-" + (timestamp ?? DateTime.UtcNow).ToString("yyyyMMdd'T'HHmmss", CultureInfo.InvariantCulture);
+
         if (originalName is null)
         {
-            return ("save" + savExt, savExt);
+            return ("save" + suffix + savExt, savExt);
         }
 
         // Check .3ds.save first — it's the more specific suffix (ends in .3ds.sav also matches it).
         if (originalName.EndsWith(saveExt, StringComparison.OrdinalIgnoreCase))
         {
-            var stem = originalName[..^saveExt.Length];
-            return ((stem.Length > 0
-                ? stem
-                : "save") + saveExt, saveExt);
+            var stem = StripExistingTimestampSuffix(originalName[..^saveExt.Length]);
+            return ((stem.Length > 0 ? stem : "save") + suffix + saveExt, saveExt);
         }
 
         if (originalName.EndsWith(savExt, StringComparison.OrdinalIgnoreCase))
         {
-            var stem = originalName[..^savExt.Length];
-            return ((stem.Length > 0
-                ? stem
-                : "save") + savExt, savExt);
+            var stem = StripExistingTimestampSuffix(originalName[..^savExt.Length]);
+            return ((stem.Length > 0 ? stem : "save") + suffix + savExt, savExt);
         }
 
         // Unknown/no compound extension — strip the last extension and default to .3ds.sav.
-        var fallbackStem = Path.GetFileNameWithoutExtension(originalName);
-        return ((fallbackStem.Length > 0
-            ? fallbackStem
-            : "save") + savExt, savExt);
+        var fallbackStem = StripExistingTimestampSuffix(Path.GetFileNameWithoutExtension(originalName));
+        return ((fallbackStem.Length > 0 ? fallbackStem : "save") + suffix + savExt, savExt);
+    }
+
+    /// <summary>
+    /// Removes a trailing <c>-yyyyMMddTHHmmss</c> timestamp suffix from <paramref name="stem" />
+    /// if one is present, so repeated round-trips don't accumulate timestamps. Uses a strict
+    /// length + digit check to avoid stripping unrelated user suffixes that happen to end in
+    /// hyphens or digits.
+    /// </summary>
+    private static string StripExistingTimestampSuffix(string stem)
+    {
+        // Format: ...-yyyyMMddTHHmmss (1 + 8 + 1 + 6 = 16 chars)
+        const int suffixLength = 16;
+        if (stem.Length < suffixLength + 1 || stem[^suffixLength] != '-' || stem[^7] != 'T')
+        {
+            return stem;
+        }
+
+        for (var i = stem.Length - suffixLength + 1; i < stem.Length; i++)
+        {
+            if (i == stem.Length - 7) continue; // 'T' separator, already checked
+            if (!char.IsDigit(stem[i])) return stem;
+        }
+
+        return stem[..^suffixLength];
     }
 
     /// <summary>

--- a/Pkmds.Core/Utilities/SaveFileLoader.cs
+++ b/Pkmds.Core/Utilities/SaveFileLoader.cs
@@ -1,0 +1,54 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Pkmds.Core.Utilities;
+
+/// <summary>
+/// Unified entry point for loading user-supplied save data. Detects Manic EMU
+/// <c>.3ds.sav</c> ZIP archives before delegating to <see cref="SaveUtil.TryGetSaveFile(Memory{byte}, out SaveFile?, string?)" />
+/// for raw saves.
+/// </summary>
+/// <remarks>
+/// The ordering here is load-bearing. PKHeX.Core's built-in <see cref="ZipReader" />
+/// (registered in <see cref="SaveUtil.CustomSaveReaders" />) recognises any ZIP with a
+/// <c>main</c> or <c>SaveData.bin</c> entry and unwraps it invisibly — including Manic EMU
+/// archives. If we call <see cref="SaveUtil.TryGetSaveFile(Memory{byte}, out SaveFile?, string?)" />
+/// first on a Manic EMU ZIP we get back a valid <see cref="SaveFile" />, but the surrounding
+/// <see cref="ManicEmuSaveHelper.ManicEmuSaveContext" /> (needed to rebuild the archive on export)
+/// is silently lost, and the user ends up exporting raw bytes that Manic EMU rejects
+/// on re-import (issue #750).
+/// </remarks>
+public static class SaveFileLoader
+{
+    /// <summary>
+    /// Attempts to load <paramref name="data" /> as either a Manic EMU ZIP archive or a raw save.
+    /// </summary>
+    /// <param name="data">Raw upload bytes.</param>
+    /// <param name="fileName">Original filename of the upload (may be <see langword="null" />).</param>
+    /// <param name="saveFile">
+    /// The parsed <see cref="SaveFile" /> instance on success.
+    /// </param>
+    /// <param name="manicEmuContext">
+    /// Non-<see langword="null" /> only when the upload was a Manic EMU ZIP. Pass this back to
+    /// <see cref="ManicEmuSaveHelper.RebuildZip" /> on export to round-trip correctly.
+    /// </param>
+    /// <returns><see langword="true" /> on successful load; <see langword="false" /> otherwise.</returns>
+    public static bool TryLoad(
+        byte[] data,
+        string? fileName,
+        [NotNullWhen(true)] out SaveFile? saveFile,
+        out ManicEmuSaveHelper.ManicEmuSaveContext? manicEmuContext)
+    {
+        manicEmuContext = null;
+
+        // Manic EMU detection must run before SaveUtil.TryGetSaveFile because PKHeX's ZipReader
+        // would otherwise unwrap the archive invisibly, stripping the context we need for re-export.
+        if (ManicEmuSaveHelper.IsZip(data) &&
+            ManicEmuSaveHelper.TryExtractSaveFromZip(data, fileName, out saveFile, out var ctx))
+        {
+            manicEmuContext = ctx;
+            return true;
+        }
+
+        return SaveUtil.TryGetSaveFile(data, out saveFile, fileName);
+    }
+}

--- a/Pkmds.Rcl/Components/Dialogs/BugReportDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/BugReportDialog.razor.cs
@@ -81,11 +81,19 @@ public partial class BugReportDialog
                     // If the current save was loaded from a Manic EMU .3ds.sav ZIP, rebuild the
                     // archive so the bug report preserves the wrapper. Without this the submitted
                     // bytes are the bare inner save and we can never diagnose ZIP round-trip
-                    // issues from user reports (see issue #750).
-                    saveBytes = AppState.ManicEmuSaveContext is { } ctx
-                        ? ManicEmuSaveHelper.RebuildZip(ctx, rawBytes)
-                        : rawBytes;
-                    saveFileName = AppState.SaveFileName ?? "save.bin";
+                    // issues from user reports (see issue #750). The attachment name must carry
+                    // the compound extension so triagers can see at a glance the payload is a ZIP
+                    // and not a bare .sav — a generic save.bin fallback would mask that.
+                    if (AppState.ManicEmuSaveContext is { } ctx)
+                    {
+                        saveBytes = ManicEmuSaveHelper.RebuildZip(ctx, rawBytes);
+                        saveFileName = ManicEmuSaveHelper.GetExportFileName(AppState.SaveFileName).ExportName;
+                    }
+                    else
+                    {
+                        saveBytes = rawBytes;
+                        saveFileName = AppState.SaveFileName ?? "save.bin";
+                    }
                 }
             }
 

--- a/Pkmds.Rcl/Components/Dialogs/BugReportDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/BugReportDialog.razor.cs
@@ -77,7 +77,14 @@ public partial class BugReportDialog
                 saveRevision = (sf as ISaveFileRevision)?.SaveRevisionString;
                 if (attachSaveFile)
                 {
-                    saveBytes = sf.Write().ToArray();
+                    var rawBytes = sf.Write().ToArray();
+                    // If the current save was loaded from a Manic EMU .3ds.sav ZIP, rebuild the
+                    // archive so the bug report preserves the wrapper. Without this the submitted
+                    // bytes are the bare inner save and we can never diagnose ZIP round-trip
+                    // issues from user reports (see issue #750).
+                    saveBytes = AppState.ManicEmuSaveContext is { } ctx
+                        ? ManicEmuSaveHelper.RebuildZip(ctx, rawBytes)
+                        : rawBytes;
                     saveFileName = AppState.SaveFileName ?? "save.bin";
                 }
             }

--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
@@ -434,6 +434,9 @@ public partial class MainLayout : IDisposable
 
                 manicEmuSaveContext = manicContext;
                 Logger.LogInformation("Loaded save from Manic EMU .3ds.sav/.3ds.save archive; entry: {EntryPath}", manicContext.SaveEntryPath);
+                Snackbar.Add(
+                    "Manic EMU save archive detected — export will rebuild the ZIP for seamless re-import.",
+                    Severity.Info);
                 FinishLoadingSaveFile(saveFile, selectedFile.Name);
             }
             else

--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
@@ -9,7 +9,6 @@ public partial class MainLayout : IDisposable
 
     private IBrowserFile? browserLoadSaveFile;
     private bool isDarkMode;
-    private ManicEmuSaveHelper.ManicEmuSaveContext? manicEmuSaveContext;
     private bool systemIsDarkMode;
     private ThemeMode themeMode = ThemeMode.System;
 
@@ -255,7 +254,7 @@ public partial class MainLayout : IDisposable
 
     private async Task ShowBackupManagerDialog()
     {
-        var parameters = new DialogParameters { { nameof(BackupManagerDialog.SaveFile), AppState.SaveFile }, { nameof(BackupManagerDialog.FileName), AppState.SaveFileName }, { nameof(BackupManagerDialog.IsManicEmu), manicEmuSaveContext is not null }, { nameof(BackupManagerDialog.ManicEmuContext), manicEmuSaveContext } };
+        var parameters = new DialogParameters { { nameof(BackupManagerDialog.SaveFile), AppState.SaveFile }, { nameof(BackupManagerDialog.FileName), AppState.SaveFileName }, { nameof(BackupManagerDialog.IsManicEmu), AppState.ManicEmuSaveContext is not null }, { nameof(BackupManagerDialog.ManicEmuContext), AppState.ManicEmuSaveContext } };
         var options = new DialogOptions { MaxWidth = MaxWidth.Medium, FullWidth = true, CloseOnEscapeKey = true };
         var dialog = await DialogService.ShowAsync<BackupManagerDialog>("Backup Manager", parameters, options);
         var result = await dialog.Result;
@@ -291,24 +290,9 @@ public partial class MainLayout : IDisposable
             var data = restore.SaveBytes;
             var fileName = restore.Entry.FileName;
 
-            if (restore.Entry.IsManicEmu &&
-                ManicEmuSaveHelper.TryExtractSaveFromZip(data, fileName, out var saveFile, out var manicContext))
+            if (SaveFileLoader.TryLoad(data, fileName, out var saveFile, out var manicContext))
             {
                 if (!saveFile.State.Exportable)
-                {
-                    Logger.LogWarning("Manic EMU backup save file is not exportable (unsupported format/ROM hack): {FileName}", fileName);
-                    await DialogService.ShowMessageBoxAsync("Unsupported save file",
-                        "This backup cannot be restored — it may be from an unsupported ROM hack or format.");
-                    AppState.ShowProgressIndicator = false;
-                    return;
-                }
-
-                manicEmuSaveContext = manicContext;
-                FinishLoadingSaveFile(saveFile, fileName);
-            }
-            else if (SaveUtil.TryGetSaveFile(data, out var rawSave, fileName))
-            {
-                if (!rawSave.State.Exportable)
                 {
                     Logger.LogWarning("Backup save file is not exportable (unsupported format/ROM hack): {FileName}", fileName);
                     await DialogService.ShowMessageBoxAsync("Unsupported save file",
@@ -317,8 +301,8 @@ public partial class MainLayout : IDisposable
                     return;
                 }
 
-                manicEmuSaveContext = null;
-                FinishLoadingSaveFile(rawSave, fileName);
+                AppState.ManicEmuSaveContext = manicContext;
+                FinishLoadingSaveFile(saveFile, fileName);
             }
             else
             {
@@ -393,7 +377,7 @@ public partial class MainLayout : IDisposable
         AppService.ClearSelection();
         ParseSettings.ClearActiveTrainer();
         AppState.SaveFile = null;
-        manicEmuSaveContext = null;
+        AppState.ManicEmuSaveContext = null;
         AppState.ShowProgressIndicator = true;
 
         var data = Array.Empty<byte>();
@@ -405,8 +389,12 @@ public partial class MainLayout : IDisposable
             data = memoryStream.ToArray();
             Logger.LogDebug("Read {ByteCount} bytes from save file", data.Length);
 
-            // Try to load the file directly as a raw save.
-            if (SaveUtil.TryGetSaveFile(data, out var saveFile, selectedFile.Name))
+            // SaveFileLoader checks for a Manic EMU .3ds.sav ZIP (sdmc/… entries) before delegating
+            // to SaveUtil.TryGetSaveFile for raw saves. The ordering matters: PKHeX's built-in
+            // ZipReader would otherwise recognise the archive by its inner `main` entry and unwrap
+            // it invisibly, so manicContext would never be set and export would silently produce
+            // raw bytes that Manic EMU rejects on re-import (see issue #750).
+            if (SaveFileLoader.TryLoad(data, selectedFile.Name, out var saveFile, out var manicContext))
             {
                 if (!saveFile.State.Exportable)
                 {
@@ -417,26 +405,15 @@ public partial class MainLayout : IDisposable
                     return;
                 }
 
-                FinishLoadingSaveFile(saveFile, selectedFile.Name);
-            }
-            // If that fails, check whether this is a Manic EMU .3ds.sav ZIP archive.
-            // Manic EMU packages 3DS saves as a ZIP containing sdmc/… directory paths.
-            else if (ManicEmuSaveHelper.TryExtractSaveFromZip(data, selectedFile.Name, out saveFile, out var manicContext))
-            {
-                if (!saveFile.State.Exportable)
+                if (manicContext is not null)
                 {
-                    Logger.LogWarning("Manic EMU save file is not exportable (unsupported format/ROM hack): {FileName}", selectedFile.Name);
-                    await DialogService.ShowMessageBoxAsync("Unsupported save file",
-                        "This save file cannot be loaded — it may be from an unsupported ROM hack or format.");
-                    AppState.ShowProgressIndicator = false;
-                    return;
+                    AppState.ManicEmuSaveContext = manicContext;
+                    Logger.LogInformation("Loaded save from Manic EMU .3ds.sav archive; entry: {EntryPath}", manicContext.SaveEntryPath);
+                    Snackbar.Add(
+                        "Manic EMU save archive detected — export will rebuild the ZIP for seamless re-import.",
+                        Severity.Info);
                 }
 
-                manicEmuSaveContext = manicContext;
-                Logger.LogInformation("Loaded save from Manic EMU .3ds.sav/.3ds.save archive; entry: {EntryPath}", manicContext.SaveEntryPath);
-                Snackbar.Add(
-                    "Manic EMU save archive detected — export will rebuild the ZIP for seamless re-import.",
-                    Severity.Info);
                 FinishLoadingSaveFile(saveFile, selectedFile.Name);
             }
             else
@@ -473,12 +450,12 @@ public partial class MainLayout : IDisposable
             try
             {
                 var rawSave = AppState.SaveFile.Write().ToArray();
-                var backupBytes = manicEmuSaveContext is not null
-                    ? ManicEmuSaveHelper.RebuildZip(manicEmuSaveContext, rawSave)
+                var backupBytes = AppState.ManicEmuSaveContext is not null
+                    ? ManicEmuSaveHelper.RebuildZip(AppState.ManicEmuSaveContext, rawSave)
                     : rawSave;
                 await BackupService.CreateBackupAsync(
                     backupBytes, AppState.SaveFile, selectedFile.Name,
-                    isManicEmu: manicEmuSaveContext is not null, source: "auto");
+                    isManicEmu: AppState.ManicEmuSaveContext is not null, source: "auto");
                 await BackupService.EnforceRetentionAsync(SettingsService.Settings.MaxBackupCount);
             }
             catch (Exception ex)
@@ -545,16 +522,17 @@ public partial class MainLayout : IDisposable
 
         // If the save was loaded from a Manic EMU .3ds.sav ZIP, rebuild the ZIP so the
         // user can import it directly back into Manic EMU without any manual repacking.
-        if (manicEmuSaveContext is not null)
+        if (AppState.ManicEmuSaveContext is not null)
         {
-            // Determine the export filename and compound extension, preserving the
-            // original Manic EMU extension (.3ds.save on iOS, .3ds.sav elsewhere) so
-            // the rebuilt ZIP can be imported directly without renaming.
+            // Echo back whichever compound extension the upload carried (.3ds.sav canonically, or
+            // .3ds.save if the user renamed manually or iOS Safari mangled the suffix) so the
+            // round-trip is bit-for-bit transparent. Flag the MIME as application/zip — the default
+            // application/x-pokemon-savedata is wrong for an archive and confuses iOS Safari.
             var (exportName, compoundExt) = ManicEmuSaveHelper.GetExportFileName(originalName);
             Logger.LogDebug("Exporting save as Manic EMU {Extension}: {FileName}", compoundExt, exportName);
 
-            var zipBytes = ManicEmuSaveHelper.RebuildZip(manicEmuSaveContext, rawSaveBytes);
-            await WriteFile(zipBytes, exportName, compoundExt, "Save File");
+            var zipBytes = ManicEmuSaveHelper.RebuildZip(AppState.ManicEmuSaveContext, rawSaveBytes);
+            await WriteFile(zipBytes, exportName, compoundExt, "Save File", mimeType: "application/zip");
         }
         // Only default to "save.sav" if we have no original filename at all
         else if (string.IsNullOrWhiteSpace(originalName))
@@ -899,14 +877,15 @@ public partial class MainLayout : IDisposable
         return data;
     }
 
-    private async Task WriteFile(byte[] data, string fileName, string fileTypeExtension, string fileTypeDescription)
+    private async Task WriteFile(byte[] data, string fileName, string fileTypeExtension, string fileTypeDescription,
+        string mimeType = "application/x-pokemon-savedata")
     {
-        Logger.LogDebug("Writing file: {FileName}, Size: {Size} bytes", fileName, data.Length);
+        Logger.LogDebug("Writing file: {FileName}, Size: {Size} bytes, MIME: {Mime}", fileName, data.Length, mimeType);
 
         if (!await FileSystemAccessService.IsSupportedAsync())
         {
             Logger.LogDebug("File System Access API not supported, using legacy method");
-            await WriteFileOldWay(data, fileName, fileTypeExtension);
+            await WriteFileOldWay(data, fileName, fileTypeExtension, mimeType);
             return;
         }
 
@@ -917,7 +896,8 @@ public partial class MainLayout : IDisposable
                 fileName,
                 data,
                 fileTypeExtension,
-                fileTypeDescription);
+                fileTypeDescription,
+                mimeType);
             Logger.LogDebug("File written successfully using File System Access API");
         }
         catch (JSException ex) when (ex.Message.Contains("AbortError", StringComparison.OrdinalIgnoreCase) ||
@@ -933,7 +913,7 @@ public partial class MainLayout : IDisposable
         }
     }
 
-    private async Task WriteFileOldWay(byte[] data, string fileName, string fileTypeExtension)
+    private async Task WriteFileOldWay(byte[] data, string fileName, string fileTypeExtension, string mimeType)
     {
         var finalName = EnsureExtension(fileName, fileTypeExtension);
 
@@ -943,11 +923,10 @@ public partial class MainLayout : IDisposable
             "eval",
             "document.createElement('a')");
 
-        // You can keep octet-stream or mirror the JS type.
         await element.InvokeVoidAsync(
             "setAttribute",
             "href",
-            $"data:application/x-pokemon-savedata;base64,{base64String}");
+            $"data:{mimeType};base64,{base64String}");
 
         await element.InvokeVoidAsync("setAttribute", "download", finalName);
 

--- a/Pkmds.Rcl/IAppState.cs
+++ b/Pkmds.Rcl/IAppState.cs
@@ -30,6 +30,14 @@ public interface IAppState
     string? SaveFileName { get; set; }
 
     /// <summary>
+    /// Gets or sets the Manic EMU ZIP context captured when the user uploaded a
+    /// <c>.3ds.sav</c> / <c>.3ds.save</c> archive. Non-null only while a Manic EMU save is loaded.
+    /// Export, auto-backup, and bug-report submission all read this to round-trip the
+    /// original ZIP wrapper instead of the raw inner save. Cleared when the save file is unloaded.
+    /// </summary>
+    ManicEmuSaveHelper.ManicEmuSaveContext? ManicEmuSaveContext { get; set; }
+
+    /// <summary>
     /// Gets or sets the secondary save file used by the cross-save Trade tab.
     /// Independent from <see cref="SaveFile" />; remains null until the user explicitly
     /// loads a second save from the Trade tab.

--- a/Pkmds.Rcl/wwwroot/js/fileSave.js
+++ b/Pkmds.Rcl/wwwroot/js/fileSave.js
@@ -117,7 +117,7 @@ window.pkmdsIsInAppBrowser = function () {
     );
 };
 
-window.showFilePickerAndWrite = async function (fileName, byteArray, extension, description) {
+window.showFilePickerAndWrite = async function (fileName, byteArray, extension, description, mimeType) {
     // byteArray is expected to be a JS array of numbers coming from a Blazor byte[]
     try {
         if (!byteArray) throw new Error('byteArray is null/undefined');
@@ -142,6 +142,11 @@ window.showFilePickerAndWrite = async function (fileName, byteArray, extension, 
             ext = '.' + ext;
         }
 
+        // Caller can override the MIME — important for ZIP archives (Manic EMU .3ds.sav)
+        // where the default is wrong and iOS Safari is known to rewrite the extension to
+        // match the declared type.
+        const blobType = mimeType || 'application/x-pokemon-savedata';
+
         // Chrome Android may have partial / flaky support for File System Access API.
         // iOS (all browsers) uses WebKit, which may expose showSaveFilePicker but has
         // incomplete support for createWritable() — always use the anchor fallback on iOS.
@@ -152,9 +157,7 @@ window.showFilePickerAndWrite = async function (fileName, byteArray, extension, 
             console.warn('[showFilePickerAndWrite] Falling back to anchor download for this platform.');
 
             const uint8 = byteArray instanceof Uint8Array ? byteArray : new Uint8Array(byteArray);
-
-            // Use a more "specific" looking type instead of generic octet-stream.
-            const blob = new Blob([uint8], {type: 'application/x-pokemon-savedata'});
+            const blob = new Blob([uint8], {type: blobType});
 
             const hasExt = ext && fileName.toLowerCase().endsWith(ext.toLowerCase());
             const finalName = (ext && !hasExt) ? fileName + ext : fileName;
@@ -172,12 +175,11 @@ window.showFilePickerAndWrite = async function (fileName, byteArray, extension, 
             return;
         }
 
-        // Only add types if we have a valid simple extension.
-        // Chrome's showSaveFilePicker rejects extensions that contain spaces or other
-        // non-alphanumeric characters (e.g. '.sav 2'), so skip types in that case.
-        // Also strip the invalid extension from suggestedName — Chrome blanks the filename
-        // field entirely if suggestedName contains spaces or other disallowed characters.
-        const isValidExtForPicker = !!ext && /^\.[a-zA-Z0-9]+$/.test(ext);
+        // Chrome's showSaveFilePicker accepts single extensions like ".sav" and compound
+        // extensions like ".3ds.sav". Disallow spaces or non-alphanumeric segments — those
+        // cause Chrome to blank the filename field — but keep compound suffixes intact so
+        // Manic EMU archives don't lose their ".3ds.sav" on export.
+        const isValidExtForPicker = !!ext && /^(?:\.[a-zA-Z0-9]+){1,2}$/.test(ext);
 
         // Build options for File System Access API
         const opts = {
@@ -187,10 +189,13 @@ window.showFilePickerAndWrite = async function (fileName, byteArray, extension, 
         };
 
         if (isValidExtForPicker) {
+            // The `accept` field only takes simple extensions per the File System Access spec,
+            // so pass the leaf extension (".sav" from ".3ds.sav") rather than the compound.
+            const leafExt = ext.lastIndexOf('.') > 0 ? ext.slice(ext.lastIndexOf('.')) : ext;
             opts.types = [{
                 description: description || 'File',
                 accept: {
-                    'application/x-pokemon-savedata': [ext]
+                    [blobType]: [leafExt]
                 }
             }];
         }
@@ -217,7 +222,9 @@ window.showFilePickerAndWrite = async function (fileName, byteArray, extension, 
 
 // Anchor-based blob download. Used as a fallback when the File System Access API isn't
 // available (or the user dismissed it). Avoids the ~33% base64 inflation of a data: URI
-// and works around URL-length limits on older engines.
+// and works around URL-length limits on older engines. The caller should pass an explicit
+// mimeType — application/zip for Manic EMU archives, application/x-pokemon-savedata for
+// raw saves, application/octet-stream for anything else.
 window.downloadBlob = function (fileName, byteArray, mimeType) {
     if (!byteArray) return;
     const uint8 = byteArray instanceof Uint8Array ? byteArray : new Uint8Array(byteArray);

--- a/Pkmds.Tests/AdvancedSearchTests.cs
+++ b/Pkmds.Tests/AdvancedSearchTests.cs
@@ -240,6 +240,7 @@ public class AdvancedSearchTests
         public DateTime? AppBuildDate => null;
         public int? PinnedBoxNumber { get; set; }
         public string? SaveFileName { get; set; }
+        public ManicEmuSaveHelper.ManicEmuSaveContext? ManicEmuSaveContext { get; set; }
         public bool SelectedSlotsAreValid => true;
         public bool IsHaXEnabled { get; set; }
         public SpriteStyle SpriteStyle { get; set; }

--- a/Pkmds.Tests/AppServiceTests.cs
+++ b/Pkmds.Tests/AppServiceTests.cs
@@ -387,6 +387,7 @@ public class AppServiceTests
         public DateTime? AppBuildDate => null;
         public int? PinnedBoxNumber { get; set; }
         public string? SaveFileName { get; set; }
+        public ManicEmuSaveHelper.ManicEmuSaveContext? ManicEmuSaveContext { get; set; }
         public bool SelectedSlotsAreValid => true;
         public bool IsHaXEnabled { get; set; }
         public SpriteStyle SpriteStyle { get; set; }

--- a/Pkmds.Tests/BoxManagementTests.cs
+++ b/Pkmds.Tests/BoxManagementTests.cs
@@ -101,6 +101,7 @@ public class BoxManagementTests
         public DateTime? AppBuildDate => null;
         public int? PinnedBoxNumber { get; set; }
         public string? SaveFileName { get; set; }
+        public ManicEmuSaveHelper.ManicEmuSaveContext? ManicEmuSaveContext { get; set; }
         public bool SelectedSlotsAreValid => true;
         public bool IsHaXEnabled { get; set; }
         public SpriteStyle SpriteStyle { get; set; }

--- a/Pkmds.Tests/BunitTestHelpers.cs
+++ b/Pkmds.Tests/BunitTestHelpers.cs
@@ -71,6 +71,7 @@ internal class TestAppState : IAppState
     public DateTime? AppBuildDate => null;
     public int? PinnedBoxNumber { get; set; }
     public string? SaveFileName { get; set; }
+    public ManicEmuSaveHelper.ManicEmuSaveContext? ManicEmuSaveContext { get; set; }
     public bool SelectedSlotsAreValid => true;
     public bool IsHaXEnabled { get; set; }
     public SpriteStyle SpriteStyle { get; set; }

--- a/Pkmds.Tests/EncounterDatabaseTests.cs
+++ b/Pkmds.Tests/EncounterDatabaseTests.cs
@@ -212,6 +212,7 @@ public class EncounterDatabaseTests
         public DateTime? AppBuildDate => null;
         public int? PinnedBoxNumber { get; set; }
         public string? SaveFileName { get; set; }
+        public ManicEmuSaveHelper.ManicEmuSaveContext? ManicEmuSaveContext { get; set; }
         public bool SelectedSlotsAreValid => true;
         public bool IsHaXEnabled { get; set; }
         public SpriteStyle SpriteStyle { get; set; }

--- a/Pkmds.Tests/EvolveTests.cs
+++ b/Pkmds.Tests/EvolveTests.cs
@@ -392,6 +392,7 @@ public class EvolveTests
         public int? SelectedPartySlotNumber { get; set; }
         public int? PinnedBoxNumber { get; set; }
         public string? SaveFileName { get; set; }
+        public ManicEmuSaveHelper.ManicEmuSaveContext? ManicEmuSaveContext { get; set; }
         public bool ShowProgressIndicator { get; set; }
         public string AppVersion => "Test";
         public DateTime? AppBuildDate => null;

--- a/Pkmds.Tests/GlobalUsings.cs
+++ b/Pkmds.Tests/GlobalUsings.cs
@@ -1,6 +1,7 @@
 ﻿global using FluentAssertions;
 global using PKHeX.Core;
 global using Pkmds.Core.Extensions;
+global using Pkmds.Core.Utilities;
 global using Pkmds.Rcl;
 global using Pkmds.Rcl.Components;
 global using Pkmds.Rcl.Components.EditForms.Tabs;

--- a/Pkmds.Tests/HaXModeTests.cs
+++ b/Pkmds.Tests/HaXModeTests.cs
@@ -165,6 +165,7 @@ public class HaXModeTests
         public DateTime? AppBuildDate => null;
         public int? PinnedBoxNumber { get; set; }
         public string? SaveFileName { get; set; }
+        public ManicEmuSaveHelper.ManicEmuSaveContext? ManicEmuSaveContext { get; set; }
         public bool SelectedSlotsAreValid => true;
         public bool IsHaXEnabled { get; set; }
         public SpriteStyle SpriteStyle { get; set; }

--- a/Pkmds.Tests/LegalityCheckerTests.cs
+++ b/Pkmds.Tests/LegalityCheckerTests.cs
@@ -243,6 +243,7 @@ public class LegalityCheckerTests
         public DateTime? AppBuildDate => null;
         public int? PinnedBoxNumber { get; set; }
         public string? SaveFileName { get; set; }
+        public ManicEmuSaveHelper.ManicEmuSaveContext? ManicEmuSaveContext { get; set; }
         public bool SelectedSlotsAreValid => true;
         public bool IsHaXEnabled { get; set; }
         public SpriteStyle SpriteStyle { get; set; }

--- a/Pkmds.Tests/ManicEmuSaveHelperTests.cs
+++ b/Pkmds.Tests/ManicEmuSaveHelperTests.cs
@@ -208,43 +208,66 @@ public class ManicEmuSaveHelperTests
 
     // ── GetExportFileName ─────────────────────────────────────────────────
 
+    private static readonly DateTime FixedTimestamp = new(2026, 04, 20, 17, 46, 12, DateTimeKind.Utc);
+    private const string TimestampSuffix = "-20260420T174612";
+
     [Fact]
-    public void GetExportFileName_NullOriginalName_ReturnsSavSuffix()
+    public void GetExportFileName_NullOriginalName_ReturnsSavSuffixWithTimestamp()
     {
-        var (name, ext) = ManicEmuSaveHelper.GetExportFileName(null);
+        var (name, ext) = ManicEmuSaveHelper.GetExportFileName(null, FixedTimestamp);
         ext.Should().Be(".3ds.sav");
-        name.Should().Be("save.3ds.sav");
+        name.Should().Be($"save{TimestampSuffix}.3ds.sav");
     }
 
     [Theory]
-    [InlineData("AlphaSapphire.3ds.sav", "AlphaSapphire.3ds.sav", ".3ds.sav")]
-    [InlineData("ALPHASAPPHIRE.3DS.SAV", "ALPHASAPPHIRE.3ds.sav", ".3ds.sav")] // case-insensitive strip
-    [InlineData(".3ds.sav", "save.3ds.sav", ".3ds.sav")] // empty stem fallback
-    public void GetExportFileName_DotSav_PreservesSavExtension(string input, string expectedName, string expectedExt)
+    [InlineData("AlphaSapphire.3ds.sav", "AlphaSapphire", ".3ds.sav")]
+    [InlineData("ALPHASAPPHIRE.3DS.SAV", "ALPHASAPPHIRE", ".3ds.sav")] // case-insensitive strip
+    [InlineData(".3ds.sav", "save", ".3ds.sav")] // empty stem fallback
+    public void GetExportFileName_DotSav_PreservesSavExtension(string input, string expectedStem, string expectedExt)
     {
-        var (name, ext) = ManicEmuSaveHelper.GetExportFileName(input);
-        name.Should().Be(expectedName);
+        var (name, ext) = ManicEmuSaveHelper.GetExportFileName(input, FixedTimestamp);
+        name.Should().Be($"{expectedStem}{TimestampSuffix}{expectedExt}");
         ext.Should().Be(expectedExt);
     }
 
     [Theory]
-    [InlineData("AlphaSapphire.3ds.save", "AlphaSapphire.3ds.save", ".3ds.save")]
-    [InlineData("ALPHASAPPHIRE.3DS.SAVE", "ALPHASAPPHIRE.3ds.save", ".3ds.save")] // case-insensitive strip
-    [InlineData(".3ds.save", "save.3ds.save", ".3ds.save")] // empty stem fallback
-    public void GetExportFileName_DotSave_PreservesSaveExtension(string input, string expectedName, string expectedExt)
+    [InlineData("AlphaSapphire.3ds.save", "AlphaSapphire", ".3ds.save")]
+    [InlineData("ALPHASAPPHIRE.3DS.SAVE", "ALPHASAPPHIRE", ".3ds.save")] // case-insensitive strip
+    [InlineData(".3ds.save", "save", ".3ds.save")] // empty stem fallback
+    public void GetExportFileName_DotSave_PreservesSaveExtension(string input, string expectedStem, string expectedExt)
     {
-        var (name, ext) = ManicEmuSaveHelper.GetExportFileName(input);
-        name.Should().Be(expectedName);
+        var (name, ext) = ManicEmuSaveHelper.GetExportFileName(input, FixedTimestamp);
+        name.Should().Be($"{expectedStem}{TimestampSuffix}{expectedExt}");
         ext.Should().Be(expectedExt);
     }
 
     [Fact]
-    public void GetExportFileName_UnknownExtension_DefaultsToSav()
+    public void GetExportFileName_UnknownExtension_DefaultsToSavWithTimestamp()
     {
         // An unknown extension should strip the last extension and default to .3ds.sav.
-        var (name, ext) = ManicEmuSaveHelper.GetExportFileName("game.unknown");
+        var (name, ext) = ManicEmuSaveHelper.GetExportFileName("game.unknown", FixedTimestamp);
         ext.Should().Be(".3ds.sav");
-        name.Should().Be("game.3ds.sav");
+        name.Should().Be($"game{TimestampSuffix}.3ds.sav");
+    }
+
+    [Theory]
+    [InlineData("AlphaSapphire-20260420T174612.3ds.sav", "AlphaSapphire")]
+    [InlineData("AlphaSapphire-20260101T000000-20260420T174612.3ds.sav", "AlphaSapphire-20260101T000000")]
+    public void GetExportFileName_PreviousTimestampSuffix_IsReplacedNotAccumulated(string input, string expectedStem)
+    {
+        // Round-tripping an already-timestamped filename through the export must not accumulate
+        // timestamps (would produce ever-longer filenames across successive round-trips).
+        var (name, _) = ManicEmuSaveHelper.GetExportFileName(input, FixedTimestamp);
+        name.Should().Be($"{expectedStem}{TimestampSuffix}.3ds.sav");
+    }
+
+    [Fact]
+    public void GetExportFileName_SuffixThatLooksLikeTimestampButIsnt_IsPreserved()
+    {
+        // A hyphen + 15 characters that happen to look like a timestamp but aren't (e.g. any
+        // non-digit, or a wrong separator) should not be mistakenly stripped.
+        var (name, _) = ManicEmuSaveHelper.GetExportFileName("AlphaSapphire-1234567X123456.3ds.sav", FixedTimestamp);
+        name.Should().Be($"AlphaSapphire-1234567X123456{TimestampSuffix}.3ds.sav");
     }
 
     [Fact]

--- a/Pkmds.Tests/SaveFileLoaderTests.cs
+++ b/Pkmds.Tests/SaveFileLoaderTests.cs
@@ -1,0 +1,116 @@
+using System.IO.Compression;
+
+namespace Pkmds.Tests;
+
+/// <summary>
+/// Regression tests for <see cref="SaveFileLoader" /> covering the ordering bug that shipped
+/// in production: PKHeX.Core's <c>ZipReader</c> runs inside <c>SaveUtil.TryGetSaveFile</c> and
+/// would silently unwrap Manic EMU archives if we didn't check for them first (see issue #750).
+/// </summary>
+public class SaveFileLoaderTests
+{
+    private const string TestFilesPath = "../../../TestFiles";
+
+    private const string ManicEmuSavePath = "sdmc/Nintendo 3DS/00000000000000000000000000000000/00000000000000000000000000000000/title/00040000/00175e00/data/00000001/main";
+
+    private static byte[] BuildManicEmuZip(byte[] saveBytes)
+    {
+        using var ms = new MemoryStream();
+        using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var entry = archive.CreateEntry(ManicEmuSavePath, CompressionLevel.Optimal);
+            using var s = entry.Open();
+            s.Write(saveBytes, 0, saveBytes.Length);
+        }
+
+        return ms.ToArray();
+    }
+
+    [Fact]
+    public void TryLoad_ManicEmuZip_ReturnsContextAndSaveFile()
+    {
+        // This is the scenario that was broken pre-fix: before SaveFileLoader existed, the code
+        // called SaveUtil.TryGetSaveFile directly, which accepts ZIPs via PKHeX's ZipReader and
+        // returned a valid SaveFile but with no Manic EMU context — causing the UI to export raw
+        // bytes that Manic EMU rejects on re-import.
+        var rawSave = File.ReadAllBytes(Path.Combine(TestFilesPath, "moon.sav"));
+        var zipBytes = BuildManicEmuZip(rawSave);
+
+        var ok = SaveFileLoader.TryLoad(zipBytes, "moon.3ds.sav", out var saveFile, out var manicContext);
+
+        ok.Should().BeTrue();
+        saveFile.Should().NotBeNull();
+        saveFile.Should().BeOfType<SAV7SM>();
+        manicContext.Should().NotBeNull();
+        manicContext!.SaveEntryPath.Should().Be(ManicEmuSavePath);
+    }
+
+    [Fact]
+    public void TryLoad_RawSave_ReturnsNullContext()
+    {
+        var rawSave = File.ReadAllBytes(Path.Combine(TestFilesPath, "moon.sav"));
+
+        var ok = SaveFileLoader.TryLoad(rawSave, "moon.sav", out var saveFile, out var manicContext);
+
+        ok.Should().BeTrue();
+        saveFile.Should().NotBeNull();
+        manicContext.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryLoad_ZipWithoutSdmcEntries_FallsThroughToPkhexZipReader()
+    {
+        // A plain ZIP whose inner file is named `main` — recognised by PKHeX's ZipReader but
+        // not by our Manic EMU helper (no sdmc/ prefix). TryLoad should still return true, with
+        // a null manic context, so non-Manic ZIPs (e.g. PKHeX-produced ones) still work.
+        var rawSave = File.ReadAllBytes(Path.Combine(TestFilesPath, "moon.sav"));
+
+        using var ms = new MemoryStream();
+        using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var entry = archive.CreateEntry("main", CompressionLevel.Optimal);
+            using var s = entry.Open();
+            s.Write(rawSave, 0, rawSave.Length);
+        }
+
+        var ok = SaveFileLoader.TryLoad(ms.ToArray(), "moon.zip", out var saveFile, out var manicContext);
+
+        ok.Should().BeTrue();
+        saveFile.Should().NotBeNull();
+        manicContext.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryLoad_NonZipNonSaveGarbage_ReturnsFalse()
+    {
+        var garbage = new byte[] { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05 };
+
+        var ok = SaveFileLoader.TryLoad(garbage, "garbage.bin", out var saveFile, out var manicContext);
+
+        ok.Should().BeFalse();
+        saveFile.Should().BeNull();
+        manicContext.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryLoad_ManicEmuZip_RoundTripsThroughRebuild()
+    {
+        // End-to-end: ZIP → load → write edited bytes → rebuild ZIP via returned context →
+        // load again → inner save still parses and has the expected size. This is the flow
+        // the MainLayout upload → export path now follows.
+        var rawSave = File.ReadAllBytes(Path.Combine(TestFilesPath, "moon.sav"));
+        var zipBytes = BuildManicEmuZip(rawSave);
+
+        SaveFileLoader.TryLoad(zipBytes, "moon.3ds.sav", out var saveFile, out var ctx).Should().BeTrue();
+
+        var exportedBytes = saveFile!.Write().ToArray();
+        var rebuilt = ManicEmuSaveHelper.RebuildZip(ctx!, exportedBytes);
+
+        SaveFileLoader.TryLoad(rebuilt, "moon.3ds.sav", out var reloaded, out var reloadedCtx).Should().BeTrue();
+        reloaded.Should().NotBeNull();
+        reloaded.Should().BeOfType<SAV7SM>();
+        reloaded!.Write().Length.Should().Be(rawSave.Length);
+        reloadedCtx.Should().NotBeNull();
+        reloadedCtx!.SaveEntryPath.Should().Be(ManicEmuSavePath);
+    }
+}

--- a/Pkmds.Tests/SaveFileLoaderTests.cs
+++ b/Pkmds.Tests/SaveFileLoaderTests.cs
@@ -13,12 +13,19 @@ public class SaveFileLoaderTests
 
     private const string ManicEmuSavePath = "sdmc/Nintendo 3DS/00000000000000000000000000000000/00000000000000000000000000000000/title/00040000/00175e00/data/00000001/main";
 
+    /// <summary>
+    /// Builds a ZIP matching what Manic EMU's <c>ShareManager.create3DSGameSave</c> produces
+    /// on device: a single store-method (uncompressed) entry at the Citra sdmc/ save path.
+    /// Matching the real compression method is load-bearing — a deflate rebuild of a Pokémon
+    /// save compresses to &lt;2% of the original size (heavy 0xFF / 0x00 padding), and Manic EMU /
+    /// iOS ZIPFoundation rejects the structurally-valid deflate archive on re-import.
+    /// </summary>
     private static byte[] BuildManicEmuZip(byte[] saveBytes)
     {
         using var ms = new MemoryStream();
         using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
         {
-            var entry = archive.CreateEntry(ManicEmuSavePath, CompressionLevel.Optimal);
+            var entry = archive.CreateEntry(ManicEmuSavePath, CompressionLevel.NoCompression);
             using var s = entry.Open();
             s.Write(saveBytes, 0, saveBytes.Length);
         }
@@ -112,5 +119,35 @@ public class SaveFileLoaderTests
         reloaded!.Write().Length.Should().Be(rawSave.Length);
         reloadedCtx.Should().NotBeNull();
         reloadedCtx!.SaveEntryPath.Should().Be(ManicEmuSavePath);
+    }
+
+    [Fact]
+    public void RebuildZip_PreservesStoreCompressionMatchingManicEmuOutput()
+    {
+        // Regression guard for the deflate-shrinkage bug observed on PR #751: a 483 kB ORAS
+        // save compressed to a 9 kB deflate entry and Manic EMU rejected the re-import.
+        // The rebuild must use store (method 0) to match what Manic EMU itself produces, so the
+        // rebuilt archive stays in the same size ballpark as the original upload.
+        var rawSave = File.ReadAllBytes(Path.Combine(TestFilesPath, "moon.sav"));
+        var original = BuildManicEmuZip(rawSave);
+
+        SaveFileLoader.TryLoad(original, "moon.3ds.sav", out var saveFile, out var ctx).Should().BeTrue();
+        var rebuilt = ManicEmuSaveHelper.RebuildZip(ctx!, saveFile!.Write().ToArray());
+
+        // Store-method rebuild must be close to the input size (allow modest drift from
+        // timestamp/header differences). A deflate-compressed rebuild would be a fraction
+        // of the input size due to the save's heavy padding.
+        rebuilt.Length.Should().BeGreaterThan((int)(original.Length * 0.95));
+        rebuilt.Length.Should().BeLessThan((int)(original.Length * 1.05));
+
+        // And confirm every entry in the rebuilt archive is store-method (compression method 0).
+        using var ms = new MemoryStream(rebuilt);
+        using var archive = new ZipArchive(ms, ZipArchiveMode.Read);
+        foreach (var entry in archive.Entries)
+        {
+            // CompressedLength == Length is the observable signal that no compression was applied.
+            entry.CompressedLength.Should().Be(entry.Length,
+                $"entry '{entry.FullName}' should be store-method (uncompressed) to match Manic EMU's own output");
+        }
     }
 }

--- a/Pkmds.Tests/SaveFileLoaderTests.cs
+++ b/Pkmds.Tests/SaveFileLoaderTests.cs
@@ -122,6 +122,67 @@ public class SaveFileLoaderTests
     }
 
     [Fact]
+    public void RebuildZip_SetsUtf8PathEncodingFlagOnAllEntries()
+    {
+        // Regression guard for PR #751 follow-up: .NET's ZipArchive only sets general-purpose
+        // bit 11 (UTF-8 path encoding) when a filename contains non-ASCII characters, but
+        // ZIPFoundation on iOS sets it unconditionally when writing and has been observed
+        // rejecting archives that omit it — even for pure-ASCII paths like Manic EMU's sdmc/
+        // tree. Our rebuild has to match ZIPFoundation's behaviour.
+        var rawSave = File.ReadAllBytes(Path.Combine(TestFilesPath, "moon.sav"));
+        var original = BuildManicEmuZip(rawSave);
+
+        SaveFileLoader.TryLoad(original, "moon.3ds.sav", out var saveFile, out var ctx).Should().BeTrue();
+        var rebuilt = ManicEmuSaveHelper.RebuildZip(ctx!, saveFile!.Write().ToArray());
+
+        // Walk the central directory and confirm bit 11 is set on every CDFH.
+        var eocdOffset = FindEndOfCentralDirectory(rebuilt);
+        eocdOffset.Should().BeGreaterThanOrEqualTo(0);
+        var cdOffset = BitConverter.ToInt32(rebuilt, eocdOffset + 16);
+        var entryCount = BitConverter.ToUInt16(rebuilt, eocdOffset + 10);
+
+        var pos = cdOffset;
+        for (var i = 0; i < entryCount; i++)
+        {
+            var flags = BitConverter.ToUInt16(rebuilt, pos + 8);
+            (flags & 0x0800).Should().NotBe(0, $"CDFH entry {i} must have UTF-8 path-encoding flag (bit 11) set");
+            var nameLen = BitConverter.ToUInt16(rebuilt, pos + 28);
+            var extraLen = BitConverter.ToUInt16(rebuilt, pos + 30);
+            var commentLen = BitConverter.ToUInt16(rebuilt, pos + 32);
+            pos += 46 + nameLen + extraLen + commentLen;
+        }
+
+        // Also walk local file headers — bit 11 has to match between LFH and CDFH per spec.
+        pos = 0;
+        for (var i = 0; i < entryCount && pos < cdOffset; i++)
+        {
+            BitConverter.ToInt32(rebuilt, pos).Should().Be(0x04034B50, $"LFH {i} signature");
+            var flags = BitConverter.ToUInt16(rebuilt, pos + 6);
+            (flags & 0x0800).Should().NotBe(0, $"LFH entry {i} must have UTF-8 path-encoding flag (bit 11) set");
+            var nameLen = BitConverter.ToUInt16(rebuilt, pos + 26);
+            var extraLen = BitConverter.ToUInt16(rebuilt, pos + 28);
+            var compSize = BitConverter.ToUInt32(rebuilt, pos + 18);
+            pos += 30 + nameLen + extraLen + (int)compSize;
+        }
+    }
+
+    private static int FindEndOfCentralDirectory(byte[] zipBytes)
+    {
+        const int eocdSignature = 0x06054B50;
+        const int eocdMinSize = 22;
+        const int eocdMaxCommentLen = 65535;
+        var searchStart = Math.Max(0, zipBytes.Length - eocdMinSize - eocdMaxCommentLen);
+        for (var i = zipBytes.Length - eocdMinSize; i >= searchStart; i--)
+        {
+            if (BitConverter.ToInt32(zipBytes, i) == eocdSignature)
+            {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    [Fact]
     public void RebuildZip_PreservesStoreCompressionMatchingManicEmuOutput()
     {
         // Regression guard for the deflate-shrinkage bug observed on PR #751: a 483 kB ORAS

--- a/Pkmds.Web/AppState.cs
+++ b/Pkmds.Web/AppState.cs
@@ -40,6 +40,7 @@ public record AppState : IAppState
             if (SaveFile is null)
             {
                 SaveFileName = null;
+                ManicEmuSaveContext = null;
             }
 
             PinnedBoxNumber = null;
@@ -48,6 +49,9 @@ public record AppState : IAppState
 
     /// <inheritdoc />
     public string? SaveFileName { get; set; }
+
+    /// <inheritdoc />
+    public ManicEmuSaveHelper.ManicEmuSaveContext? ManicEmuSaveContext { get; set; }
 
     /// <inheritdoc />
     public SaveFile? SaveFileB

--- a/Pkmds.Web/GlobalUsings.cs
+++ b/Pkmds.Web/GlobalUsings.cs
@@ -6,6 +6,7 @@ global using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 global using Microsoft.JSInterop;
 global using MudBlazor.Services;
 global using PKHeX.Core;
+global using Pkmds.Core.Utilities;
 global using Pkmds.Rcl;
 global using Pkmds.Rcl.Extensions;
 global using Pkmds.Rcl.Services;


### PR DESCRIPTION
## Summary

Fixes the Manic EMU save round-trip: every upload of a real `.3ds.sav` ZIP was silently downgraded to a raw save on export, so Manic EMU rejected the re-import as "corrupted" (issues #669, #746). Root cause: PKHeX.Core 26.4.11 ships a `ZipReader` in `SaveUtil.CustomSaveReaders` that unwraps the archive before our Manic EMU detection branch ever runs, leaving `manicEmuSaveContext` null and every export bare (see #750 for the empirical probe).

## What changed

- **New `Pkmds.Core.Utilities.SaveFileLoader`** runs Manic EMU ZIP detection (`sdmc/` entries) before delegating to `SaveUtil.TryGetSaveFile`. Both the upload path and the backup-restore path in `MainLayout.razor.cs` now go through it, so the context survives.
- **`ManicEmuSaveContext` lifted onto `IAppState`** so `BugReportDialog` and the `App.razor.cs` crash path can read it, and so `AppState.SaveFile = null` can clear it atomically. Removes the `manicEmuSaveContext` private field from `MainLayout`.
- **`BugReportDialog`** now rebuilds the ZIP via `ManicEmuSaveHelper.RebuildZip` when the context is set. Previously every Manic EMU bug report contained only the bare inner save, so ZIP round-trip issues were undiagnosable from the payload.
- **`fileSave.js`** accepts a `mimeType` argument and the compound-extension regex now matches `.3ds.sav` (previously stripped to `MyGame` on desktop, forcing users to re-type the suffix). The `accept` map still passes only the leaf extension per the File System Access spec.
- **`WriteFile` / `WriteFileOldWay`** take an optional `mimeType` parameter, defaulting to `application/x-pokemon-savedata`. Manic EMU exports pass `application/zip` — the wrong MIME on a ZIP is a known trigger for iOS Safari renaming the download.
- **`ManicEmuSaveHelper` XML docs** stop claiming iOS Manic EMU exports `.3ds.save`. Upstream source uses `.3ds.sav` on every platform (`ThreeDS.swift`, `ShareManager.swift`, `FilesImporter.swift`). We still accept `.3ds.save` defensively for manual renames or Safari mangling.

## Tests

New `SaveFileLoaderTests` exercising the regression path and the full round-trip:

- `TryLoad_ManicEmuZip_ReturnsContextAndSaveFile` — the primary regression: ensures the context survives PKHeX ZipReader.
- `TryLoad_RawSave_ReturnsNullContext` — raw saves don't mistakenly pick up a context.
- `TryLoad_ZipWithoutSdmcEntries_FallsThroughToPkhexZipReader` — non-Manic ZIPs (e.g. PKHeX's own) still work with a null context.
- `TryLoad_NonZipNonSaveGarbage_ReturnsFalse` — negative-path coverage.
- `TryLoad_ManicEmuZip_RoundTripsThroughRebuild` — full end-to-end: ZIP → load → write → rebuild → reload → confirm save loads and inner size matches.

All `TestAppState` implementations in the test project pick up the new `ManicEmuSaveContext` property.

## Test plan

- [ ] Upload a raw `.sav` (e.g. Omega Ruby): loads normally, no Manic EMU snackbar.
- [ ] Upload a `.3ds.sav` Manic EMU archive: loads normally, **Info snackbar** appears confirming Manic EMU detection.
- [ ] Export after edit from a Manic EMU upload: the saved filename is `Original.3ds.sav`, the download is a ZIP, and re-importing into Manic EMU on device succeeds.
- [ ] Export on desktop via File System Access API: the suggested save name keeps the `.3ds.sav` compound extension.
- [ ] Submit a bug report while a Manic EMU save is loaded: the attached file is a ZIP (not the bare inner save).
- [ ] Auto-backup of a Manic EMU save → restore: the restored save is still recognised as Manic EMU and re-export produces a ZIP.

Closes #669, #746, #750.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
