### PR TITLE
feat: expand advanced search with more criteria (#737)

### DIFF
--- a/Pkmds.Rcl/Components/MainTabPages/AdvancedSearchTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/AdvancedSearchTab.razor
@@ -745,25 +745,31 @@
                             <MudExpansionPanel Text="Ribbons / Marks">
                                 <MudStack Spacing="2">
 
-                                    <MudText Typo="@Typo.subtitle2">Markings</MudText>
-                                    <MudStack Row
-                                              Wrap="@Wrap.Wrap"
-                                              Spacing="1">
-                                        @foreach (var (markingIndex, symbol, label) in MarkingShapes)
-                                        {
-                                            var idx = markingIndex;
-                                            var isSelected = selectedMarkings.Contains(idx);
-                                            <MudChip T="@int"
-                                                     Value="@idx"
-                                                     Variant="@(isSelected ? Variant.Filled : Variant.Outlined)"
-                                                     Color="@(isSelected ? Color.Primary : Color.Default)"
-                                                     Size="@Size.Large"
-                                                     OnClick="@(() => ToggleMarking(idx))"
-                                                     title="@label">
-                                                @symbol
-                                            </MudChip>
-                                        }
-                                    </MudStack>
+                                    @{
+                                        var markingShapes = GetAvailableMarkingShapes().ToList();
+                                    }
+                                    @if (markingShapes.Count > 0)
+                                    {
+                                        <MudText Typo="@Typo.subtitle2">Markings</MudText>
+                                        <MudStack Row
+                                                  Wrap="@Wrap.Wrap"
+                                                  Spacing="1">
+                                            @foreach (var (markingIndex, symbol, label) in markingShapes)
+                                            {
+                                                var idx = markingIndex;
+                                                var isSelected = selectedMarkings.Contains(idx);
+                                                <MudChip T="@int"
+                                                         Value="@idx"
+                                                         Variant="@(isSelected ? Variant.Filled : Variant.Outlined)"
+                                                         Color="@(isSelected ? Color.Primary : Color.Default)"
+                                                         Size="@Size.Large"
+                                                         OnClick="@(() => ToggleMarking(idx))"
+                                                         title="@label">
+                                                    @symbol
+                                                </MudChip>
+                                            }
+                                        </MudStack>
+                                    }
 
                                     <MudText Typo="@Typo.subtitle2">Ribbons</MudText>
                                     <MudAutocomplete T="@string"

--- a/Pkmds.Rcl/Components/MainTabPages/AdvancedSearchTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/AdvancedSearchTab.razor
@@ -149,6 +149,45 @@
                                         </MudItem>
                                     </MudGrid>
 
+                                    <MudGrid Spacing="2">
+                                        <MudItem xs="6">
+                                            <MudSelect T="@(int?)"
+                                                       Label="Type 1"
+                                                       @bind-Value="@type1"
+                                                       Clearable>
+                                                <MudSelectItem T="@(int?)"
+                                                               Value="@((int?)null)">Any
+                                                </MudSelectItem>
+                                                @for (var i = 0; i < 18; i++)
+                                                {
+                                                    var typeIndex = i;
+                                                    <MudSelectItem T="@(int?)"
+                                                                   Value="@typeIndex">
+                                                        @GameInfo.Strings.Types[typeIndex]
+                                                    </MudSelectItem>
+                                                }
+                                            </MudSelect>
+                                        </MudItem>
+                                        <MudItem xs="6">
+                                            <MudSelect T="@(int?)"
+                                                       Label="Type 2"
+                                                       @bind-Value="@type2"
+                                                       Clearable>
+                                                <MudSelectItem T="@(int?)"
+                                                               Value="@((int?)null)">Any
+                                                </MudSelectItem>
+                                                @for (var i = 0; i < 18; i++)
+                                                {
+                                                    var typeIndex = i;
+                                                    <MudSelectItem T="@(int?)"
+                                                                   Value="@typeIndex">
+                                                        @GameInfo.Strings.Types[typeIndex]
+                                                    </MudSelectItem>
+                                                }
+                                            </MudSelect>
+                                        </MudItem>
+                                    </MudGrid>
+
                                     <MudSelect T="@(bool?)"
                                                Label="Legal status"
                                                @bind-Value="@isLegal"
@@ -163,6 +202,152 @@
                                                        Value="@false">Illegal only
                                         </MudSelectItem>
                                     </MudSelect>
+
+                                </MudStack>
+                            </MudExpansionPanel>
+
+                            @* ── Appearance ── *@
+                            <MudExpansionPanel Text="Appearance">
+                                <MudStack Spacing="2">
+
+                                    @{
+                                        var formList = GetFormList();
+                                    }
+                                    @if (formList.Count > 0)
+                                    {
+                                        <MudSelect T="@(byte?)"
+                                                   Label="Form"
+                                                   @bind-Value="@form"
+                                                   Clearable>
+                                            <MudSelectItem T="@(byte?)"
+                                                           Value="@((byte?)null)">Any
+                                            </MudSelectItem>
+                                            @for (byte i = 0; i < formList.Count; i++)
+                                            {
+                                                var formIndex = i;
+                                                var formName = formList[formIndex];
+                                                if (string.IsNullOrEmpty(formName))
+                                                {
+                                                    continue;
+                                                }
+                                                <MudSelectItem T="@(byte?)"
+                                                               Value="@((byte?)formIndex)">
+                                                    @formName
+                                                </MudSelectItem>
+                                            }
+                                        </MudSelect>
+                                    }
+                                    else if (speciesItem is not { Value: > 0 })
+                                    {
+                                        <MudText Typo="@Typo.caption">
+                                            Pick a species to enable form filtering.
+                                        </MudText>
+                                    }
+
+                                    @if (SaveSupportsTeraType())
+                                    {
+                                        <MudSelect T="@(int?)"
+                                                   Label="Tera Type"
+                                                   @bind-Value="@teraType"
+                                                   Clearable>
+                                            <MudSelectItem T="@(int?)"
+                                                           Value="@((int?)null)">Any
+                                            </MudSelectItem>
+                                            @for (var i = 0; i < 18; i++)
+                                            {
+                                                var typeIndex = i;
+                                                <MudSelectItem T="@(int?)"
+                                                               Value="@typeIndex">
+                                                    @GameInfo.Strings.Types[typeIndex]
+                                                </MudSelectItem>
+                                            }
+                                            <MudSelectItem T="@(int?)"
+                                                           Value="@((int?)TeraTypeUtil.Stellar)">
+                                                @GameInfo.Strings.Types[TeraTypeUtil.StellarTypeDisplayStringIndex]
+                                            </MudSelectItem>
+                                        </MudSelect>
+                                    }
+
+                                    @if (SaveSupportsFavorite())
+                                    {
+                                        <MudSelect T="@(bool?)"
+                                                   Label="Favorite"
+                                                   @bind-Value="@isFavorite"
+                                                   Clearable>
+                                            <MudSelectItem T="@(bool?)"
+                                                           Value="@((bool?)null)">Any
+                                            </MudSelectItem>
+                                            <MudSelectItem T="@(bool?)"
+                                                           Value="@true">Favorites only
+                                            </MudSelectItem>
+                                            <MudSelectItem T="@(bool?)"
+                                                           Value="@false">Non-favorites only
+                                            </MudSelectItem>
+                                        </MudSelect>
+                                    }
+
+                                    @if (SaveSupportsAlpha())
+                                    {
+                                        <MudSelect T="@(bool?)"
+                                                   Label="Alpha"
+                                                   @bind-Value="@isAlpha"
+                                                   Clearable>
+                                            <MudSelectItem T="@(bool?)"
+                                                           Value="@((bool?)null)">Any
+                                            </MudSelectItem>
+                                            <MudSelectItem T="@(bool?)"
+                                                           Value="@true">Alphas only
+                                            </MudSelectItem>
+                                            <MudSelectItem T="@(bool?)"
+                                                           Value="@false">Non-alphas only
+                                            </MudSelectItem>
+                                        </MudSelect>
+                                    }
+
+                                    @if (SaveSupportsShadow())
+                                    {
+                                        <MudSelect T="@(bool?)"
+                                                   Label="Shadow"
+                                                   @bind-Value="@isShadow"
+                                                   Clearable>
+                                            <MudSelectItem T="@(bool?)"
+                                                           Value="@((bool?)null)">Any
+                                            </MudSelectItem>
+                                            <MudSelectItem T="@(bool?)"
+                                                           Value="@true">Shadow only
+                                            </MudSelectItem>
+                                            <MudSelectItem T="@(bool?)"
+                                                           Value="@false">Non-shadow only
+                                            </MudSelectItem>
+                                        </MudSelect>
+                                    }
+
+                                    @if (SaveSupportsGigantamax())
+                                    {
+                                        <MudSelect T="@(bool?)"
+                                                   Label="Gigantamax factor"
+                                                   @bind-Value="@canGigantamax"
+                                                   Clearable>
+                                            <MudSelectItem T="@(bool?)"
+                                                           Value="@((bool?)null)">Any
+                                            </MudSelectItem>
+                                            <MudSelectItem T="@(bool?)"
+                                                           Value="@true">Gigantamax-capable only
+                                            </MudSelectItem>
+                                            <MudSelectItem T="@(bool?)"
+                                                           Value="@false">Non-Gigantamax only
+                                            </MudSelectItem>
+                                        </MudSelect>
+                                    }
+
+                                    @if (SaveSupportsDynamaxLevel())
+                                    {
+                                        <MudNumericField T="@(byte?)"
+                                                         Label="Min Dynamax level"
+                                                         @bind-Value="@dynamaxLevelMin"
+                                                         Min="0"
+                                                         Max="10"/>
+                                    }
 
                                 </MudStack>
                             </MudExpansionPanel>
@@ -505,6 +690,105 @@
                                             </MudSelectItem>
                                         }
                                     </MudSelect>
