### PR TITLE
feat: haptic feedback for drag/drop and key actions

### DIFF
--- a/Pkmds.Rcl/Components/Dialogs/AlcremieEditorDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/AlcremieEditorDialog.razor.cs
@@ -66,6 +66,7 @@ public partial class AlcremieEditorDialog
             fa.FormArgument = selectedDeco;
         }
 
+        Haptics.Confirm();
         MudDialog?.Close(DialogResult.Ok(true));
     }
 

--- a/Pkmds.Rcl/Components/Dialogs/AppSettingsDialog.razor
+++ b/Pkmds.Rcl/Components/Dialogs/AppSettingsDialog.razor
@@ -91,18 +91,37 @@
                              Color="@Color.Secondary">
                         Choose which overlay icons appear on box and party slots.
                     </MudText>
-                    <MudSwitch @bind-Value="@showLegalIndicator"
+                    <MudSwitch T="@bool"
+                               Value="@showLegalIndicator"
                                Color="@Color.Success"
                                Label="Show Legal (green)"
-                               title="Show a green check on slots whose Pokémon are fully legal"/>
-                    <MudSwitch @bind-Value="@showFishyIndicator"
+                               title="Show a green check on slots whose Pokémon are fully legal"
+                               ValueChanged="@(v => OnToggle(v, x => showLegalIndicator = x))"/>
+                    <MudSwitch T="@bool"
+                               Value="@showFishyIndicator"
                                Color="@Color.Warning"
                                Label="Show Fishy (yellow)"
-                               title="Show a yellow warning on slots whose Pokémon pass legality but have suspicious checks"/>
-                    <MudSwitch @bind-Value="@showIllegalIndicator"
+                               title="Show a yellow warning on slots whose Pokémon pass legality but have suspicious checks"
+                               ValueChanged="@(v => OnToggle(v, x => showFishyIndicator = x))"/>
+                    <MudSwitch T="@bool"
+                               Value="@showIllegalIndicator"
                                Color="@Color.Error"
                                Label="Show Illegal (red)"
-                               title="Show a red indicator on slots whose Pokémon fail legality"/>
+                               title="Show a red indicator on slots whose Pokémon fail legality"
+                               ValueChanged="@(v => OnToggle(v, x => showIllegalIndicator = x))"/>
+
+                    <MudDivider/>
+
+                    <MudText Typo="@Typo.subtitle1"
+                             Color="@Color.Primary">
+                        Haptic Feedback
+                    </MudText>
+                    <MudSwitch T="@bool"
+                               Value="@hapticsEnabled"
+                               Color="@Color.Primary"
+                               Label="Enable haptics"
+                               title="Short vibration pulses on drag, drop, save export, and other key actions. No effect on iOS — Safari does not support web haptics."
+                               ValueChanged="@(v => OnToggle(v, x => hapticsEnabled = x))"/>
 
                     <MudDivider/>
 
@@ -116,10 +135,12 @@
                                Label="PKHaX Mode"
                                title="Enables unrestricted editing. May create illegal/untradable Pokémon. Use at your own risk."
                                ValueChanged="@(value => OnHaXEnabledChanged(value))"/>
-                    <MudSwitch @bind-Value="@isVerboseLogging"
+                    <MudSwitch T="@bool"
+                               Value="@isVerboseLogging"
                                Color="@Color.Primary"
                                Label="Verbose Logging"
-                               title="Enable verbose logging to browser console"/>
+                               title="Enable verbose logging to browser console"
+                               ValueChanged="@(v => OnToggle(v, x => isVerboseLogging = x))"/>
                 </MudStack>
             </MudTabPanel>
 
@@ -165,10 +186,12 @@
                              Color="@Color.Primary">
                         Backup
                     </MudText>
-                    <MudSwitch @bind-Value="@isAutoBackupEnabled"
+                    <MudSwitch T="@bool"
+                               Value="@isAutoBackupEnabled"
                                Color="@Color.Primary"
                                Label="Auto-backup on load"
-                               title="Automatically create a backup each time a save file is loaded"/>
+                               title="Automatically create a backup each time a save file is loaded"
+                               ValueChanged="@(v => OnToggle(v, x => isAutoBackupEnabled = x))"/>
                     <MudNumericField @bind-Value="@maxBackupCount"
                                      Label="Max backups to keep"
                                      Variant="@Variant.Outlined"

--- a/Pkmds.Rcl/Components/Dialogs/AppSettingsDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/AppSettingsDialog.razor.cs
@@ -27,6 +27,7 @@ public partial class AppSettingsDialog
     private bool showFishyIndicator = true;
     private bool showIllegalIndicator = true;
     private bool showLegalIndicator = true;
+    private bool hapticsEnabled = true;
     private SpriteStyle spriteStyle;
 
     // Working copy — only committed on Save
@@ -58,10 +59,20 @@ public partial class AppSettingsDialog
         showLegalIndicator = InitialSettings.ShowLegalIndicator;
         showFishyIndicator = InitialSettings.ShowFishyIndicator;
         showIllegalIndicator = InitialSettings.ShowIllegalIndicator;
+        hapticsEnabled = InitialSettings.HapticsEnabled;
+    }
+
+    // Pulse a Tap before applying the new value so the toggle feels responsive when the
+    // user is turning haptics off (otherwise the disabled-then-set order eats the final tap).
+    private void OnToggle(bool value, Action<bool> setter)
+    {
+        Haptics.Tap();
+        setter(value);
     }
 
     private async Task OnHaXEnabledChanged(bool newValue)
     {
+        Haptics.Tap();
         if (newValue && !InitialSettings.IsHaXEnabled)
         {
             var ack = await JSRuntime.InvokeAsync<string?>("localStorage.getItem", "pkmds_hax_warning_ack");
@@ -107,6 +118,8 @@ public partial class AppSettingsDialog
         showLegalIndicator = defaults.ShowLegalIndicator;
         showFishyIndicator = defaults.ShowFishyIndicator;
         showIllegalIndicator = defaults.ShowIllegalIndicator;
+        hapticsEnabled = defaults.HapticsEnabled;
+        Haptics.Confirm();
         StateHasChanged();
     }
 
@@ -124,6 +137,7 @@ public partial class AppSettingsDialog
             return;
         }
 
+        Haptics.Confirm();
         await JSRuntime.InvokeVoidAsync("clearAppCacheAndReload");
     }
 
@@ -152,7 +166,8 @@ public partial class AppSettingsDialog
             MaxBackupCount = maxBackupCount,
             ShowLegalIndicator = showLegalIndicator,
             ShowFishyIndicator = showFishyIndicator,
-            ShowIllegalIndicator = showIllegalIndicator
+            ShowIllegalIndicator = showIllegalIndicator,
+            HapticsEnabled = hapticsEnabled
         };
 
         MudDialog.Close(DialogResult.Ok(updated));

