### PR TITLE
fix: theme mismatch on first load when persisted theme is Light (#755)

### DIFF
--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
@@ -156,7 +156,19 @@ public partial class MainLayout : IDisposable
             var themeStr = newValue
                 ? "dark"
                 : "light";
-            await JSRuntime.InvokeVoidAsync("setAppTheme", themeStr);
+
+            // `OnSystemPreferenceChanged` is `async void` (required by MudThemeProvider's
+            // WatchSystemDarkModeAsync callback), so any JSException thrown from the
+            // setAppTheme call would otherwise be unobserved and could tear down rendering.
+            try
+            {
+                await JSRuntime.InvokeVoidAsync("setAppTheme", themeStr);
+            }
+            catch (JSException ex)
+            {
+                Logger.LogWarning(ex, "Failed to apply system theme change to DOM");
+            }
+
             StateHasChanged();
         }
     }

--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
@@ -10,6 +10,7 @@ public partial class MainLayout : IDisposable
     private IBrowserFile? browserLoadSaveFile;
     private bool isDarkMode;
     private bool systemIsDarkMode;
+    private bool settingsLoaded;
     private ThemeMode themeMode = ThemeMode.System;
 
     [Inject]
@@ -125,6 +126,7 @@ public partial class MainLayout : IDisposable
             "light" => ThemeMode.Light,
             _ => ThemeMode.System
         };
+        settingsLoaded = true;
         isDarkMode = ComputeIsDarkMode();
         RefreshService.RefreshTheme(isDarkMode);
         RefreshService.Refresh();
@@ -135,6 +137,18 @@ public partial class MainLayout : IDisposable
     private async void OnSystemPreferenceChanged(bool newValue)
     {
         systemIsDarkMode = newValue;
+
+        // Until persisted settings have loaded, `themeMode` is still the default `System`,
+        // so a transient OS-dark signal would incorrectly flip `isDarkMode` to true even when
+        // the user's persisted preference is explicitly Light (or Dark). That intermediate
+        // flip leaves MudMainContent stranded in dark mode on first load — see issue #755.
+        // Gating here preserves the cached `systemIsDarkMode` for later use once settings
+        // load and the user's real preference is known.
+        if (!settingsLoaded)
+        {
+            return;
+        }
+
         if (themeMode == ThemeMode.System)
         {
             isDarkMode = newValue;


### PR DESCRIPTION
## Summary

- Fixes #755. On initial load with persisted theme **Light** and OS preference **Dark**, the main content area rendered dark while the drawer rendered light until the user toggled the theme.
- Root cause: `MainLayout.OnSystemPreferenceChanged` fired (from `App.OnAfterRenderAsync`'s initial `GetSystemDarkModeAsync` call) before `MainLayout.OnAfterRenderAsync` had loaded settings. With `themeMode` still at its default `System`, the handler flipped `isDarkMode` to true; settings load then reverted it to false, but `MudMainContent` remained stranded in the transient dark state.
- Fix: gate `OnSystemPreferenceChanged` on a new `settingsLoaded` flag so system pref changes only propagate once the persisted preference is known. The cached `systemIsDarkMode` is still captured for later use when `themeMode == System`.

## Test plan

- [ ] OS = Dark, persisted theme = Light → reload and confirm drawer + main content both render Light (no stranded dark content area).
- [ ] OS = Light, persisted theme = Dark → reload and confirm drawer + main content both render Dark consistently.
- [ ] OS = Dark, persisted theme = System → reload and confirm dark mode applies everywhere.
- [ ] OS = Light, persisted theme = System → reload and confirm light mode applies everywhere.
- [ ] With `ThemeMode.System` active, flip OS dark-mode preference at runtime and confirm the app updates (verifies the gate doesn't break the live OS watcher once settings load).
- [ ] Toggle theme button through all three modes — still persists and applies correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)