+
+                                </MudStack>
+                            </MudExpansionPanel>
+
+                            @* ── Origin ── *@
+                            <MudExpansionPanel Text="Origin">
+                                <MudStack Spacing="2">
+
+                                    <MudAutocomplete T="@ComboItem"
+                                                     Label="Met location"
+                                                     Value="@metLocationItem"
+                                                     ValueChanged="@(v => metLocationItem = v)"
+                                                     SearchFunc="@SearchMetLocationsAsync"
+                                                     ToStringFunc="@(l => l?.Text ?? string.Empty)"
+                                                     Clearable
+                                                     ResetValueOnEmptyText/>
+
+                                    <MudGrid Spacing="2">
+                                        <MudItem xs="6">
+                                            <MudDatePicker Label="Met date (from)"
+                                                           @bind-Date="@metDateMin"
+                                                           Clearable/>
+                                        </MudItem>
+                                        <MudItem xs="6">
+                                            <MudDatePicker Label="Met date (to)"
+                                                           @bind-Date="@metDateMax"
+                                                           Clearable/>
+                                        </MudItem>
+                                    </MudGrid>
+
+                                    <MudSelect T="@(int?)"
+                                               Label="Pokerus"
+                                               @bind-Value="@pokerusState"
+                                               Clearable>
+                                        <MudSelectItem T="@(int?)"
+                                                       Value="@((int?)null)">Any
+                                        </MudSelectItem>
+                                        <MudSelectItem T="@(int?)"
+                                                       Value="@((int?)0)">Never infected
+                                        </MudSelectItem>
+                                        <MudSelectItem T="@(int?)"
+                                                       Value="@((int?)1)">Currently infected
+                                        </MudSelectItem>
+                                        <MudSelectItem T="@(int?)"
+                                                       Value="@((int?)2)">Cured
+                                        </MudSelectItem>
+                                    </MudSelect>
+
+                                </MudStack>
+                            </MudExpansionPanel>
+
+                            @* ── Ribbons / Marks ── *@
+                            <MudExpansionPanel Text="Ribbons / Marks">
+                                <MudStack Spacing="2">
+
+                                    <MudText Typo="@Typo.subtitle2">Markings</MudText>
+                                    <MudStack Row
+                                              Wrap="@Wrap.Wrap"
+                                              Spacing="1">
+                                        @foreach (var (markingIndex, symbol, label) in MarkingShapes)
+                                        {
+                                            var idx = markingIndex;
+                                            var isSelected = selectedMarkings.Contains(idx);
+                                            <MudChip T="@int"
+                                                     Value="@idx"
+                                                     Variant="@(isSelected ? Variant.Filled : Variant.Outlined)"
+                                                     Color="@(isSelected ? Color.Primary : Color.Default)"
+                                                     Size="@Size.Large"
+                                                     OnClick="@(() => ToggleMarking(idx))"
+                                                     title="@label">
+                                                @symbol
+                                            </MudChip>
+                                        }
+                                    </MudStack>
+
+                                    <MudText Typo="@Typo.subtitle2">Ribbons</MudText>
+                                    <MudAutocomplete T="@string"
+                                                     Label="Add ribbon…"
+                                                     Value="@pendingRibbonName"
+                                                     ValueChanged="@AddRibbon"
+                                                     SearchFunc="@SearchRibbonNamesAsync"
+                                                     ToStringFunc="@(n => string.IsNullOrEmpty(n) ? string.Empty : RibbonHelper.GetRibbonDisplayName(n))"
+                                                     ResetValueOnEmptyText
+                                                     Clearable/>
+
+                                    <MudStack Row
+                                              Wrap="@Wrap.Wrap"
+                                              Spacing="1">
+                                        @foreach (var ribbon in selectedRibbons)
+                                        {
+                                            var ribbonName = ribbon;
+                                            <MudChip T="@string"
+                                                     Color="@Color.Warning"
+                                                     Size="@Size.Small"
+                                                     OnClose="@(() => RemoveRibbon(ribbonName))">
+                                                @RibbonHelper.GetRibbonDisplayName(ribbonName)
+                                            </MudChip>
+                                        }
+                                    </MudStack>
 
                                 </MudStack>
                             </MudExpansionPanel>