--- a/Pkmds.Rcl/Components/Dialogs/ConfirmActionDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/ConfirmActionDialog.razor.cs
@@ -34,6 +34,9 @@ public partial class ConfirmActionDialog
 
     private void Confirm()
     {
+        // One pulse covers every destructive/primary callsite that funnels through this
+        // generic dialog (Delete Pokémon, Reset to Defaults, etc.) — no per-call wiring.
+        Haptics.Confirm();
         OnConfirm.InvokeAsync(true);
         MudDialog?.Close();
     }

--- a/Pkmds.Rcl/Components/Dialogs/EvolvePickerDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/EvolvePickerDialog.razor.cs
@@ -212,6 +212,7 @@ public partial class EvolvePickerDialog
             return;
         }
 
+        Haptics.Confirm();
         MudDialog?.Close(DialogResult.Ok(selected));
     }
 

--- a/Pkmds.Rcl/Components/Dialogs/FlowerColorDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/FlowerColorDialog.razor.cs
@@ -33,6 +33,7 @@ public partial class FlowerColorDialog
         }
 
         Pokemon.Form = selectedForm;
+        Haptics.Confirm();
         MudDialog?.Close(DialogResult.Ok(true));
     }
 

--- a/Pkmds.Rcl/Components/Dialogs/FurfrouEditorDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/FurfrouEditorDialog.razor.cs
@@ -52,6 +52,7 @@ public partial class FurfrouEditorDialog
             ? 0
             : daysRemaining);
 
+        Haptics.Confirm();
         MudDialog?.Close(DialogResult.Ok(true));
     }
 

--- a/Pkmds.Rcl/Components/Dialogs/MiniorColorDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/MiniorColorDialog.razor.cs
@@ -38,6 +38,7 @@ public partial class MiniorColorDialog
         }
 
         Pokemon.Form = selectedForm;
+        Haptics.Confirm();
         MudDialog?.Close(DialogResult.Ok(true));
     }
 

--- a/Pkmds.Rcl/Components/Dialogs/MoveShopDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/MoveShopDialog.razor.cs
@@ -113,6 +113,7 @@ public partial class MoveShopDialog
         }
 
         RefreshService.Refresh();
+        Haptics.Confirm();
         MudDialog?.Close(DialogResult.Ok(true));
     }
 

--- a/Pkmds.Rcl/Components/Dialogs/PidEcDialog.razor
+++ b/Pkmds.Rcl/Components/Dialogs/PidEcDialog.razor
@@ -20,22 +20,26 @@
                           Class="mb-2">
                     @if (IsGen345)
                     {
-                        <MudCheckBox @bind-Value="@KeepNature"
-                                     Label="Keep nature"
-                                     Color="@Color.Primary"/>
+                        <HapticCheckBox T="@bool"
+                                        @bind-Value="@KeepNature"
+                                        Label="Keep nature"
+                                        Color="@Color.Primary"/>
                         @if (Pokemon.PersonalInfo.IsDualGender)
                         {
-                            <MudCheckBox @bind-Value="@KeepGender"
-                                         Label="Keep gender"
-                                         Color="@Color.Primary"/>
+                            <HapticCheckBox T="@bool"
+                                            @bind-Value="@KeepGender"
+                                            Label="Keep gender"
+                                            Color="@Color.Primary"/>
                         }
                     }
-                    <MudCheckBox @bind-Value="@AvoidShiny"
-                                 Label="Avoid shiny"
-                                 Color="@Color.Primary"/>
-                    <MudCheckBox @bind-Value="@ForceShiny"
-                                 Label="Force shiny"
-                                 Color="@Color.Primary"/>
+                    <HapticCheckBox T="@bool"
+                                    @bind-Value="@AvoidShiny"
+                                    Label="Avoid shiny"
+                                    Color="@Color.Primary"/>
+                    <HapticCheckBox T="@bool"
+                                    @bind-Value="@ForceShiny"
+                                    Label="Force shiny"
+                                    Color="@Color.Primary"/>
                 </MudStack>
 
                 <MudStack Row

--- a/Pkmds.Rcl/Components/Dialogs/PidEcDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/PidEcDialog.razor.cs
@@ -117,6 +117,7 @@ public partial class PidEcDialog
         }
 
         AppService.LoadPokemonStats(Pokemon);
+        Haptics.Confirm();
         RefreshService.Refresh();
     }
 
@@ -128,6 +129,7 @@ public partial class PidEcDialog
         }
 
         Pokemon.SetIsShiny(true);
+        Haptics.Confirm();
         RefreshService.Refresh();
     }
 
@@ -206,6 +208,7 @@ public partial class PidEcDialog
 
         Pokemon.SetIVs(ivs);
         AppService.LoadPokemonStats(Pokemon);
+        Haptics.Confirm();
         RefreshService.Refresh();
     }
 
@@ -221,6 +224,7 @@ public partial class PidEcDialog
         // EC satisfies newEc % 6 == oldEc % 6 before calling SetRandomEC.
         Pokemon.SetRandomEC();
         AppService.LoadPokemonStats(Pokemon);
+        Haptics.Confirm();
         RefreshService.Refresh();
     }
 
@@ -232,6 +236,7 @@ public partial class PidEcDialog
         }
 
         Pokemon.SetShiny(SelectedShinyType);
+        Haptics.Confirm();
         RefreshService.Refresh();
     }
 

--- a/Pkmds.Rcl/Components/Dialogs/PlusFlagsDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/PlusFlagsDialog.razor.cs
@@ -90,6 +90,7 @@ public partial class PlusFlagsDialog
         }
 
         RefreshService.Refresh();
+        Haptics.Confirm();
         MudDialog?.Close(DialogResult.Ok(true));
     }
 

--- a/Pkmds.Rcl/Components/Dialogs/PumpkabooSizeDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/PumpkabooSizeDialog.razor.cs
@@ -33,6 +33,7 @@ public partial class PumpkabooSizeDialog
         }
 
         Pokemon.Form = selectedForm;
+        Haptics.Confirm();
         MudDialog?.Close(DialogResult.Ok(true));
     }
 

--- a/Pkmds.Rcl/Components/Dialogs/RelearnFlagsDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/RelearnFlagsDialog.razor.cs
@@ -94,6 +94,7 @@ public partial class RelearnFlagsDialog
         }
 
         RefreshService.Refresh();
+        Haptics.Confirm();
         MudDialog?.Close(DialogResult.Ok(true));
     }
 

--- a/Pkmds.Rcl/Components/Dialogs/SpindaPatternDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/SpindaPatternDialog.razor.cs
@@ -77,6 +77,7 @@ public partial class SpindaPatternDialog
         }
 
         ApplyPattern(Pokemon, pattern);
+        Haptics.Confirm();
         MudDialog?.Close(DialogResult.Ok(true));
     }
 

--- a/Pkmds.Rcl/Components/Dialogs/VivillonEditorDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/VivillonEditorDialog.razor.cs
@@ -33,6 +33,7 @@ public partial class VivillonEditorDialog
         }
 
         Pokemon.Form = selectedForm;