--- a/Pkmds.Rcl/Components/MainTabPages/AdvancedSearchTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/AdvancedSearchTab.razor.cs
@@ -68,6 +68,30 @@ public partial class AdvancedSearchTab : RefreshAwareComponent
     private ComboItem? speciesItem;
     private uint? trainerId;
 
+    // Appearance
+    private int? type1;
+    private int? type2;
+    private byte? form;
+    private int? teraType;
+    private bool? isFavorite;
+    private bool? isAlpha;
+    private bool? isShadow;
+    private bool? canGigantamax;
+    private byte? dynamaxLevelMin;
+
+    // Origin
+    private ComboItem? metLocationItem;
+    private DateTime? metDateMin;
+    private DateTime? metDateMax;
+    private int? pokerusState;
+
+    // Ribbons
+    private readonly List<string> selectedRibbons = [];
+    private string? pendingRibbonName;
+
+    // Markings — HashSet of indices (0=Circle..5=Diamond)
+    private readonly HashSet<int> selectedMarkings = [];
+
     /// <summary>Callback invoked after a result row is clicked to jump to the Party / Box tab.</summary>
     [Parameter]
     public EventCallback OnJumpToPartyBox { get; set; }
@@ -194,6 +218,22 @@ public partial class AdvancedSearchTab : RefreshAwareComponent
         hiddenPowerType = null;
         anyMoveItems = [];
         allMoveItems = [];
+        type1 = null;
+        type2 = null;
+        form = null;
+        teraType = null;
+        isFavorite = null;
+        isAlpha = null;
+        isShadow = null;
+        canGigantamax = null;
+        dynamaxLevelMin = null;
+        metLocationItem = null;
+        metDateMin = null;
+        metDateMax = null;
+        pokerusState = null;
+        selectedRibbons.Clear();
+        pendingRibbonName = null;
+        selectedMarkings.Clear();
         results = [];
         selectedRows = [];
     }
@@ -242,7 +282,28 @@ public partial class AdvancedSearchTab : RefreshAwareComponent
             SpeEvMin = speEvMin,
             AnyMoves = anyMoveItems.Select(m => (ushort)m.Value).ToList(),
             AllMoves = allMoveItems.Select(m => (ushort)m.Value).ToList(),
-            HiddenPowerType = hiddenPowerType
+            HiddenPowerType = hiddenPowerType,
+            Form = form,
+            Type1 = type1,
+            Type2 = type2,
+            TeraType = teraType,
+            IsFavorite = isFavorite,
+            IsAlpha = isAlpha,
+            IsShadow = isShadow,
+            CanGigantamax = canGigantamax,
+            DynamaxLevelMin = dynamaxLevelMin,
+            MetLocation = metLocationItem is { Value: > 0 }
+                ? metLocationItem.Value
+                : null,
+            MetDateMin = metDateMin.HasValue
+                ? DateOnly.FromDateTime(metDateMin.Value)
+                : null,
+            MetDateMax = metDateMax.HasValue
+                ? DateOnly.FromDateTime(metDateMax.Value)
+                : null,
+            PokerusState = pokerusState,
+            RequiredRibbons = selectedRibbons.ToList(),
+            RequiredMarkings = selectedMarkings.ToList()
         };
 
     // ── Row navigation ────────────────────────────────────────────────────
@@ -361,6 +422,109 @@ public partial class AdvancedSearchTab : RefreshAwareComponent
         else
         {
             filterAbilityInfo = null;
+        }
+    }
+
+    // ── Form / Tera / Flags / Origin helpers ──────────────────────────────
+
+    private IReadOnlyList<string> GetFormList()
+    {
+        if (AppState.SaveFile is not { } sf || speciesItem is not { Value: > 0 } sp)
+        {
+            return [];
+        }
+
+        var forms = FormConverter.GetFormList(
+            (ushort)sp.Value,
+            GameInfo.Strings.types,
+            GameInfo.Strings.forms,
+            GameInfo.GenderSymbolUnicode,
+            sf.Context);
+        return forms.Any(f => !string.IsNullOrEmpty(f))
+            ? forms
+            : [];
+    }
+
+    private bool SaveSupportsTeraType() =>
+        AppState.SaveFile?.BlankPKM is ITeraType;
+
+    private bool SaveSupportsFavorite() =>
+        AppState.SaveFile?.BlankPKM is IFavorite;
+
+    private bool SaveSupportsAlpha() =>
+        AppState.SaveFile?.BlankPKM is IAlpha;
+
+    private bool SaveSupportsShadow() =>
+        AppState.SaveFile?.BlankPKM is IShadowCapture;
+
+    private bool SaveSupportsGigantamax() =>
+        AppState.SaveFile?.BlankPKM is IGigantamax;
+
+    private bool SaveSupportsDynamaxLevel() =>
+        AppState.SaveFile?.BlankPKM is IDynamaxLevel;
+
+    private async Task<IEnumerable<ComboItem>> SearchMetLocationsAsync(string search, CancellationToken ct) =>
+        AppState.SaveFile is not { } sf
+            ? []
+            : await Task.FromResult(AppService.SearchMetLocations(search, sf.Version, sf.Context));
+
+    private IReadOnlyList<string> GetAvailableRibbonNames()
+    {
+        if (AppState.SaveFile is not { } sf)
+        {
+            return [];
+        }
+
+        return [.. RibbonHelper.GetAllRibbonInfo(sf.BlankPKM)
+            .Select(r => r.Name)
+            .Where(n => !selectedRibbons.Contains(n))
+            .Distinct()
+            .OrderBy(RibbonHelper.GetRibbonDisplayName)];
+    }
+
+    private async Task<IEnumerable<string>> SearchRibbonNamesAsync(string search, CancellationToken ct)
+    {
+        var names = GetAvailableRibbonNames();
+        if (string.IsNullOrWhiteSpace(search))
+        {
+            return await Task.FromResult(names.Take(30).ToList());
+        }
+
+        return await Task.FromResult(names
+            .Where(n => RibbonHelper.GetRibbonDisplayName(n)
+                .Contains(search, StringComparison.OrdinalIgnoreCase))
+            .Take(30)
+            .ToList());
+    }
+
+    private void AddRibbon(string? name)
+    {
+        if (string.IsNullOrWhiteSpace(name) || selectedRibbons.Contains(name))
+        {
+            return;
+        }
+
+        selectedRibbons.Add(name);
+        pendingRibbonName = null;
+    }
+
+    private void RemoveRibbon(string name) => selectedRibbons.Remove(name);
+
+    private static readonly (int Index, string Symbol, string Label)[] MarkingShapes =
+    [
+        ((int)MarkingsHelper.Markings.Circle, MarkingsHelper.Circle, "Circle"),
+        ((int)MarkingsHelper.Markings.Triangle, MarkingsHelper.Triangle, "Triangle"),
+        ((int)MarkingsHelper.Markings.Square, MarkingsHelper.Square, "Square"),
+        ((int)MarkingsHelper.Markings.Heart, MarkingsHelper.Heart, "Heart"),
+        ((int)MarkingsHelper.Markings.Star, MarkingsHelper.Star, "Star"),
+        ((int)MarkingsHelper.Markings.Diamond, MarkingsHelper.Diamond, "Diamond"),
+    ];
+
+    private void ToggleMarking(int index)
+    {
+        if (!selectedMarkings.Add(index))
+        {
+            selectedMarkings.Remove(index);
         }
     }
 
@@ -512,6 +676,32 @@ public partial class AdvancedSearchTab : RefreshAwareComponent
             .Select(id => AppService.GetMoveComboItem(id))
             .Where(c => c is { Value: > 0 })
             .ToList();
+        form = f.Form;
+        type1 = f.Type1;
+        type2 = f.Type2;
+        teraType = f.TeraType;
+        isFavorite = f.IsFavorite;
+        isAlpha = f.IsAlpha;
+        isShadow = f.IsShadow;
+        canGigantamax = f.CanGigantamax;
+        dynamaxLevelMin = f.DynamaxLevelMin;
+        metLocationItem = null;
+        if (f.MetLocation is > 0 && AppState.SaveFile is { } sf)
+        {
+            metLocationItem = AppService.GetMetLocationComboItem(
+                (ushort)f.MetLocation.Value, sf.Version, sf.Context);
+        }
+        metDateMin = f.MetDateMin?.ToDateTime(TimeOnly.MinValue);
+        metDateMax = f.MetDateMax?.ToDateTime(TimeOnly.MinValue);
+        pokerusState = f.PokerusState;
+        selectedRibbons.Clear();
+        selectedRibbons.AddRange(f.RequiredRibbons);
+        pendingRibbonName = null;
+        selectedMarkings.Clear();
+        foreach (var markingIndex in f.RequiredMarkings)
+        {
+            selectedMarkings.Add(markingIndex);
+        }
         results = [];
         selectedRows = [];
     }

--- a/Pkmds.Rcl/Components/MainTabPages/AdvancedSearchTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/AdvancedSearchTab.razor.cs
@@ -510,7 +510,7 @@ public partial class AdvancedSearchTab : RefreshAwareComponent
 
     private void RemoveRibbon(string name) => selectedRibbons.Remove(name);
 
-    private static readonly (int Index, string Symbol, string Label)[] MarkingShapes =
+    private static readonly (int Index, string Symbol, string Label)[] AllMarkingShapes =
     [
         ((int)MarkingsHelper.Markings.Circle, MarkingsHelper.Circle, "Circle"),
         ((int)MarkingsHelper.Markings.Triangle, MarkingsHelper.Triangle, "Triangle"),
@@ -519,6 +519,18 @@ public partial class AdvancedSearchTab : RefreshAwareComponent
         ((int)MarkingsHelper.Markings.Star, MarkingsHelper.Star, "Star"),
         ((int)MarkingsHelper.Markings.Diamond, MarkingsHelper.Diamond, "Diamond"),
     ];