+        Haptics.Confirm();
         MudDialog?.Close(DialogResult.Ok(true));
     }
 

--- a/Pkmds.Rcl/Components/EditForms/Tabs/CosmeticTab.razor
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/CosmeticTab.razor
@@ -30,9 +30,10 @@
 
 @if (Pokemon is IFavorite)
 {
-    <MudCheckBox Label="Favorite"
-                 @bind-Value="@IsFavorite"
-                 @bind-Value:after="@RefreshService.Refresh"/>
+    <HapticCheckBox T="@bool"
+                    Label="Favorite"
+                    @bind-Value="@IsFavorite"
+                    @bind-Value:after="@RefreshService.Refresh"/>
 }
 
 @if (Pokemon is IScaledSize scaledSize)

--- a/Pkmds.Rcl/Components/EditForms/Tabs/GenSpecificTab.razor
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/GenSpecificTab.razor
@@ -92,17 +92,17 @@
                 @for (var i = 0; i < 5; i++)
                 {
                     var bit = i;
-                    <MudCheckBox T="@bool"
-                                 Label="@($"Leaf {bit + 1}")"
-                                 Value="@GetShinyLeafBit(g4.ShinyLeaf, bit)"
-                                 ValueChanged="@(v => g4.ShinyLeaf = SetShinyLeafBit(g4.ShinyLeaf, bit, v))"
-                                 title="@($"Shiny Leaf {bit + 1}")"/>
+                    <HapticCheckBox T="@bool"
+                                    Label="@($"Leaf {bit + 1}")"
+                                    Value="@GetShinyLeafBit(g4.ShinyLeaf, bit)"
+                                    ValueChanged="@(v => g4.ShinyLeaf = SetShinyLeafBit(g4.ShinyLeaf, bit, v))"
+                                    title="@($"Shiny Leaf {bit + 1}")"/>
                 }
-                <MudCheckBox T="@bool"
-                             Label="Crown"
-                             Value="@GetShinyLeafBit(g4.ShinyLeaf, 5)"
-                             ValueChanged="@(v => g4.ShinyLeaf = SetShinyLeafBit(g4.ShinyLeaf, 5, v))"
-                             title="Shiny Leaf Crown (requires all 5 leaves)"/>
+                <HapticCheckBox T="@bool"
+                                Label="Crown"
+                                Value="@GetShinyLeafBit(g4.ShinyLeaf, 5)"
+                                ValueChanged="@(v => g4.ShinyLeaf = SetShinyLeafBit(g4.ShinyLeaf, 5, v))"
+                                title="Shiny Leaf Crown (requires all 5 leaves)"/>
             </MudStack>
 
             <MudNumericField T="@sbyte"
@@ -121,10 +121,11 @@
             <MudDivider/>
             <MudText Typo="@Typo.subtitle2">Gen 5</MudText>
 
-            <MudCheckBox Label="N's Sparkle"
-                         @bind-Value="@pk5.NSparkle"
-                         @bind-Value:after="@RefreshService.Refresh"
-                         For="@(() => pk5.NSparkle)"/>
+            <HapticCheckBox T="@bool"
+                            Label="N's Sparkle"
+                            @bind-Value="@pk5.NSparkle"
+                            @bind-Value:after="@RefreshService.Refresh"
+                            For="@(() => pk5.NSparkle)"/>
 
             <MudNumericField T="@byte"
                              Label="PokéStar Fame (B2/W2 only)"
@@ -210,9 +211,10 @@
                                  Style="max-width: 160px;"/>
                 @if (Pokemon is IGigantamax gigantamax)
                 {
-                    <MudCheckBox Label="Gigantamax"
-                                 @bind-Value="@gigantamax.CanGigantamax"
-                                 For="@(() => gigantamax.CanGigantamax)"/>
+                    <HapticCheckBox T="@bool"
+                                    Label="Gigantamax"
+                                    @bind-Value="@gigantamax.CanGigantamax"
+                                    For="@(() => gigantamax.CanGigantamax)"/>
                 }
             </MudStack>
         }
@@ -227,16 +229,18 @@
                       Wrap="@Wrap.Wrap">
                 @if (Pokemon is INoble noble)
                 {
-                    <MudCheckBox Label="Noble"
-                                 @bind-Value="@noble.IsNoble"
-                                 For="@(() => noble.IsNoble)"/>
+                    <HapticCheckBox T="@bool"
+                                    Label="Noble"
+                                    @bind-Value="@noble.IsNoble"
+                                    For="@(() => noble.IsNoble)"/>
                 }
                 @switch (Pokemon)
                 {
                     case IAlpha alpha:
-                        <MudCheckBox Label="Alpha"
-                                     @bind-Value="@alpha.IsAlpha"
-                                     For="@(() => alpha.IsAlpha)"/>
+                        <HapticCheckBox T="@bool"
+                                        Label="Alpha"
+                                        @bind-Value="@alpha.IsAlpha"
+                                        For="@(() => alpha.IsAlpha)"/>
                         break;
                     case IAlphaReadOnly alphaReadOnly:
                         <MudCheckBox Label="Alpha"

--- a/Pkmds.Rcl/Components/EditForms/Tabs/MainTab.razor
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/MainTab.razor
@@ -84,9 +84,10 @@
 
     <MudStack Row>
 
-        <MudCheckBox Label="Is Nicknamed"
-                     @bind-Value="@Pokemon.IsNicknamed"
-                     For="@(() => Pokemon.IsNicknamed)"/>
+        <HapticCheckBox T="@bool"
+                        Label="Is Nicknamed"
+                        @bind-Value="@Pokemon.IsNicknamed"
+                        For="@(() => Pokemon.IsNicknamed)"/>
 
         <MudButton OnClick="@RevertNickname"
                    ButtonType="@ButtonType.Button"
@@ -491,10 +492,11 @@
             <MudStack Row
                       AlignItems="@AlignItems.Center"
                       Spacing="0">
-                <MudCheckBox Label="Is Egg"
-                             @bind-Value="@Pokemon.IsEgg"
-                             @bind-Value:after="@RefreshService.Refresh"
-                             For="@(() => Pokemon.IsEgg)"/>
+                <HapticCheckBox T="@bool"
+                                Label="Is Egg"
+                                @bind-Value="@Pokemon.IsEgg"
+                                @bind-Value:after="@RefreshService.Refresh"
+                                For="@(() => Pokemon.IsEgg)"/>
                 <LegalityIndicator
                     Severity="@(GetCheckResult(CheckIdentifier.Egg)?.Judgement ?? PKHeX.Core.Severity.Valid)"
                     Message="@HumanizeCheckResult(GetCheckResult(CheckIdentifier.Egg))"/>
@@ -506,10 +508,11 @@
         <MudStack Row
                   AlignItems="@AlignItems.Center"
                   Spacing="0">
-            <MudCheckBox Label="Shiny"
-                         @bind-Value:get="@Pokemon.GetIsShinySafe()"
-                         @bind-Value:set="@(isShiny => OnShinySet(isShiny))"
-                         For="@(() => Pokemon.IsShiny)"/>
+            <HapticCheckBox T="@bool"
+                            Label="Shiny"
+                            @bind-Value:get="@Pokemon.GetIsShinySafe()"
+                            @bind-Value:set="@(isShiny => OnShinySet(isShiny))"
+                            For="@(() => Pokemon.IsShiny)"/>
             <LegalityIndicator
                 Severity="@(GetCheckResult(CheckIdentifier.Shiny)?.Judgement ?? PKHeX.Core.Severity.Valid)"
                 Message="@HumanizeCheckResult(GetCheckResult(CheckIdentifier.Shiny))"/>

--- a/Pkmds.Rcl/Components/EditForms/Tabs/MainTab.razor.cs
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/MainTab.razor.cs
@@ -339,6 +339,7 @@ public partial class MainTab : IDisposable
             return;
         }
 
+        Haptics.Confirm();
         Pokemon.IsNicknamed = false;
         Pokemon.ClearNickname();
     }

--- a/Pkmds.Rcl/Components/EditForms/Tabs/MetTab.razor
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/MetTab.razor
@@ -184,11 +184,11 @@
 
     @if (saveGeneration >= 4)
     {
-        <MudCheckBox Label="This Pokémon was met as an Egg"
-                     T="@bool"
-                     Value="@PokemonMetAsEgg"
-                     ValueChanged="@MetAsEggChanged"
-                     For="@(() => Pokemon.FatefulEncounter)"/>
+        <HapticCheckBox Label="This Pokémon was met as an Egg"
+                        T="@bool"
+                        Value="@PokemonMetAsEgg"
+                        ValueChanged="@MetAsEggChanged"
+                        For="@(() => Pokemon.FatefulEncounter)"/>
     }
 
     @if (saveGeneration >= 4 && PokemonMetAsEgg)
@@ -211,15 +211,17 @@
                    @bind-Value="@Pokemon.EggMetDate"/>
     }
 
-    <MudCheckBox Label="Is Egg"
-                 @bind-Value="@Pokemon.IsEgg"
-                 @bind-Value:after="@RefreshService.Refresh"
-                 For="@(() => Pokemon.IsEgg)"/>
+    <HapticCheckBox T="@bool"
+                    Label="Is Egg"
+                    @bind-Value="@Pokemon.IsEgg"
+                    @bind-Value:after="@RefreshService.Refresh"
+                    For="@(() => Pokemon.IsEgg)"/>
 
     @if (saveGeneration >= 3)
     {
-        <MudCheckBox Label="Fateful Encounter"
-                     @bind-Value="@Pokemon.FatefulEncounter"
-                     For="@(() => Pokemon.FatefulEncounter)"/>
+        <HapticCheckBox T="@bool"
+                        Label="Fateful Encounter"
+                        @bind-Value="@Pokemon.FatefulEncounter"
+                        For="@(() => Pokemon.FatefulEncounter)"/>
     }
 }

--- a/Pkmds.Rcl/Components/EditForms/Tabs/MovesTab.razor
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/MovesTab.razor
@@ -221,22 +221,24 @@
                             {
                                 var localMoveId = Pokemon.GetMove(i);
                                 var plusFlagIndex = PersonalInfo9ZA.PlusMoves.IndexOf(localMoveId);
-                                <MudCheckBox Label="+"
-                                             Dense
-                                             title="Plus Move"
-                                             @bind-Value:get="@GetPokemonMoveIsPlus(plusFlagIndex)"
-                                             @bind-Value:set="@(newValue => SetPokemonMoveIsPlus(plusFlagIndex, newValue))"/>
+                                <HapticCheckBox T="@bool"
+                                                Label="+"
+                                                Dense
+                                                title="Plus Move"
+                                                @bind-Value:get="@GetPokemonMoveIsPlus(plusFlagIndex)"
+                                                @bind-Value:set="@(newValue => SetPokemonMoveIsPlus(plusFlagIndex, newValue))"/>
                             }
                             @if (showMasteredMove && Pokemon is IMoveShop8Mastery)
                             {
                                 var localMoveId = Pokemon.GetMove(i);
                                 var masteredFlagIndex = GetMasteredRecordIndex(localMoveId);
-                                <MudCheckBox Label="+"
-                                             Dense
-                                             title="Mastered Move"
-                                             Disabled="@(masteredFlagIndex < 0)"
-                                             @bind-Value:get="@GetPokemonMoveIsMastered(masteredFlagIndex)"
-                                             @bind-Value:set="@(newValue => SetPokemonMoveIsMastered(masteredFlagIndex, newValue))"/>
+                                <HapticCheckBox T="@bool"
+                                                Label="+"
+                                                Dense
+                                                title="Mastered Move"
+                                                Disabled="@(masteredFlagIndex < 0)"
+                                                @bind-Value:get="@GetPokemonMoveIsMastered(masteredFlagIndex)"
+                                                @bind-Value:set="@(newValue => SetPokemonMoveIsMastered(masteredFlagIndex, newValue))"/>
                             }
                         </MudStack>
                     </MudItem>

--- a/Pkmds.Rcl/Components/EditForms/Tabs/OtMiscTab.razor.cs
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/OtMiscTab.razor.cs
@@ -295,6 +295,7 @@ public partial class OtMiscTab : IDisposable
             return;
         }
 
+        Haptics.Confirm();
         Pokemon.OriginalTrainerName = saveFile.OT;
         Pokemon.OriginalTrainerGender = saveFile.Gender;
 