+
+    private IEnumerable<(int Index, string Symbol, string Label)> GetAvailableMarkingShapes()
+    {
+        // Gen 3 only has 4 markings (no Star/Diamond). Gate the UI on the save's
+        // blank PKM so users can't pick indices that will never match.
+        if (AppState.SaveFile?.BlankPKM is not IAppliedMarkings marks)
+        {
+            return [];
+        }
+
+        return AllMarkingShapes.Where(s => s.Index < marks.MarkingCount);
+    }
 
     private void ToggleMarking(int index)
     {

--- a/Pkmds.Rcl/Models/AdvancedSearchFilter.cs
+++ b/Pkmds.Rcl/Models/AdvancedSearchFilter.cs
@@ -15,6 +15,27 @@ public sealed record AdvancedSearchFilter
     public byte? Form { get; init; }
 
     /// <summary>
+    /// First type filter slot (0–17, indexing into <see cref="GameInfo.Strings" /> type names
+    /// where 0 = Normal), or <see langword="null" /> for any.
+    /// Order-agnostic: matches whether the selected type appears as the Pokémon's primary
+    /// <em>or</em> secondary type. When both <see cref="Type1" /> and <see cref="Type2" /> are
+    /// set, both must appear in the Pokémon's type set (in any order).
+    /// </summary>
+    public int? Type1 { get; init; }
+
+    /// <summary>
+    /// Second type filter slot (0–17), or <see langword="null" /> for any. Order-agnostic —
+    /// see <see cref="Type1" />.
+    /// </summary>
+    public int? Type2 { get; init; }
+
+    /// <summary>
+    /// Tera Type to match (MoveType byte value; 99 = Stellar), or <see langword="null" /> for any.
+    /// Only applies to PKM types that implement <c>ITeraType</c> (Gen 9 SV).
+    /// </summary>
+    public int? TeraType { get; init; }
+
+    /// <summary>
     /// <see langword="true" /> = shiny only, <see langword="false" /> = non-shiny only,
     /// <see langword="null" /> = any.
     /// </summary>
@@ -65,6 +86,57 @@ public sealed record AdvancedSearchFilter
 
     /// <summary>Language ID, or <see langword="null" /> for any.</summary>
     public int? LanguageId { get; init; }
+
+    // ── Origin ────────────────────────────────────────────────────────────
+
+    /// <summary>Met location ID to match exactly, or <see langword="null" /> for any.</summary>
+    public int? MetLocation { get; init; }
+
+    /// <summary>Minimum met date (inclusive), or <see langword="null" /> for no lower bound.</summary>
+    public DateOnly? MetDateMin { get; init; }
+
+    /// <summary>Maximum met date (inclusive), or <see langword="null" /> for no upper bound.</summary>
+    public DateOnly? MetDateMax { get; init; }
+
+    /// <summary>
+    /// Pokerus state filter:
+    /// <c>0</c> = never infected, <c>1</c> = currently infected, <c>2</c> = cured,
+    /// <see langword="null" /> = any.
+    /// </summary>
+    public int? PokerusState { get; init; }
+
+    // ── Flags (conditional on PKM type) ───────────────────────────────────
+
+    /// <summary>
+    /// <see langword="true" /> = favorites only, <see langword="false" /> = non-favorites only,
+    /// <see langword="null" /> = any. Applies only to Let's Go Pokémon (<c>IFavorite</c>).
+    /// </summary>
+    public bool? IsFavorite { get; init; }
+
+    /// <summary>
+    /// <see langword="true" /> = alphas only, <see langword="false" /> = non-alphas only,
+    /// <see langword="null" /> = any. Applies only to Legends Arceus / ZA Pokémon (<c>IAlpha</c>).
+    /// </summary>
+    public bool? IsAlpha { get; init; }
+
+    /// <summary>
+    /// <see langword="true" /> = shadow only, <see langword="false" /> = non-shadow only,
+    /// <see langword="null" /> = any. Applies only to Colosseum/XD Pokémon (<c>IShadowCapture</c>).
+    /// </summary>
+    public bool? IsShadow { get; init; }
+
+    /// <summary>
+    /// <see langword="true" /> = Gigantamax-capable only, <see langword="false" /> = non-Gigantamax only,
+    /// <see langword="null" /> = any. Applies to Gen 8 Pokémon (<c>IGigantamax</c>: PK8, PB8, PA8).
+    /// </summary>
+    public bool? CanGigantamax { get; init; }
+
+    /// <summary>
+    /// Minimum Dynamax level (0–10, inclusive), or <see langword="null" /> for no lower bound.
+    /// Applies to Gen 8 Pokémon (<c>IDynamaxLevel</c>: PK8, PB8, PA8). PKM types that don't
+    /// support the field are excluded when a floor is set.
+    /// </summary>
+    public byte? DynamaxLevelMin { get; init; }
 
     // ── Level ─────────────────────────────────────────────────────────────
 
@@ -119,4 +191,12 @@ public sealed record AdvancedSearchFilter
     /// Empty list = skip check.
     /// </summary>
     public IReadOnlyList<string> RequiredRibbons { get; init; } = [];
+
+    /// <summary>
+    /// Required markings by index (0=Circle, 1=Triangle, 2=Square, 3=Heart, 4=Star, 5=Diamond).
+    /// Each listed marking must be set to any non-off state (Gen 7+ blue or pink count equally).
+    /// PKM types that don't implement <c>IAppliedMarkings</c> are excluded when any marking is required.
+    /// Empty list = skip check.
+    /// </summary>
+    public IReadOnlyList<int> RequiredMarkings { get; init; } = [];
 }

--- a/Pkmds.Rcl/Services/AppService.cs
+++ b/Pkmds.Rcl/Services/AppService.cs
@@ -1743,6 +1743,124 @@ public class AppService(IAppState appState, IRefreshService refreshService, ILeg
             return false;
         }
 
+        // ── Types (order-agnostic multiset match against PersonalInfo) ────
+
+        if (f.Type1.HasValue || f.Type2.HasValue)
+        {
+            var t1 = pkm.PersonalInfo.Type1;
+            var t2 = pkm.PersonalInfo.Type2;
+
+            if (f.Type1.HasValue && f.Type2.HasValue)
+            {
+                var a = f.Type1.Value;
+                var b = f.Type2.Value;
+                var pairMatches = (a == t1 && b == t2) || (a == t2 && b == t1);
+                if (!pairMatches)
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                var filterType = f.Type1 ?? f.Type2!.Value;
+                if (filterType != t1 && filterType != t2)
+                {
+                    return false;
+                }
+            }
+        }
+
+        // ── Tera Type (Gen 9 SV only) ─────────────────────────────────────
+
+        if (f.TeraType.HasValue)
+        {
+            if (pkm is not ITeraType tera || (byte)tera.TeraType != f.TeraType.Value)
+            {
+                return false;
+            }
+        }
+
+        // ── Conditional flags ─────────────────────────────────────────────
+
+        if (f.IsFavorite.HasValue)
+        {
+            if (pkm is not IFavorite fav || fav.IsFavorite != f.IsFavorite.Value)
+            {
+                return false;
+            }
+        }
+
+        if (f.IsAlpha.HasValue)
+        {
+            if (pkm is not IAlpha alpha || alpha.IsAlpha != f.IsAlpha.Value)
+            {
+                return false;
+            }
+        }
+
+        if (f.IsShadow.HasValue)
+        {
+            if (pkm is not IShadowCapture shadow || shadow.IsShadow != f.IsShadow.Value)
+            {
+                return false;
+            }
+        }
+
+        if (f.CanGigantamax.HasValue)
+        {
+            if (pkm is not IGigantamax gmax || gmax.CanGigantamax != f.CanGigantamax.Value)
+            {
+                return false;
+            }
+        }
+
+        if (f.DynamaxLevelMin.HasValue)
+        {
+            if (pkm is not IDynamaxLevel dmax || dmax.DynamaxLevel < f.DynamaxLevelMin.Value)
+            {
+                return false;
+            }
+        }
+
+        // ── Origin (met date / location / Pokerus) ────────────────────────
+
+        if (f.MetLocation.HasValue && pkm.MetLocation != f.MetLocation.Value)
+        {
+            return false;
+        }
+
+        if (f.MetDateMin.HasValue || f.MetDateMax.HasValue)
+        {
+            if (pkm.MetDate is not { } metDate)
+            {
+                return false;
+            }
+
+            if (f.MetDateMin.HasValue && metDate < f.MetDateMin.Value)
+            {
+                return false;
+            }
+
+            if (f.MetDateMax.HasValue && metDate > f.MetDateMax.Value)
+            {
+                return false;
+            }
+        }
+
+        if (f.PokerusState.HasValue)
+        {
+            var state = pkm switch
+            {
+                { IsPokerusCured: true } => 2,
+                { IsPokerusInfected: true } => 1,
+                _ => 0,
+            };
+            if (state != f.PokerusState.Value)
+            {
+                return false;
+            }
+        }
+
         // ── Language ──────────────────────────────────────────────────────
 
         if (f.LanguageId.HasValue && pkm.Language != f.LanguageId.Value)
@@ -1888,6 +2006,24 @@ public class AppService(IAppState appState, IRefreshService refreshService, ILeg
                 .Any(prop => prop?.GetValue(pkm) is not true))
             {
                 return false;
+            }
+        }
+
+        // ── Markings (shape toggles — Gen 3+) ─────────────────────────────
+
+        if (f.RequiredMarkings.Count > 0)
+        {
+            if (pkm is not IAppliedMarkings)
+            {
+                return false;
+            }
+
+            foreach (var index in f.RequiredMarkings)
+            {
+                if (pkm.GetMarking(index) == 0)
+                {
+                    return false;
+                }
             }
         }
 