--- a/Pkmds.Rcl/Components/EditForms/Tabs/PokerusComponent.razor
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/PokerusComponent.razor
@@ -1,14 +1,16 @@
 ﻿@if (Pokemon is { } pokemon)
 {
-    <MudCheckBox Label="Infected"
-                 @bind-Value:get="@pokemon.IsPokerusInfected"
-                 @bind-Value:set="@(infected => SetPokerusInfected(infected))"
-                 For="@(() => pokemon.IsPokerusInfected)"/>
+    <HapticCheckBox T="@bool"
+                    Label="Infected"
+                    @bind-Value:get="@pokemon.IsPokerusInfected"
+                    @bind-Value:set="@(infected => SetPokerusInfected(infected))"
+                    For="@(() => pokemon.IsPokerusInfected)"/>
 
-    <MudCheckBox Label="Cured"
-                 @bind-Value:get="@pokemon.IsPokerusCured"
-                 @bind-Value:set="@(cured => SetPokerusCured(cured))"
-                 For="@(() => pokemon.IsPokerusCured)"/>
+    <HapticCheckBox T="@bool"
+                    Label="Cured"
+                    @bind-Value:get="@pokemon.IsPokerusCured"
+                    @bind-Value:set="@(cured => SetPokerusCured(cured))"
+                    For="@(() => pokemon.IsPokerusCured)"/>
 
     @if (pokemon.IsPokerusInfected)
     {

--- a/Pkmds.Rcl/Components/EditForms/Tabs/RibbonsTab.razor.cs
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/RibbonsTab.razor.cs
@@ -197,6 +197,7 @@ public partial class RibbonsTab : IDisposable
             return;
         }
 
+        Haptics.Confirm();
         foreach (var ribbon in GetAllRibbonInfo())
         {
             var value = ribbon.Type is RibbonValueType.Boolean
@@ -215,6 +216,7 @@ public partial class RibbonsTab : IDisposable
             return;
         }
 
+        Haptics.Confirm();
         foreach (var ribbon in GetAllRibbonInfo())
         {
             var value = ribbon.Type is RibbonValueType.Boolean

--- a/Pkmds.Rcl/Components/EditForms/Tabs/StatsTab.razor
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/StatsTab.razor
@@ -18,9 +18,11 @@
 
         <MudItem xs="12">
             <MudStack>
-                <MudSwitch @bind-Value="@ShowStatsChart"
+                <MudSwitch T="@bool"
+                           Value="@ShowStatsChart"
                            Color="@Color.Primary"
-                           Label="Show Stats Chart"/>
+                           Label="Show Stats Chart"
+                           ValueChanged="@(v => { Haptics.Tap(); ShowStatsChart = v; })"/>
                 @if (ShowStatsChart)
                 {
                     <MudPaper Class="pa-1">

--- a/Pkmds.Rcl/Components/HapticCheckBox.razor
+++ b/Pkmds.Rcl/Components/HapticCheckBox.razor
@@ -1,0 +1,40 @@
+@typeparam T
+
+@*
+    Thin wrapper around <MudCheckBox<T>> that fires Haptics.Tap() before propagating
+    the value change. Drop-in for editor controls where toggling represents a real
+    state change worth signalling. Skip for bulk-fill grids (Pokédex, Bag) where a
+    haptic per click would become noise. ReadOnly checkboxes naturally don't pulse
+    because MudCheckBox doesn't fire ValueChanged for them.
+*@
+<MudCheckBox T="@T"
+             Value="@Value"
+             ValueChanged="@HandleValueChanged"
+             For="@For"
+             @attributes="@AdditionalAttributes">
+    @ChildContent
+</MudCheckBox>
+
+@code {
+
+    [Parameter] public T? Value { get; set; }
+
+    [Parameter] public EventCallback<T?> ValueChanged { get; set; }
+
+    [Parameter] public System.Linq.Expressions.Expression<System.Func<T>>? For { get; set; }
+
+    [Parameter] public RenderFragment? ChildContent { get; set; }
+
+    [Parameter(CaptureUnmatchedValues = true)]
+    public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private async Task HandleValueChanged(T? newValue)
+    {
+        Haptics.Tap();
+        if (ValueChanged.HasDelegate)
+        {
+            await ValueChanged.InvokeAsync(newValue);
+        }
+    }
+
+}

--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
@@ -493,6 +493,7 @@ public partial class MainLayout : IDisposable
 
         AppState.ShowProgressIndicator = false;
         RefreshService.RefreshBoxAndPartyState();
+        Haptics.Success();
     }
 
     private void FinishLoadingSaveFile(SaveFile saveFile, string? fileName = null)
@@ -588,6 +589,7 @@ public partial class MainLayout : IDisposable
             }
 
             Logger.LogInformation("Save file exported successfully");
+            Haptics.Success();
         }
         catch (Exception ex)
         {

--- a/Pkmds.Rcl/Components/MainTabPages/AdvancedSearchTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/AdvancedSearchTab.razor.cs
@@ -539,6 +539,7 @@ public partial class AdvancedSearchTab : RefreshAwareComponent
 
     private void ToggleMarking(int index)
     {
+        Haptics.Tap();
         if (!selectedMarkings.Add(index))
         {
             selectedMarkings.Remove(index);

--- a/Pkmds.Rcl/Components/MainTabPages/BadgesComponent.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/BadgesComponent.razor.cs
@@ -130,6 +130,8 @@ public partial class BadgesComponent : IDisposable
             return;
         }
 
+        Haptics.Tap();
+
         switch (saveFile.Context)
         {
             case EntityContext.Gen1 when saveFile is SAV1 sav1:

--- a/Pkmds.Rcl/Components/MainTabPages/BagTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/BagTab.razor
@@ -51,9 +51,11 @@
                                        StartIcon="@Icons.Material.Filled.Sort">
                                 Sort By Index
                             </MudButton>
-                            <MudSwitch @bind-Value="@ShowEmptySlots"
+                            <MudSwitch T="@bool"
+                                       Value="@ShowEmptySlots"
                                        Color="@Color.Primary"
-                                       Label="Show Empty Slots"/>
+                                       Label="Show Empty Slots"
+                                       ValueChanged="@(v => { Haptics.Tap(); ShowEmptySlots = v; })"/>
                         </MudStack>
                         <MudDataGrid T="@InventoryItem"
                                      Items="@(ShowEmptySlots

--- a/Pkmds.Rcl/Components/MainTabPages/LegalityReportTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/LegalityReportTab.razor.cs
@@ -179,6 +179,23 @@ public partial class LegalityReportTab : RefreshAwareComponent
         var summary = BuildLegalizeSummary(targets.Count, processed, successCount, fishyCount, failureCount, cancelled);
         Snackbar.Add(summary.Message, summary.Severity);
 
+        // Skip a haptic on plain cancellation — the user already knows; only signal completion.
+        if (!cancelled)
+        {
+            if (successCount > 0 && failureCount == 0)
+            {
+                Haptics.Success();
+            }
+            else if (successCount == 0 && failureCount > 0)
+            {
+                Haptics.Error();
+            }
+            else
+            {
+                Haptics.Confirm();
+            }
+        }
+
         isLegalizing = false;
         legalizationStatusText = string.Empty;
         legalizationPercent = 0;

--- a/Pkmds.Rcl/Components/MainTabPages/MysteryGiftDatabaseTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/MysteryGiftDatabaseTab.razor
@@ -27,10 +27,11 @@
                       @bind-Value:after="@OnSortOrFilterChanged"
                       Clearable/>
 
-        <MudSwitch @bind-Value="@ShinyOnly"
+        <MudSwitch T="@bool"
+                   Value="@ShinyOnly"
                    Color="@Color.Primary"
                    Label="Shiny only"
-                   @bind-Value:after="@OnSortOrFilterChanged"/>
+                   ValueChanged="@(v => { Haptics.Tap(); ShinyOnly = v; OnSortOrFilterChanged(); })"/>
 
     </MudStack>
 

--- a/Pkmds.Rcl/Components/MainTabPages/PokedexTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/PokedexTab.razor
@@ -80,6 +80,7 @@
                     break;
                 case SAV5 sav5:
                     <MudStack Row
+                              Wrap="@Wrap.Wrap"
                               AlignItems="AlignItems.Center">
                         <HapticCheckBox Label="National Mode Unlocked"
                                         T="@bool"
@@ -93,6 +94,7 @@
                     break;
                 case SAV6XY sav6Xy:
                     <MudStack Row
+                              Wrap="@Wrap.Wrap"
                               AlignItems="AlignItems.Center">
                         <HapticCheckBox Label="National Mode Unlocked"
                                         T="@bool"
@@ -106,6 +108,7 @@
                     break;
                 case SAV6AO sav6Ao:
                     <MudStack Row
+                              Wrap="@Wrap.Wrap"
                               AlignItems="AlignItems.Center">
                         <HapticCheckBox Label="National Mode Unlocked"
                                         T="@bool"

--- a/Pkmds.Rcl/Components/MainTabPages/PokedexTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/PokedexTab.razor
@@ -72,67 +72,67 @@
                 case SAV3 sav3:
                     <MudStack Row
                               AlignItems="AlignItems.Center">
-                        <MudCheckBox Label="National Mode Unlocked"
-                                     T="@bool"
-                                     Value="@sav3.NationalDex"
-                                     ValueChanged="@(v => sav3.NationalDex = v)"/>
+                        <HapticCheckBox Label="National Mode Unlocked"
+                                        T="@bool"
+                                        Value="@sav3.NationalDex"
+                                        ValueChanged="@(v => sav3.NationalDex = v)"/>
                     </MudStack>
                     break;
                 case SAV5 sav5:
                     <MudStack Row
                               AlignItems="AlignItems.Center">
-                        <MudCheckBox Label="National Mode Unlocked"
-                                     T="@bool"
-                                     Value="@sav5.Zukan.IsNationalDexUnlocked"
-                                     ValueChanged="@(v => sav5.Zukan.IsNationalDexUnlocked = v)"/>
-                        <MudCheckBox Label="National Mode Active"
-                                     T="@bool"
-                                     Value="@sav5.Zukan.IsNationalDexMode"
-                                     ValueChanged="@(v => sav5.Zukan.IsNationalDexMode = v)"/>
+                        <HapticCheckBox Label="National Mode Unlocked"
+                                        T="@bool"
+                                        Value="@sav5.Zukan.IsNationalDexUnlocked"
+                                        ValueChanged="@(v => sav5.Zukan.IsNationalDexUnlocked = v)"/>
+                        <HapticCheckBox Label="National Mode Active"
+                                        T="@bool"
+                                        Value="@sav5.Zukan.IsNationalDexMode"
+                                        ValueChanged="@(v => sav5.Zukan.IsNationalDexMode = v)"/>
                     </MudStack>
                     break;
                 case SAV6XY sav6Xy:
                     <MudStack Row
                               AlignItems="AlignItems.Center">
-                        <MudCheckBox Label="National Mode Unlocked"
-                                     T="@bool"
-                                     Value="@sav6Xy.Zukan.IsNationalDexUnlocked"
-                                     ValueChanged="@(v => sav6Xy.Zukan.IsNationalDexUnlocked = v)"/>
-                        <MudCheckBox Label="National Mode Active"
-                                     T="@bool"
-                                     Value="@sav6Xy.Zukan.IsNationalDexMode"
-                                     ValueChanged="@(v => sav6Xy.Zukan.IsNationalDexMode = v)"/>
+                        <HapticCheckBox Label="National Mode Unlocked"
+                                        T="@bool"
+                                        Value="@sav6Xy.Zukan.IsNationalDexUnlocked"
+                                        ValueChanged="@(v => sav6Xy.Zukan.IsNationalDexUnlocked = v)"/>
+                        <HapticCheckBox Label="National Mode Active"
+                                        T="@bool"
+                                        Value="@sav6Xy.Zukan.IsNationalDexMode"
+                                        ValueChanged="@(v => sav6Xy.Zukan.IsNationalDexMode = v)"/>
                     </MudStack>
                     break;
                 case SAV6AO sav6Ao:
                     <MudStack Row
                               AlignItems="AlignItems.Center">
-                        <MudCheckBox Label="National Mode Unlocked"
-                                     T="@bool"
-                                     Value="@sav6Ao.Zukan.IsNationalDexUnlocked"
-                                     ValueChanged="@(v => sav6Ao.Zukan.IsNationalDexUnlocked = v)"/>
-                        <MudCheckBox Label="National Mode Active"
-                                     T="@bool"
-                                     Value="@sav6Ao.Zukan.IsNationalDexMode"
-                                     ValueChanged="@(v => sav6Ao.Zukan.IsNationalDexMode = v)"/>
+                        <HapticCheckBox Label="National Mode Unlocked"
+                                        T="@bool"
+                                        Value="@sav6Ao.Zukan.IsNationalDexUnlocked"
+                                        ValueChanged="@(v => sav6Ao.Zukan.IsNationalDexUnlocked = v)"/>
+                        <HapticCheckBox Label="National Mode Active"
+                                        T="@bool"
+                                        Value="@sav6Ao.Zukan.IsNationalDexMode"
+                                        ValueChanged="@(v => sav6Ao.Zukan.IsNationalDexMode = v)"/>
                     </MudStack>
                     break;
                 case SAV7 sav7:
                     <MudStack Row
                               AlignItems="AlignItems.Center">
-                        <MudCheckBox Label="National Mode Unlocked"
-                                     T="@bool"
-                                     Value="@sav7.Zukan.NationalDex"
-                                     ValueChanged="@(v => sav7.Zukan.NationalDex = v)"/>
+                        <HapticCheckBox Label="National Mode Unlocked"
+                                        T="@bool"
+                                        Value="@sav7.Zukan.NationalDex"
+                                        ValueChanged="@(v => sav7.Zukan.NationalDex = v)"/>
                     </MudStack>
                     break;
                 case SAV8BS sav8Bs:
                     <MudStack Row
                               AlignItems="AlignItems.Center">
-                        <MudCheckBox Label="National Mode Unlocked"
-                                     T="@bool"
-                                     Value="@sav8Bs.Zukan.HasNationalDex"
-                                     ValueChanged="@(v => sav8Bs.Zukan.HasNationalDex = v)"/>
+                        <HapticCheckBox Label="National Mode Unlocked"
+                                        T="@bool"
+                                        Value="@sav8Bs.Zukan.HasNationalDex"
+                                        ValueChanged="@(v => sav8Bs.Zukan.HasNationalDex = v)"/>
                     </MudStack>
                     break;
                 case SAV9SV sav9Sv:

--- a/Pkmds.Rcl/Components/MainTabPages/PokemonBankTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/PokemonBankTab.razor
@@ -109,10 +109,11 @@
                           Clearable
                           Style="min-width: 220px;"/>
 
-            <MudSwitch @bind-Value="shinyOnly"
-                       @bind-Value:after="ApplyFilter"
+            <MudSwitch T="@bool"
+                       Value="@shinyOnly"
                        Color="@Color.Primary"
-                       Label="Shiny only"/>
+                       Label="Shiny only"
+                       ValueChanged="@(v => { Haptics.Tap(); shinyOnly = v; ApplyFilter(); })"/>
 
             @if (filteredEntries.Count != entries.Count)
             {

--- a/Pkmds.Rcl/Components/MainTabPages/TeamsTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TeamsTab.razor
@@ -34,7 +34,7 @@
                     <CardHeaderActions>
                         <MudSwitch T="bool"
                                    Value="@bbLocked"
-                                   ValueChanged="@(v => AppService.SetBattleBoxLocked(v))"
+                                   ValueChanged="@(v => { Haptics.Tap(); AppService.SetBattleBoxLocked(v); })"
                                    Color="@Color.Warning"
                                    Label="Locked"
                                    title="Toggle Battle Box lock"/>
@@ -105,14 +105,14 @@
                 <MudButton Variant="@Variant.Text"
                            Color="@Color.Primary"
                            StartIcon="@Icons.Material.Filled.LockOpen"
-                           OnClick="@(() => AppService.UnlockAllBattleTeams())"
+                           OnClick="@(() => { Haptics.Confirm(); AppService.UnlockAllBattleTeams(); })"
                            Size="@Size.Small">
                     Unlock All
                 </MudButton>
                 <MudButton Variant="@Variant.Text"
                            Color="@Color.Error"
                            StartIcon="@Icons.Material.Filled.DeleteSweep"
-                           OnClick="@(() => AppService.ClearAllBattleTeams())"
+                           OnClick="@(() => { Haptics.Confirm(); AppService.ClearAllBattleTeams(); })"
                            Size="@Size.Small">
                     Clear All
                 </MudButton>
@@ -144,7 +144,7 @@
                         <CardHeaderActions>
                             <MudSwitch T="bool"
                                        Value="@isLocked"
-                                       ValueChanged="@(v => AppService.SetBattleTeamLocked(teamIndex, v))"
+                                       ValueChanged="@(v => { Haptics.Tap(); AppService.SetBattleTeamLocked(teamIndex, v); })"
                                        Color="@Color.Warning"
                                        Label="Locked"
                                        title="Toggle team lock"/>

--- a/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor.cs
@@ -191,6 +191,7 @@ public partial class TradeSlot : RefreshAwareComponent
 
         DragDropService.StartDrag(Pokemon, OwnerSaveFile, BoxNumber, SlotNumber, IsPartySlot);
         e.DataTransfer.EffectAllowed = "move";
+        Haptics.Tap();
 
         // iOS Safari cancels a drag whose dragstart ends with an empty DataTransfer,
         // which is why long-press lifts the slot then the drag aborts. PokemonSlotComponent

--- a/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor.cs
@@ -491,6 +491,7 @@ public partial class TradeTab : RefreshAwareComponent
             }
 
             MarkSlotBDirtyIfInvolved(srcSave, destSave);
+            Haptics.Confirm();
             RefreshService.Refresh();
             return;
         }
@@ -624,6 +625,7 @@ public partial class TradeTab : RefreshAwareComponent
         }
 
         MarkSlotBDirtyIfInvolved(srcSave, destSave);
+        Haptics.Confirm();
         RefreshService.Refresh();
     }
 