--- a/Pkmds.Rcl/Services/AppService.cs
+++ b/Pkmds.Rcl/Services/AppService.cs
@@ -1747,8 +1747,7 @@ public class AppService(IAppState appState, IRefreshService refreshService, ILeg
 
         if (f.Type1.HasValue || f.Type2.HasValue)
         {
-            var t1 = pkm.PersonalInfo.Type1;
-            var t2 = pkm.PersonalInfo.Type2;
+            var (t1, t2) = pkm.GetGenerationTypes();
 
             if (f.Type1.HasValue && f.Type2.HasValue)
             {
@@ -2013,13 +2012,20 @@ public class AppService(IAppState appState, IRefreshService refreshService, ILeg
 
         if (f.RequiredMarkings.Count > 0)
         {
-            if (pkm is not IAppliedMarkings)
+            if (pkm is not IAppliedMarkings marks)
             {
                 return false;
             }
 
             foreach (var index in f.RequiredMarkings)
             {
+                if ((uint)index >= (uint)marks.MarkingCount)
+                {
+                    // Persisted filters can outlive the save they were built against;
+                    // unsupported indices on this PKM are "not set" rather than an error.
+                    return false;
+                }
+
                 if (pkm.GetMarking(index) == 0)
                 {
                     return false;

--- a/Pkmds.Tests/AdvancedSearchTests.cs
+++ b/Pkmds.Tests/AdvancedSearchTests.cs
@@ -199,6 +199,203 @@ public class AdvancedSearchTests
     }
 
     [Fact]
+    public void SearchPokemon_TypeFilter_IsOrderAgnostic()
+    {
+        // Arrange — Charizard is Fire (9) / Flying (2).
+        var (service, saveFile) = CreateServiceFromFile("Black - Full Completion.sav");
+
+        var charizard = new PK5 { Species = (ushort)Species.Charizard, CurrentLevel = 50 };
+        charizard.RefreshChecksum();
+        saveFile.SetBoxSlotAtIndex(charizard, 2, 0);
+
+        const int flying = 2;
+        const int fire = 9;
+
+        // Act — Flying as Type1 should still surface Charizard (Flying is its secondary type).
+        var byFlying = service.SearchPokemon(new AdvancedSearchFilter { Type1 = flying }).ToList();
+
+        // Fire + Flying together should match regardless of slot order.
+        var byBothOrderA = service
+            .SearchPokemon(new AdvancedSearchFilter { Type1 = fire, Type2 = flying }).ToList();
+        var byBothOrderB = service
+            .SearchPokemon(new AdvancedSearchFilter { Type1 = flying, Type2 = fire }).ToList();
+
+        // Assert
+        byFlying.Should().Contain(r => r.Pokemon.Species == (ushort)Species.Charizard);
+        byFlying.Should().AllSatisfy(r =>
+        {
+            var info = r.Pokemon.PersonalInfo;
+            (info.Type1 == flying || info.Type2 == flying).Should().BeTrue();
+        });
+
+        byBothOrderA.Should().Contain(r => r.Pokemon.Species == (ushort)Species.Charizard);
+        byBothOrderB.Should().Contain(r => r.Pokemon.Species == (ushort)Species.Charizard);
+    }
+
+    [Fact]
+    public void SearchPokemon_FormFilter_MatchesExactForm()
+    {
+        // Arrange
+        var (service, saveFile) = CreateServiceFromFile("Black - Full Completion.sav");
+
+        // Place a Deerling with form 2 (Autumn).
+        const byte autumnForm = 2;
+        var deerling = new PK5
+        {
+            Species = (ushort)Species.Deerling,
+            Form = autumnForm,
+            CurrentLevel = 10,
+        };
+        deerling.RefreshChecksum();
+        saveFile.SetBoxSlotAtIndex(deerling, 3, 0);
+
+        // Act
+        var results = service.SearchPokemon(new AdvancedSearchFilter
+        {
+            Species = (ushort)Species.Deerling,
+            Form = autumnForm,
+        }).ToList();
+
+        // Assert
+        results.Should().NotBeEmpty();
+        results.Should().AllSatisfy(r =>
+        {
+            r.Pokemon.Species.Should().Be((ushort)Species.Deerling);
+            r.Pokemon.Form.Should().Be(autumnForm);
+        });
+    }
+
+    [Fact]
+    public void SearchPokemon_MetDateRange_InclusiveBoundary()
+    {
+        // Arrange
+        var (service, saveFile) = CreateServiceFromFile("Black - Full Completion.sav");
+
+        // Pin a Pokémon with a known met date.
+        var target = new DateOnly(2020, 6, 15);
+        var pk5 = new PK5
+        {
+            Species = (ushort)Species.Rattata,
+            CurrentLevel = 5,
+            MetYear = (byte)(target.Year - 2000),
+            MetMonth = (byte)target.Month,
+            MetDay = (byte)target.Day,
+        };
+        pk5.RefreshChecksum();
+        saveFile.SetBoxSlotAtIndex(pk5, 4, 0);
+
+        // Act — inclusive range exactly on the target date
+        var inclusive = service.SearchPokemon(new AdvancedSearchFilter
+        {
+            MetDateMin = target,
+            MetDateMax = target,
+        }).ToList();
+
+        // Day before the target: target should be excluded
+        var excludedAfter = service.SearchPokemon(new AdvancedSearchFilter
+        {
+            MetDateMax = target.AddDays(-1),
+        }).ToList();
+
+        // Assert
+        inclusive.Should().Contain(r =>
+            r.Pokemon.Species == (ushort)Species.Rattata && r.Pokemon.MetDate == target);
+        excludedAfter.Should().NotContain(r =>
+            r.Pokemon.Species == (ushort)Species.Rattata && r.Pokemon.MetDate == target);
+    }
+
+    [Fact]
+    public void SearchPokemon_GigantamaxAndDynamaxFilters_MatchSwShFlags()
+    {
+        // Need a Gen 8 save since IGigantamax/IDynamaxLevel are G8PKM-only.
+        var (service, saveFile) = CreateServiceFromFile("Test-Save-Shield.sav");
+
+        var gmaxHighLevel = saveFile.BlankPKM.Clone();
+        gmaxHighLevel.Species = (ushort)Species.Pikachu;
+        gmaxHighLevel.CurrentLevel = 50;
+        ((IGigantamax)gmaxHighLevel).CanGigantamax = true;
+        ((IDynamaxLevel)gmaxHighLevel).DynamaxLevel = 10;
+        gmaxHighLevel.RefreshChecksum();
+        saveFile.SetBoxSlotAtIndex(gmaxHighLevel, 0, 0);
+
+        var plainLowLevel = saveFile.BlankPKM.Clone();
+        plainLowLevel.Species = (ushort)Species.Bulbasaur;
+        plainLowLevel.CurrentLevel = 5;
+        ((IGigantamax)plainLowLevel).CanGigantamax = false;
+        ((IDynamaxLevel)plainLowLevel).DynamaxLevel = 2;
+        plainLowLevel.RefreshChecksum();
+        saveFile.SetBoxSlotAtIndex(plainLowLevel, 0, 1);
+
+        var gmaxOnly = service.SearchPokemon(new AdvancedSearchFilter { CanGigantamax = true }).ToList();
+        var maxedLevel = service.SearchPokemon(new AdvancedSearchFilter { DynamaxLevelMin = 10 }).ToList();
+
+        gmaxOnly.Should().AllSatisfy(r =>
+            ((IGigantamax)r.Pokemon).CanGigantamax.Should().BeTrue());
+        gmaxOnly.Should().Contain(r => r.Pokemon.Species == (ushort)Species.Pikachu);
+        gmaxOnly.Should().NotContain(r => r.Pokemon.Species == (ushort)Species.Bulbasaur);
+
+        maxedLevel.Should().AllSatisfy(r =>
+            ((IDynamaxLevel)r.Pokemon).DynamaxLevel.Should().BeGreaterThanOrEqualTo((byte)10));
+        maxedLevel.Should().Contain(r => r.Pokemon.Species == (ushort)Species.Pikachu);
+    }
+
+    [Fact]
+    public void SearchPokemon_MarkingsFilter_MatchesAllRequiredShapes()
+    {
+        var (service, saveFile) = CreateServiceFromFile("Black - Full Completion.sav");
+
+        // Hand-craft a PK5 with Circle + Heart markings set (indices 0 and 3).
+        var marked = new PK5 { Species = (ushort)Species.Zubat, CurrentLevel = 5 };
+        ((IAppliedMarkings<bool>)marked).SetMarking(0, true); // Circle
+        ((IAppliedMarkings<bool>)marked).SetMarking(3, true); // Heart
+        marked.RefreshChecksum();
+        saveFile.SetBoxSlotAtIndex(marked, 6, 0);
+
+        // A Pokémon with only Circle (missing Heart) must be excluded.
+        var partial = new PK5 { Species = (ushort)Species.Golbat, CurrentLevel = 5 };
+        ((IAppliedMarkings<bool>)partial).SetMarking(0, true);
+        partial.RefreshChecksum();
+        saveFile.SetBoxSlotAtIndex(partial, 6, 1);
+
+        var results = service.SearchPokemon(new AdvancedSearchFilter { RequiredMarkings = [0, 3] }).ToList();
+
+        results.Should().Contain(r => r.Pokemon.Species == (ushort)Species.Zubat);
+        results.Should().NotContain(r => r.Pokemon.Species == (ushort)Species.Golbat);
+        results.Should().AllSatisfy(r =>
+        {
+            r.Pokemon.GetMarking(0).Should().NotBe(0);
+            r.Pokemon.GetMarking(3).Should().NotBe(0);
+        });
+    }
+
+    [Fact]
+    public void SearchPokemon_PokerusFilter_DistinguishesStates()
+    {
+        // Arrange
+        var (service, saveFile) = CreateServiceFromFile("Black - Full Completion.sav");
+
+        var infected = new PK5 { Species = (ushort)Species.Bidoof, CurrentLevel = 5, PokerusStrain = 1, PokerusDays = 3 };
+        infected.RefreshChecksum();
+        saveFile.SetBoxSlotAtIndex(infected, 5, 0);
+
+        var cured = new PK5 { Species = (ushort)Species.Starly, CurrentLevel = 5, PokerusStrain = 1, PokerusDays = 0 };
+        cured.RefreshChecksum();
+        saveFile.SetBoxSlotAtIndex(cured, 5, 1);
+
+        // Act
+        var infectedResults = service.SearchPokemon(new AdvancedSearchFilter { PokerusState = 1 }).ToList();
+        var curedResults = service.SearchPokemon(new AdvancedSearchFilter { PokerusState = 2 }).ToList();
+
+        // Assert
+        infectedResults.Should().Contain(r => r.Pokemon.Species == (ushort)Species.Bidoof);
+        infectedResults.Should().AllSatisfy(r => r.Pokemon.IsPokerusInfected.Should().BeTrue());
+        infectedResults.Should().AllSatisfy(r => r.Pokemon.IsPokerusCured.Should().BeFalse());
+
+        curedResults.Should().Contain(r => r.Pokemon.Species == (ushort)Species.Starly);
+        curedResults.Should().AllSatisfy(r => r.Pokemon.IsPokerusCured.Should().BeTrue());
+    }
+
+    [Fact]
     public void SearchPokemon_OtNameFilter_IsCaseInsensitive()
     {
         // Arrange


### PR DESCRIPTION
## Summary

Closes #737.

Expands the Advanced Search filter panel with the criteria noted on the issue plus a few extras:

- **Types** — Type 1 / Type 2 slots with order-agnostic matching (selecting a type in either slot finds Pokémon with that type as their primary *or* secondary type; both slots set = both types required in any order).
- **Appearance** — Form picker (enabled once a species is chosen), Tera Type dropdown (Gen 9 SV only — correctly excludes PA9/ZA), Favorite / Alpha / Shadow tri-states, **Gigantamax factor** tri-state, **Min Dynamax level** numeric (0–10). Each flag/field is gated on the save's blank PKM implementing the relevant PKHeX interface, so the UI hides on saves that don't support it.
- **Origin** — Met location autocomplete, Met date from/to range (inclusive boundaries), Pokerus tri-state (never/infected/cured).
- **Ribbons / Marks** — Six clickable shape chips (●▲■♥★♦) that AND together for markings, plus the existing ribbon autocomplete sourced from the save's PKM-type ribbon list.

All new fields persist through localStorage saved-filter round-trip. Old saved filters deserialize cleanly (missing fields = null/empty = "any").

## Implementation notes

- Type match uses multiset containment against `PersonalInfo.Type1/Type2`.
- Tera Type check uses `ITeraType.TeraType` — PKHeX's computed current-type getter: the override if one is set, else the original. Gated on `pkm is ITeraType` (PK9 implements; PA9 does not — ZA saves correctly hide the filter).
- Dynamax/Gigantamax guard on `IDynamaxLevel` / `IGigantamax` so SwSh, BDSP, and PLA saves all get the controls.
- Markings match: requires every listed shape (0–5) to be set to any non-off state (Gen 7+ blue and pink both count).
- Cheap checks run before the legality filter, preserving the existing "expensive check runs last" ordering.

## Test plan

- [ ] Load a **Gen 6+** save (e.g. X/Y, ORAS, a Sun save), pick Fairy in Type 1 → results include Pokémon with Fairy in either slot. (Fairy didn't exist pre-Gen 6, so on a Gen 5 save use something like Electric or Flying instead.)
- [ ] Load a Sword save → Gigantamax + Min Dynamax level fields appear; setting "Gigantamax-capable only" filters correctly
- [ ] Load a Scarlet save → Tera Type dropdown appears. Picking Fire should surface Pokémon whose **current** Tera Type is Fire — i.e. the override if one is set, otherwise the original.
- [ ] Load a PLA save → Alpha filter appears, Tera Type does NOT
- [ ] Set Met date range to a specific day → only Pokémon met on that date appear
- [ ] Click three marking chips → only Pokémon with all three shapes appear
- [ ] Save a filter with new fields → reload page → filter restores with all fields intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)