--- a/Pkmds.Rcl/Components/MarkingComponent.razor.cs
+++ b/Pkmds.Rcl/Components/MarkingComponent.razor.cs
@@ -33,5 +33,14 @@ public partial class MarkingComponent
             _ => string.Empty
         }}";
 
-    private void Toggle() => Pokemon?.ToggleMarking((int)Shape);
+    private void Toggle()
+    {
+        if (Pokemon is null)
+        {
+            return;
+        }
+
+        Haptics.Tap();
+        Pokemon.ToggleMarking((int)Shape);
+    }
 }

--- a/Pkmds.Rcl/Components/PokemonSlotComponent.razor.cs
+++ b/Pkmds.Rcl/Components/PokemonSlotComponent.razor.cs
@@ -282,6 +282,7 @@ public partial class PokemonSlotComponent : IDisposable
 
         DragDropService.StartDrag(Pokemon, BoxNumber, SlotNumber, IsPartySlot);
         e.DataTransfer.EffectAllowed = "copyMove";
+        Haptics.Tap();
 
         // Set drag-out data so the PKM file can be dragged to the OS desktop (Chrome/Edge only).
         // Uses IJSInProcessRuntime for a synchronous call — required because dataTransfer can only
@@ -413,6 +414,7 @@ public partial class PokemonSlotComponent : IDisposable
         AppService.ClearSelection();
 
         DragDropService.ClearDrag();
+        Haptics.Confirm();
         StateHasChanged();
     }
 
@@ -528,6 +530,7 @@ public partial class PokemonSlotComponent : IDisposable
             Snackbar.Add(
                 $"Successfully imported {AppService.GetPokemonSpeciesName(pokemon.Species) ?? "Pokémon"} from {fileName}",
                 Severity.Success);
+            Haptics.Success();
         }
         catch (Exception ex)
         {

--- a/Pkmds.Rcl/IAppState.cs
+++ b/Pkmds.Rcl/IAppState.cs
@@ -160,4 +160,11 @@ public interface IAppState
 
     /// <summary>Whether to render the red "illegal" indicator on slots.</summary>
     bool ShowIllegalIndicator { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether haptic feedback is enabled for key interactions.
+    /// No effect on devices without <c>navigator.vibrate</c> (notably iOS Safari).
+    /// Persisted across sessions via localStorage.
+    /// </summary>
+    bool HapticsEnabled { get; set; }
 }

--- a/Pkmds.Rcl/Models/AppSettings.cs
+++ b/Pkmds.Rcl/Models/AppSettings.cs
@@ -72,4 +72,11 @@ public record AppSettings
     /// Whether to show the red "illegal" indicator on box/party slots.
     /// </summary>
     public bool ShowIllegalIndicator { get; init; } = true;
+
+    /// <summary>
+    /// Whether to fire short haptic pulses (via the Vibration API) on key interactions —
+    /// drag lift / drop, save export, batch-legalize completion, and settings toggles.
+    /// Silently no-ops on devices without <c>navigator.vibrate</c> (notably iOS Safari).
+    /// </summary>
+    public bool HapticsEnabled { get; init; } = true;
 }

--- a/Pkmds.Rcl/Services/HapticService.cs
+++ b/Pkmds.Rcl/Services/HapticService.cs
@@ -1,0 +1,54 @@
+namespace Pkmds.Rcl.Services;
+
+/// <inheritdoc cref="IHapticService" />
+public sealed class HapticService(IJSRuntime jsRuntime, IAppState appState) : IHapticService
+{
+    public void Tap() => Vibrate(10);
+
+    public void Confirm() => Vibrate(20);
+
+    public void Success() => Vibrate([10, 40, 15]);
+
+    public void Error() => Vibrate([30, 30, 30, 30, 30]);
+
+    public void Vibrate(int milliseconds)
+    {
+        if (!appState.HapticsEnabled || milliseconds <= 0)
+        {
+            return;
+        }
+
+        Invoke(milliseconds);
+    }
+
+    public void Vibrate(int[] pattern)
+    {
+        if (!appState.HapticsEnabled || pattern.Length == 0)
+        {
+            return;
+        }
+
+        Invoke(pattern);
+    }
+
+    // Prefer IJSInProcessRuntime so dragstart handlers can fire haptics synchronously
+    // without awaiting — same pattern as setSlotDragMarker. Fire-and-forget on the async
+    // path so callers never have to await a haptic.
+    private void Invoke(object pattern)
+    {
+        try
+        {
+            if (jsRuntime is IJSInProcessRuntime inProcess)
+            {
+                inProcess.InvokeVoid("pkmdsHaptic", pattern);
+                return;
+            }
+
+            _ = jsRuntime.InvokeVoidAsync("pkmdsHaptic", pattern);
+        }
+        catch (JSException)
+        {
+            // Vibration failures are not user-visible and not worth surfacing.
+        }
+    }
+}

--- a/Pkmds.Rcl/Services/IHapticService.cs
+++ b/Pkmds.Rcl/Services/IHapticService.cs
@@ -1,0 +1,28 @@
+namespace Pkmds.Rcl.Services;
+
+/// <summary>
+/// Plays short haptic pulses via <c>navigator.vibrate</c> for key interactions
+/// (drag/drop, save export, batch legalize completion, settings toggles).
+/// Silently no-ops when the user has haptics disabled or when the platform doesn't
+/// implement the Vibration API (notably iOS Safari).
+/// </summary>
+public interface IHapticService
+{
+    /// <summary>Light tap — drag lift, slot tap, switch toggle.</summary>
+    void Tap();
+
+    /// <summary>Slightly longer tap — confirms a successful action (drop, button press).</summary>
+    void Confirm();
+
+    /// <summary>Double-pulse — successful completion of a multi-step action (export, legalize).</summary>
+    void Success();
+
+    /// <summary>Triple low pulse — a destructive or error condition.</summary>
+    void Error();
+
+    /// <summary>Plays an arbitrary pattern (single duration in ms or a pattern array).</summary>
+    void Vibrate(int milliseconds);
+
+    /// <summary>Plays an arbitrary pattern (alternating vibrate/pause durations in ms).</summary>
+    void Vibrate(int[] pattern);
+}

--- a/Pkmds.Rcl/Services/SettingsService.cs
+++ b/Pkmds.Rcl/Services/SettingsService.cs
@@ -107,6 +107,7 @@ public sealed class SettingsService(
         appState.ShowLegalIndicator = Settings.ShowLegalIndicator;
         appState.ShowFishyIndicator = Settings.ShowFishyIndicator;
         appState.ShowIllegalIndicator = Settings.ShowIllegalIndicator;
+        appState.HapticsEnabled = Settings.HapticsEnabled;
         loggingService.IsVerboseLoggingEnabled = Settings.IsVerboseLoggingEnabled;
     }
 }

--- a/Pkmds.Rcl/_Imports.razor
+++ b/Pkmds.Rcl/_Imports.razor
@@ -45,3 +45,4 @@
 @inject ILoggingService LoggingService
 @inject IDescriptionService DescriptionService
 @inject IDialogOptionsHelper DialogOptionsHelper
+@inject IHapticService Haptics

--- a/Pkmds.Rcl/wwwroot/js/fileSave.js
+++ b/Pkmds.Rcl/wwwroot/js/fileSave.js
@@ -69,6 +69,19 @@ window.setDragDownloadData = function (filename, base64data) {
     }
 };
 
+// Haptic feedback via the Vibration API. Android Chrome / Samsung / Firefox honour this;
+// iOS Safari doesn't implement navigator.vibrate at all, so this is a silent no-op there
+// (iOS still gets the system "lift" haptic from native HTML5 drag for free — see #770).
+// Caller passes either a duration in ms or an array pattern (e.g. [10, 30, 10]).
+window.pkmdsHaptic = function (pattern) {
+    if (!navigator || typeof navigator.vibrate !== 'function') return false;
+    try {
+        return navigator.vibrate(pattern);
+    } catch (e) {
+        return false;
+    }
+};
+
 // iOS Safari cancels a drag whose dragstart completes with an empty DataTransfer.
 // Set a minimal text/plain payload so the drag survives through to dragover/drop
 // on touch devices. Desktop browsers are unaffected — they ignore unused payloads.

--- a/Pkmds.Web/AppState.cs
+++ b/Pkmds.Web/AppState.cs
@@ -144,4 +144,7 @@ public record AppState : IAppState
 
     /// <inheritdoc />
     public bool ShowIllegalIndicator { get; set; } = true;
+
+    /// <inheritdoc />
+    public bool HapticsEnabled { get; set; } = true;
 }

--- a/Pkmds.Web/Program.cs
+++ b/Pkmds.Web/Program.cs
@@ -40,6 +40,7 @@ services
     .AddSingleton<IDragDropService, DragDropService>()
     .AddSingleton<ILoggingService, LoggingService>()
     .AddSingleton<ISettingsService, SettingsService>()
+    .AddSingleton<IHapticService, HapticService>()
     .AddSingleton(levelSwitch)
     .AddSingleton<JsService>()
     .AddSingleton<BlazorAesProvider>()


### PR DESCRIPTION
Closes #766.

## Summary
- Adds `IHapticService` (Tap / Confirm / Success / Error presets) backed by `navigator.vibrate` via a new `window.pkmdsHaptic` JS helper.
- Wires haptics into: drag lift, successful drop / file import, save file export and load, batch-legalize completion (success / error / mixed), Trade tab transfers, and settings switches (incl. Reset All and Clear App Cache).
- Adds a single on/off `HapticsEnabled` toggle in **Settings → UI → Haptic Feedback** (default on), persisted via the existing `AppSettings` / `SettingsService` chain.
- Silent no-op when the platform doesn't expose the Vibration API. Filed parking-spot follow-ups: #770 (iOS Safari) and #771 (desktop / laptop touchpads).

## Test plan
- [ ] On Android Chrome: drag a Pokémon between box slots — feel a tap on lift and a confirm pulse on drop.
- [ ] On Android Chrome: drag a `.pk*` file from the OS onto a slot — feel a success pulse after import.
- [ ] On Android Chrome: export the save file — feel a success pulse on completion.
- [ ] On Android Chrome: load a save file — feel a success pulse on completion.
- [ ] On Android Chrome: run a batch legality scan, then Legalize All — feel an appropriate completion pulse.
- [ ] On Android Chrome: open Settings, flip switches — feel a tap each time. Toggle Haptics off, confirm subsequent actions go silent.
- [ ] On iOS Safari and desktop: confirm everything still works and silently produces no haptics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)