### PR TITLE
feat: add individual and multi-select Pokémon to Bank

### DIFF
--- a/Pkmds.Rcl/Components/Dialogs/AddToBankDialog.razor
+++ b/Pkmds.Rcl/Components/Dialogs/AddToBankDialog.razor
@@ -1,0 +1,137 @@
+<MudDialog>
+    <TitleContent>
+        <MudText Typo="@Typo.h6">Add to Bank</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudStack Spacing="3">
+
+            @if (!isLetsGo)
+            {
+                <MudRadioGroup T="AddToBankDialog.AddToBankScope"
+                               @bind-Value="scope"
+                               @bind-Value:after="LoadCandidatesAsync"
+                               Disabled="@(isAdding || isLoading)">
+                    <MudRadio T="AddToBankDialog.AddToBankScope"
+                              Value="@AddToBankDialog.AddToBankScope.Party"
+                              Color="@Color.Primary">
+                        Party
+                    </MudRadio>
+                    <MudRadio T="AddToBankDialog.AddToBankScope"
+                              Value="@AddToBankDialog.AddToBankScope.CurrentBox"
+                              Color="@Color.Primary">
+                        Current Box
+                    </MudRadio>
+                    <MudRadio T="AddToBankDialog.AddToBankScope"
+                              Value="@AddToBankDialog.AddToBankScope.AllBoxes"
+                              Color="@Color.Primary">
+                        All Boxes
+                    </MudRadio>
+                </MudRadioGroup>
+            }
+
+            @if (isLoading)
+            {
+                <MudProgressCircular Indeterminate
+                                     Color="@Color.Primary"
+                                     Size="@Size.Small"/>
+            }
+            else if (candidates.Count == 0)
+            {
+                <MudText Typo="@Typo.body2"
+                         Color="@Color.Secondary">
+                    No Pokémon in this scope.
+                </MudText>
+            }
+            else
+            {
+                <MudStack Row
+                          AlignItems="@AlignItems.Center"
+                          Spacing="1">
+                    <MudButton Size="@Size.Small"
+                               OnClick="@(() => ToggleSelectAll(true))"
+                               Variant="@Variant.Text"
+                               Disabled="@isAdding">
+                        Select All
+                    </MudButton>
+                    <MudButton Size="@Size.Small"
+                               OnClick="@(() => ToggleSelectAll(false))"
+                               Variant="@Variant.Text"
+                               Disabled="@isAdding">
+                        Select None
+                    </MudButton>
+                    <MudSpacer/>
+                    <MudText Typo="@Typo.body2">@AddCount selected</MudText>
+                </MudStack>
+
+                <div style="max-height: 320px; overflow-y: auto;">
+                    @foreach (var c in candidates)
+                    {
+                        <MudStack Row
+                                  AlignItems="@AlignItems.Center"
+                                  Spacing="1"
+                                  Class="py-0">
+                            <MudCheckBox T="bool"
+                                         @bind-Value="c.IsSelected"
+                                         Disabled="@(isAdding || (skipDuplicates && c.IsDuplicate))"/>
+                            @if (c.Pokemon.IsShiny)
+                            {
+                                <MudText Typo="@Typo.body2">✨</MudText>
+                            }
+                            <MudText Typo="@Typo.body2">@c.SpeciesName</MudText>
+                            @if (c.IsParty)
+                            {
+                                <MudChip T="string"
+                                         Size="@Size.Small"
+                                         Color="@Color.Info"
+                                         Class="ml-1">
+                                    Party
+                                </MudChip>
+                            }
+                            @if (c.IsDuplicate)
+                            {
+                                <MudTooltip Text="Already in Bank">
+                                    <MudIcon Icon="@Icons.Material.Filled.Warning"
+                                             Color="@Color.Warning"
+                                             Size="@Size.Small"/>
+                                </MudTooltip>
+                            }
+                        </MudStack>
+                    }
+                </div>
+
+                <MudRadioGroup T="bool"
+                               @bind-Value="skipDuplicates"
+                               @bind-Value:after="OnSkipDuplicatesChanged"
+                               Disabled="@isAdding">
+                    <MudRadio T="bool"
+                              Value="true"
+                              Color="@Color.Primary">
+                        Skip duplicates
+                    </MudRadio>
+                    <MudRadio T="bool"
+                              Value="false"
+                              Color="@Color.Primary">
+                        Add duplicates anyway
+                    </MudRadio>
+                </MudRadioGroup>
+            }
+
+        </MudStack>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@Cancel"
+                   StartIcon="@Icons.Material.Filled.Clear"
+                   Variant="@Variant.Filled"
+                   Color="@Color.Default"
+                   Disabled="@isAdding">
+            Cancel
+        </MudButton>
+        <MudButton OnClick="@AddToBankAsync"
+                   StartIcon="@Icons.Material.Filled.AccountBalanceWallet"
+                   Variant="@Variant.Filled"
+                   Color="@Color.Primary"
+                   Disabled="@(isAdding || isLoading || AddCount == 0)">
+            Add @AddCount to Bank
+        </MudButton>
+    </DialogActions>
+</MudDialog>

--- a/Pkmds.Rcl/Components/Dialogs/AddToBankDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/AddToBankDialog.razor.cs
@@ -1,0 +1,220 @@
+namespace Pkmds.Rcl.Components.Dialogs;
+
+public partial class AddToBankDialog
+{
+    public enum AddToBankScope
+    {
+        Party,
+        CurrentBox,
+        AllBoxes
+    }
+
+    [CascadingParameter]
+    private IMudDialogInstance? MudDialog { get; set; }
+
+    [Inject]
+    private IBankService BankService { get; set; } = null!;
+
+    private AddToBankScope scope = AddToBankScope.CurrentBox;
+    private bool skipDuplicates = true;
+    private bool isAdding;
+    private bool isLoading = true;
+    private bool isLetsGo;
+    private List<CandidateItem> candidates = [];
+
+    private int AddCount => skipDuplicates
+        ? candidates.Count(c => c.IsSelected && !c.IsDuplicate)
+        : candidates.Count(c => c.IsSelected);
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (AppState.SaveFile is not { } saveFile)
+        {
+            isLoading = false;
+            return;
+        }
+
+        isLetsGo = saveFile is SAV7b;
+        await LoadCandidatesAsync();
+    }
+
+    private async Task LoadCandidatesAsync()
+    {
+        if (AppState.SaveFile is not { } saveFile)
+        {
+            isLoading = false;
+            return;
+        }
+
+        isLoading = true;
+        StateHasChanged();
+
+        var pokemon = CollectPokemon(saveFile);
+
+        var (_, duplicates) = await BankService.PartitionDuplicatesAsync(
+            pokemon.Select(p => p.Pokemon));
+
+        var duplicateSet = new HashSet<PKM>(ReferenceEqualityComparer.Instance);
+        foreach (var d in duplicates)
+        {
+            duplicateSet.Add(d);
+        }
+
+        candidates = pokemon.Select(p => new CandidateItem
+        {
+            Pokemon = p.Pokemon,
+            IsParty = p.IsParty,
+            SpeciesName = AppService.GetPokemonSpeciesName(p.Pokemon.Species)
+                          ?? p.Pokemon.Species.ToString(CultureInfo.InvariantCulture),
+            IsDuplicate = duplicateSet.Contains(p.Pokemon),
+            IsSelected = true,
+        }).ToList();
+
+        if (skipDuplicates)
+        {
+            foreach (var c in candidates.Where(c => c.IsDuplicate))
+            {
+                c.IsSelected = false;
+            }
+        }
+
+        isLoading = false;
+    }
+
+    private List<(PKM Pokemon, bool IsParty)> CollectPokemon(SaveFile saveFile)
+    {
+        var result = new List<(PKM, bool)>();
+
+        if (saveFile is SAV7b lgsave)
+        {
+            var count = 0;
+            foreach (var pkm in lgsave.BoxData)
+            {
+                if (pkm.Species != 0)
+                {
+                    var flags = lgsave.GetBoxSlotFlags(0, count);
+                    var isParty = flags.IsParty() >= 0;
+                    result.Add((pkm, isParty));
+                }
+
+                count++;
+            }
+
+            return result;
+        }
+
+        if (scope is AddToBankScope.Party)
+        {
+            for (var i = 0; i < saveFile.PartyCount; i++)
+            {
+                var pkm = saveFile.GetPartySlotAtIndex(i);
+                if (pkm.Species != 0)
+                {
+                    result.Add((pkm, true));
+                }
+            }
+
+            return result;
+        }
+
+        var boxes = scope switch
+        {
+            AddToBankScope.CurrentBox => new[] { AppState.BoxEdit?.CurrentBox ?? saveFile.CurrentBox },
+            AddToBankScope.AllBoxes => Enumerable.Range(0, saveFile.BoxCount).ToArray(),
+            _ => Array.Empty<int>()
+        };
+
+        foreach (var box in boxes)
+        {
+            for (var slot = 0; slot < saveFile.BoxSlotCount; slot++)
+            {
+                var pkm = saveFile.GetBoxSlotAtIndex(box, slot);
+                if (pkm.Species != 0)
+                {
+                    result.Add((pkm, false));
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private void ToggleSelectAll(bool select)
+    {
+        foreach (var c in candidates)
+        {
+            if (!select || !skipDuplicates || !c.IsDuplicate)
+            {
+                c.IsSelected = select;
+            }
+        }
+    }
+
+    private void OnSkipDuplicatesChanged()
+    {
+        foreach (var c in candidates.Where(c => c.IsDuplicate))
+        {
+            c.IsSelected = !skipDuplicates;
+        }
+    }
+
+    private async Task AddToBankAsync()
+    {
+        if (AppState.SaveFile is not { } saveFile)
+        {
+            return;
+        }
+
+        var toAdd = (skipDuplicates
+                ? candidates.Where(c => c.IsSelected && !c.IsDuplicate)
+                : candidates.Where(c => c.IsSelected))
+            .Select(c => c.Pokemon)
+            .ToList();
+
+        if (toAdd.Count == 0)
+        {
+            Snackbar.Add("No Pokémon selected.", Severity.Warning);
+            return;
+        }
+
+        isAdding = true;
+        StateHasChanged();
+
+        try
+        {
+            var tid = saveFile.DisplayTID.ToString(AppService.GetIdFormatString());
+            var gameName = SaveFileNameDisplay.FriendlyGameName(saveFile.Version);
+            var sourceSave = $"{saveFile.OT} ({tid}, {gameName})";
+
+            await BankService.AddRangeAsync(toAdd, sourceSave: sourceSave);
+
+            var dupeCount = skipDuplicates
+                ? 0
+                : candidates.Count(c => c.IsSelected && c.IsDuplicate);
+
+            var msg = $"{toAdd.Count} Pokémon added to Bank.";
+            if (dupeCount > 0)
+            {
+                msg += $" ({dupeCount} duplicate{(dupeCount == 1 ? string.Empty : "s")} included.)";
+            }
+
+            Snackbar.Add(msg, Severity.Success);
+            MudDialog?.Close(DialogResult.Ok(toAdd.Count));
+        }
+        finally
+        {
+            isAdding = false;
+        }
+    }
+
+    private void Cancel() => MudDialog?.Close(DialogResult.Cancel());
+
+    private sealed class CandidateItem
+    {
+        public required PKM Pokemon { get; init; }
+        public required string SpeciesName { get; init; }
+        public required bool IsParty { get; init; }
+        public bool IsDuplicate { get; init; }
+        public bool IsSelected { get; set; }
+    }
+}

--- a/Pkmds.Rcl/Components/EditForms/PokemonEditForm.razor
+++ b/Pkmds.Rcl/Components/EditForms/PokemonEditForm.razor
@@ -42,6 +42,18 @@
                 Save
             </MudButton>
 
+            <MudButton OnClick="@AddToBankAsync"
+                       ButtonType="@ButtonType.Button"
+                       Variant="@Variant.Filled"
+                       StartIcon="@Icons.Material.Filled.AccountBalanceWallet"
+                       Class="my-2"
+                       Color="@Color.Default"
+                       Size="@Size.Small"
+                       title="Add Pokémon to Bank"
+                       Disabled="@(Pokemon.Species.IsInvalidSpecies())">
+                Bank
+            </MudButton>
+
             <MudButton OnClick="@OnClickCopy"
                        ButtonType="@ButtonType.Button"
                        Variant="@Variant.Filled"

--- a/Pkmds.Rcl/Components/EditForms/PokemonEditForm.razor.cs
+++ b/Pkmds.Rcl/Components/EditForms/PokemonEditForm.razor.cs
@@ -6,6 +6,9 @@ public partial class PokemonEditForm : IDisposable
     [EditorRequired]
     public PKM? Pokemon { get; set; }
 
+    [Inject]
+    private IBankService BankService { get; set; } = null!;
+
     private LegalityAnalysis? Analysis { get; set; }
 
     public void Dispose() =>
@@ -64,6 +67,87 @@ public partial class PokemonEditForm : IDisposable
             "Import from Showdown / PokePaste",
             new DialogParameters<ShowdownImportDialog>(),
             options);
+    }
+
+    private async Task AddToBankAsync()
+    {
+        if (Pokemon is null || Pokemon.Species.IsInvalidSpecies() || AppState.SaveFile is not { } saveFile)
+        {
+            return;
+        }
+
+        if (HasUnsavedChanges(saveFile))
+        {
+            var save = await DialogService.ShowMessageBoxAsync(
+                "Unsaved Changes",
+                "This Pokémon has unsaved changes. Save before adding to the Bank?",
+                yesText: "Save & Bank",
+                cancelText: "Cancel");
+
+            if (save is not true)
+            {
+                return;
+            }
+
+            AppService.SavePokemon(Pokemon);
+        }
+
+        var isDuplicate = await BankService.IsDuplicateAsync(Pokemon);
+        if (isDuplicate)
+        {
+            var addAnyway = await DialogService.ShowMessageBoxAsync(
+                "Already in Bank",
+                "This Pokémon is already in the Bank. Add it again?",
+                yesText: "Add Again",
+                cancelText: "Cancel");
+
+            if (addAnyway is not true)
+            {
+                return;
+            }
+        }
+
+        var tid = saveFile.DisplayTID.ToString(AppService.GetIdFormatString());
+        var gameName = SaveFileNameDisplay.FriendlyGameName(saveFile.Version);
+        var sourceSave = $"{saveFile.OT} ({tid}, {gameName})";
+
+        await BankService.AddAsync(Pokemon, sourceSave: sourceSave);
+
+        var speciesName = AppService.GetPokemonSpeciesName(Pokemon.Species)
+                          ?? Pokemon.Species.ToString(CultureInfo.InvariantCulture);
+        Snackbar.Add($"{speciesName} added to Bank.", Severity.Success);
+    }
+
+    private bool HasUnsavedChanges(SaveFile saveFile)
+    {
+        if (Pokemon is null)
+        {
+            return false;
+        }
+
+        var selectedPokemonType = AppService.GetSelectedPokemonSlot(out var partySlot, out var boxNumber, out var boxSlot);
+
+        PKM? slotPokemon = selectedPokemonType switch
+        {
+            SelectedPokemonType.Party => saveFile.GetPartySlotAtIndex(partySlot),
+            SelectedPokemonType.Box => saveFile.GetBoxSlotAtIndex(boxNumber, boxSlot),
+            SelectedPokemonType.None when saveFile is SAV7b && AppState.SelectedBoxSlotNumber is { } lgSlot =>
+                saveFile.GetBoxSlotAtIndex(lgSlot / saveFile.BoxSlotCount, lgSlot % saveFile.BoxSlotCount),
+            _ => null
+        };
+
+        if (slotPokemon is null || Pokemon.SIZE_STORED != slotPokemon.SIZE_STORED)
+        {
+            return false;
+        }
+
+        var editedBytes = new byte[Pokemon.SIZE_STORED];
+        Pokemon.WriteDecryptedDataStored(editedBytes);
+
+        var slotBytes = new byte[slotPokemon.SIZE_STORED];
+        slotPokemon.WriteDecryptedDataStored(slotBytes);
+
+        return !editedBytes.AsSpan().SequenceEqual(slotBytes);
     }
 
     private void SaveAndClose()

--- a/Pkmds.Rcl/Components/PokemonStorageComponent.razor
+++ b/Pkmds.Rcl/Components/PokemonStorageComponent.razor
@@ -9,6 +9,15 @@
 
     @if (saveFile.Version is GameVersion.LG or GameVersion.GP or GameVersion.GE)
     {
+        <div class="flex flex-wrap mx-[5px] mb-[5px] px-[5px] items-center">
+            <MudIconButton OnClick="@OpenAddToBankDialogAsync"
+                           title="Add to Bank…"
+                           ButtonType="@ButtonType.Button"
+                           Icon="@Icons.Material.Filled.AccountBalanceWallet"
+                           Variant="@Variant.Filled"
+                           Class="m-1.5 p-1.5">
+            </MudIconButton>
+        </div>
         <LetsGoBoxComponent/>
     }
     else
@@ -123,6 +132,14 @@
                            Icon="@(AppState.PinnedBoxNumber == boxEdit.CurrentBox
                                      ? Icons.Material.Filled.PushPin
                                      : Icons.Material.Outlined.PushPin)"
+                           Variant="@Variant.Filled"
+                           Class="m-1.5 p-1.5">
+            </MudIconButton>
+
+            <MudIconButton OnClick="@OpenAddToBankDialogAsync"
+                           title="Add to Bank…"
+                           ButtonType="@ButtonType.Button"
+                           Icon="@Icons.Material.Filled.AccountBalanceWallet"
                            Variant="@Variant.Filled"
                            Class="m-1.5 p-1.5">
             </MudIconButton>

--- a/Pkmds.Rcl/Components/PokemonStorageComponent.razor.cs
+++ b/Pkmds.Rcl/Components/PokemonStorageComponent.razor.cs
@@ -180,6 +180,57 @@ public partial class PokemonStorageComponent : RefreshAwareComponent
         await DialogService.ShowAsync<BoxListDialog>("All Boxes", options);
     }
 
+    private async Task OpenAddToBankDialogAsync()
+    {
+        if (AppService.EditFormPokemon is { Species: > 0 } editedPkm && AppState.SaveFile is { } sav
+            && HasUnsavedEditFormChanges(editedPkm, sav))
+        {
+            var save = await DialogService.ShowMessageBoxAsync(
+                "Unsaved Changes",
+                "The open Pokémon has unsaved changes. Save before opening the Bank dialog?",
+                yesText: "Save & Continue",
+                cancelText: "Cancel");
+
+            if (save is not true)
+            {
+                return;
+            }
+
+            AppService.SavePokemon(editedPkm);
+        }
+
+        var options = await DialogOptionsHelper.BuildAsync(MaxWidth.Small);
+        await DialogService.ShowAsync<AddToBankDialog>("Add to Bank", options);
+    }
+
+    private bool HasUnsavedEditFormChanges(PKM editedPkm, SaveFile saveFile)
+    {
+        var selectedPokemonType =
+            AppService.GetSelectedPokemonSlot(out var partySlot, out var boxNumber, out var boxSlot);
+
+        PKM? slotPokemon = selectedPokemonType switch
+        {
+            SelectedPokemonType.Party => saveFile.GetPartySlotAtIndex(partySlot),
+            SelectedPokemonType.Box => saveFile.GetBoxSlotAtIndex(boxNumber, boxSlot),
+            SelectedPokemonType.None when saveFile is SAV7b && AppState.SelectedBoxSlotNumber is { } lgSlot =>
+                saveFile.GetBoxSlotAtIndex(lgSlot / saveFile.BoxSlotCount, lgSlot % saveFile.BoxSlotCount),
+            _ => null
+        };
+
+        if (slotPokemon is null || editedPkm.SIZE_STORED != slotPokemon.SIZE_STORED)
+        {
+            return false;
+        }
+
+        var editedBytes = new byte[editedPkm.SIZE_STORED];
+        editedPkm.WriteDecryptedDataStored(editedBytes);
+
+        var slotBytes = new byte[slotPokemon.SIZE_STORED];
+        slotPokemon.WriteDecryptedDataStored(slotBytes);
+
+        return !editedBytes.AsSpan().SequenceEqual(slotBytes);
+    }
+
     private async Task LegalizeBoxAsync()
     {
         if (AppState.SaveFile is not { } saveFile || AppState.BoxEdit is not { } boxEdit)

--- a/Pkmds.Rcl/wwwroot/css/tailwind.css
+++ b/Pkmds.Rcl/wwwroot/css/tailwind.css
@@ -1,791 +1,655 @@
 /*! tailwindcss v4.0.11 | MIT License | https://tailwindcss.com */
 @layer theme, base, components, utilities;
 @layer theme {
-    :root, :host {
-        --font-sans: ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
-        'Noto Color Emoji';
-        --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
-        monospace;
-        --color-red-500: oklch(0.637 0.237 25.331);
-        --color-blue-500: oklch(0.623 0.214 259.815);
-        --color-gray-300: oklch(0.872 0.01 258.338);
-        --color-gray-500: oklch(0.551 0.027 264.364);
-        --color-black: #000;
-        --spacing: 0.25rem;
-        --default-font-family: var(--font-sans);
-        --default-font-feature-settings: var(--font-sans--font-feature-settings);
-        --default-font-variation-settings: var(--font-sans--font-variation-settings);
-        --default-mono-font-family: var(--font-mono);
-        --default-mono-font-feature-settings: var(--font-mono--font-feature-settings);
-        --default-mono-font-variation-settings: var(--font-mono--font-variation-settings);
-    }
+  :root, :host {
+    --font-sans: ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
+    'Noto Color Emoji';
+    --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+    monospace;
+    --color-red-500: oklch(0.637 0.237 25.331);
+    --color-blue-500: oklch(0.623 0.214 259.815);
+    --color-gray-300: oklch(0.872 0.01 258.338);
+    --color-gray-500: oklch(0.551 0.027 264.364);
+    --color-black: #000;
+    --spacing: 0.25rem;
+    --default-transition-duration: 150ms;
+    --default-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    --default-font-family: var(--font-sans);
+    --default-font-feature-settings: var(--font-sans--font-feature-settings);
+    --default-font-variation-settings: var(--font-sans--font-variation-settings);
+    --default-mono-font-family: var(--font-mono);
+    --default-mono-font-feature-settings: var(--font-mono--font-feature-settings);
+    --default-mono-font-variation-settings: var(--font-mono--font-variation-settings);
+  }
 }
 @layer base {
-    *, ::after, ::before, ::backdrop, ::file-selector-button {
-        box-sizing: border-box;
-        margin: 0;
-        padding: 0;
-        border: 0 solid;
-    }
-
-    html, :host {
-        line-height: 1.5;
-        -webkit-text-size-adjust: 100%;
-        tab-size: 4;
-        font-family: var(--default-font-family, ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji');
-        font-feature-settings: var(--default-font-feature-settings, normal);
-        font-variation-settings: var(--default-font-variation-settings, normal);
-        -webkit-tap-highlight-color: transparent;
-    }
-
-    body {
-        line-height: inherit;
-    }
-
-    hr {
-        height: 0;
-        color: inherit;
-        border-top-width: 1px;
-    }
-
-    abbr:where([title]) {
-        -webkit-text-decoration: underline dotted;
-        text-decoration: underline dotted;
-    }
-
-    h1, h2, h3, h4, h5, h6 {
-        font-size: inherit;
-        font-weight: inherit;
-    }
-
-    a {
-        color: inherit;
-        -webkit-text-decoration: inherit;
-        text-decoration: inherit;
-    }
-
-    b, strong {
-        font-weight: bolder;
-    }
-
-    code, kbd, samp, pre {
-        font-family: var(--default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace);
-        font-feature-settings: var(--default-mono-font-feature-settings, normal);
-        font-variation-settings: var(--default-mono-font-variation-settings, normal);
-        font-size: 1em;
-    }
-
-    small {
-        font-size: 80%;
-    }
-
-    sub, sup {
-        font-size: 75%;
-        line-height: 0;
-        position: relative;
-        vertical-align: baseline;
-    }
-
-    sub {
-        bottom: -0.25em;
-    }
-
-    sup {
-        top: -0.5em;
-    }
-
-    table {
-        text-indent: 0;
-        border-color: inherit;
-        border-collapse: collapse;
-    }
-
-    :-moz-focusring {
-        outline: auto;
-    }
-
-    progress {
-        vertical-align: baseline;
-    }
-
-    summary {
-        display: list-item;
-    }
-
-    ol, ul, menu {
-        list-style: none;
-    }
-
-    img, svg, video, canvas, audio, iframe, embed, object {
-        display: block;
-        vertical-align: middle;
-    }
-
-    img, video {
-        max-width: 100%;
-        height: auto;
-    }
-
-    button, input, select, optgroup, textarea, ::file-selector-button {
-        font: inherit;
-        font-feature-settings: inherit;
-        font-variation-settings: inherit;
-        letter-spacing: inherit;
-        color: inherit;
-        border-radius: 0;
-        background-color: transparent;
-        opacity: 1;
-    }
-
-    :where(select:is([multiple], [size])) optgroup {
-        font-weight: bolder;
-    }
-
-    :where(select:is([multiple], [size])) optgroup option {
-        padding-inline-start: 20px;
-    }
-
-    ::file-selector-button {
-        margin-inline-end: 4px;
-    }
-
-    ::placeholder {
-        opacity: 1;
-        color: color-mix(in oklab, currentColor 50%, transparent);
-    }
-
-    textarea {
-        resize: vertical;
-    }
-
-    ::-webkit-search-decoration {
-        -webkit-appearance: none;
-    }
-
-    ::-webkit-date-and-time-value {
-        min-height: 1lh;
-        text-align: inherit;
-    }
-
-    ::-webkit-datetime-edit {
-        display: inline-flex;
-    }
-
-    ::-webkit-datetime-edit-fields-wrapper {
-        padding: 0;
-    }
-
-    ::-webkit-datetime-edit, ::-webkit-datetime-edit-year-field, ::-webkit-datetime-edit-month-field, ::-webkit-datetime-edit-day-field, ::-webkit-datetime-edit-hour-field, ::-webkit-datetime-edit-minute-field, ::-webkit-datetime-edit-second-field, ::-webkit-datetime-edit-millisecond-field, ::-webkit-datetime-edit-meridiem-field {
-        padding-block: 0;
-    }
-
-    :-moz-ui-invalid {
-        box-shadow: none;
-    }
-
-    button, input:where([type='button'], [type='reset'], [type='submit']), ::file-selector-button {
-        appearance: button;
-    }
-
-    ::-webkit-inner-spin-button, ::-webkit-outer-spin-button {
-        height: auto;
-    }
-
-    [hidden]:where(:not([hidden='until-found'])) {
-        display: none !important;
-    }
+  *, ::after, ::before, ::backdrop, ::file-selector-button {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    border: 0 solid;
+  }
+  html, :host {
+    line-height: 1.5;
+    -webkit-text-size-adjust: 100%;
+    tab-size: 4;
+    font-family: var( --default-font-family, ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji' );
+    font-feature-settings: var(--default-font-feature-settings, normal);
+    font-variation-settings: var(--default-font-variation-settings, normal);
+    -webkit-tap-highlight-color: transparent;
+  }
+  body {
+    line-height: inherit;
+  }
+  hr {
+    height: 0;
+    color: inherit;
+    border-top-width: 1px;
+  }
+  abbr:where([title]) {
+    -webkit-text-decoration: underline dotted;
+    text-decoration: underline dotted;
+  }
+  h1, h2, h3, h4, h5, h6 {
+    font-size: inherit;
+    font-weight: inherit;
+  }
+  a {
+    color: inherit;
+    -webkit-text-decoration: inherit;
+    text-decoration: inherit;
+  }
+  b, strong {
+    font-weight: bolder;
+  }
+  code, kbd, samp, pre {
+    font-family: var( --default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace );
+    font-feature-settings: var(--default-mono-font-feature-settings, normal);
+    font-variation-settings: var(--default-mono-font-variation-settings, normal);
+    font-size: 1em;
+  }
+  small {
+    font-size: 80%;
+  }
+  sub, sup {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
+  sub {
+    bottom: -0.25em;
+  }
+  sup {
+    top: -0.5em;
+  }
+  table {
+    text-indent: 0;
+    border-color: inherit;
+    border-collapse: collapse;
+  }
+  :-moz-focusring {
+    outline: auto;
+  }
+  progress {
+    vertical-align: baseline;
+  }
+  summary {
+    display: list-item;
+  }
+  ol, ul, menu {
+    list-style: none;
+  }
+  img, svg, video, canvas, audio, iframe, embed, object {
+    display: block;
+    vertical-align: middle;
+  }
+  img, video {
+    max-width: 100%;
+    height: auto;
+  }
+  button, input, select, optgroup, textarea, ::file-selector-button {
+    font: inherit;
+    font-feature-settings: inherit;
+    font-variation-settings: inherit;
+    letter-spacing: inherit;
+    color: inherit;
+    border-radius: 0;
+    background-color: transparent;
+    opacity: 1;
+  }
+  :where(select:is([multiple], [size])) optgroup {
+    font-weight: bolder;
+  }
+  :where(select:is([multiple], [size])) optgroup option {
+    padding-inline-start: 20px;
+  }
+  ::file-selector-button {
+    margin-inline-end: 4px;
+  }
+  ::placeholder {
+    opacity: 1;
+    color: color-mix(in oklab, currentColor 50%, transparent);
+  }
+  textarea {
+    resize: vertical;
+  }
+  ::-webkit-search-decoration {
+    -webkit-appearance: none;
+  }
+  ::-webkit-date-and-time-value {
+    min-height: 1lh;
+    text-align: inherit;
+  }
+  ::-webkit-datetime-edit {
+    display: inline-flex;
+  }
+  ::-webkit-datetime-edit-fields-wrapper {
+    padding: 0;
+  }
+  ::-webkit-datetime-edit, ::-webkit-datetime-edit-year-field, ::-webkit-datetime-edit-month-field, ::-webkit-datetime-edit-day-field, ::-webkit-datetime-edit-hour-field, ::-webkit-datetime-edit-minute-field, ::-webkit-datetime-edit-second-field, ::-webkit-datetime-edit-millisecond-field, ::-webkit-datetime-edit-meridiem-field {
+    padding-block: 0;
+  }
+  :-moz-ui-invalid {
+    box-shadow: none;
+  }
+  button, input:where([type='button'], [type='reset'], [type='submit']), ::file-selector-button {
+    appearance: button;
+  }
+  ::-webkit-inner-spin-button, ::-webkit-outer-spin-button {
+    height: auto;
+  }
+  [hidden]:where(:not([hidden='until-found'])) {
+    display: none !important;
+  }
 }
 @layer utilities {
-    .invisible {
-        visibility: hidden;
-    }
-
-    .visible {
-        visibility: visible;
-    }
-
-    .fixed {
-        position: fixed;
-    }
-
-    .relative {
-        position: relative;
-    }
-
-    .static {
-        position: static;
-    }
-
-    .sticky {
-        position: sticky;
-    }
-
-    .container {
-        width: 100%;
-        @media (width >= 40rem) {
-            max-width: 40rem;
-        }
-        @media (width >= 48rem) {
-            max-width: 48rem;
-        }
-        @media (width >= 64rem) {
-            max-width: 64rem;
-        }
-        @media (width >= 80rem) {
-            max-width: 80rem;
-        }
-        @media (width >= 96rem) {
-            max-width: 96rem;
-        }
-    }
-
-    .m-1\.5 {
-        margin: calc(var(--spacing) * 1.5);
-    }
-
-    .m-\[5px\] {
-        margin: 5px;
-    }
-
-    .mx-2 {
-        margin-inline: calc(var(--spacing) * 2);
-    }
-
-    .mx-3 {
-        margin-inline: calc(var(--spacing) * 3);
-    }
-
-    .mx-auto {
-        margin-inline: auto;
-    }
-
-    .my-2 {
-        margin-block: calc(var(--spacing) * 2);
-    }
-
-    .my-3 {
-        margin-block: calc(var(--spacing) * 3);
-    }
-
-    .ms-2 {
-        margin-inline-start: calc(var(--spacing) * 2);
-    }
-
-    .ms-auto {
-        margin-inline-start: auto;
-    }
-
-    .mt-1 {
-        margin-top: calc(var(--spacing) * 1);
-    }
-
-    .mt-2 {
-        margin-top: calc(var(--spacing) * 2);
-    }
-
-    .mt-3 {
-        margin-top: calc(var(--spacing) * 3);
-    }
-
-    .mt-4 {
-        margin-top: calc(var(--spacing) * 4);
-    }
-
-    .mt-8 {
-        margin-top: calc(var(--spacing) * 8);
-    }
-
-    .mr-2 {
-        margin-right: calc(var(--spacing) * 2);
-    }
-
-    .mb-1 {
-        margin-bottom: calc(var(--spacing) * 1);
-    }
-
-    .mb-2 {
-        margin-bottom: calc(var(--spacing) * 2);
-    }
-
-    .mb-3 {
-        margin-bottom: calc(var(--spacing) * 3);
-    }
-
-    .box-border {
-        box-sizing: border-box;
-    }
-
-    .block {
-        display: block;
-    }
-
-    .flex {
-        display: flex;
-    }
-
-    .grid {
-        display: grid;
-    }
-
-    .hidden {
-        display: none;
-    }
-
-    .inline {
-        display: inline;
-    }
-
-    .table {
-        display: table;
-    }
-
-    .aspect-\[6\/1\] {
-        aspect-ratio: 6/1;
-    }
-
-    .aspect-\[6\/5\] {
-        aspect-ratio: 6/5;
-    }
-
-    .aspect-square {
-        aspect-ratio: 1 / 1;
-    }
-
-    .h-\[50px\] {
-        height: 50px;
-    }
-
-    .h-\[398px\] {
-        height: 398px;
-    }
-
-    .h-\[400px\] {
-        height: 400px;
-    }
-
-    .h-auto {
-        height: auto;
-    }
-
-    .h-full {
-        height: 100%;
-    }
-
-    .w-80 {
-        width: calc(var(--spacing) * 80);
-    }
-
-    .w-\[100px\] {
-        width: 100px;
-    }
-
-    .w-\[300px\] {
-        width: 300px;
-    }
-
-    .w-full {
-        width: 100%;
-    }
-
-    .max-w-full {
-        max-width: 100%;
-    }
-
-    .min-w-0 {
-        min-width: calc(var(--spacing) * 0);
-    }
-
-    .flex-1 {
-        flex: 1;
-    }
-
-    .flex-shrink {
-        flex-shrink: 1;
-    }
-
-    .grow {
-        flex-grow: 1;
-    }
-
-    .transform {
-        transform: var(--tw-rotate-x) var(--tw-rotate-y) var(--tw-rotate-z) var(--tw-skew-x) var(--tw-skew-y);
-    }
-
-    .cursor-pointer {
-        cursor: pointer;
-    }
-
-    .grid-cols-3 {
-        grid-template-columns: repeat(3, minmax(0, 1fr));
-    }
-
-    .grid-cols-4 {
-        grid-template-columns: repeat(4, minmax(0, 1fr));
-    }
-
-    .grid-cols-6 {
-        grid-template-columns: repeat(6, minmax(0, 1fr));
-    }
-
-    .grid-rows-2 {
-        grid-template-rows: repeat(2, minmax(0, 1fr));
-    }
-
-    .grid-rows-5 {
-        grid-template-rows: repeat(5, minmax(0, 1fr));
-    }
-
-    .grid-rows-\[repeat\(167\,80px\)\] {
-        grid-template-rows: repeat(167, 80px);
-    }
-
-    .flex-wrap {
-        flex-wrap: wrap;
-    }
-
-    .items-center {
-        align-items: center;
-    }
-
-    .justify-center {
-        justify-content: center;
-    }
-
-    .justify-items-center {
-        justify-items: center;
-    }
-
-    .gap-0 {
-        gap: calc(var(--spacing) * 0);
-    }
-
-    .gap-1 {
-        gap: calc(var(--spacing) * 1);
-    }
-
-    .gap-2 {
-        gap: calc(var(--spacing) * 2);
-    }
-
-    .gap-\[25px\] {
-        gap: 25px;
-    }
-
-    .overflow-hidden {
-        overflow: hidden;
-    }
-
-    .overflow-x-hidden {
-        overflow-x: hidden;
-    }
-
-    .overflow-y-auto {
-        overflow-y: auto;
-    }
-
-    .rounded {
-        border-radius: 0.25rem;
-    }
-
-    .border {
-        border-style: var(--tw-border-style);
-        border-width: 1px;
-    }
-
-    .border-gray-300 {
-        border-color: var(--color-gray-300);
-    }
-
-    .border-transparent {
-        border-color: transparent;
-    }
-
-    .object-contain {
-        object-fit: contain;
-    }
-
-    .p-0 {
-        padding: calc(var(--spacing) * 0);
-    }
-
-    .p-1\.5 {
-        padding: calc(var(--spacing) * 1.5);
-    }
-
-    .p-\[5px\] {
-        padding: 5px;
-    }
-
-    .px-2 {
-        padding-inline: calc(var(--spacing) * 2);
-    }
-
-    .px-3 {
-        padding-inline: calc(var(--spacing) * 3);
-    }
-
-    .py-1 {
-        padding-block: calc(var(--spacing) * 1);
-    }
-
-    .py-8 {
-        padding-block: calc(var(--spacing) * 8);
-    }
-
-    .pt-3 {
-        padding-top: calc(var(--spacing) * 3);
-    }
-
-    .pt-\[3px\] {
-        padding-top: 3px;
-    }
-
-    .pb-1 {
-        padding-bottom: calc(var(--spacing) * 1);
-    }
-
-    .pb-4 {
-        padding-bottom: calc(var(--spacing) * 4);
-    }
-
-    .text-center {
-        text-align: center;
-    }
-
-    .text-\[3\.0rem\] {
-        font-size: 3.0rem;
-    }
-
-    .leading-none {
-        --tw-leading: 1;
-        line-height: 1;
-    }
-
-    .text-black {
-        color: var(--color-black);
-    }
-
-    .text-blue-500 {
-        color: var(--color-blue-500);
-    }
-
-    .text-gray-500 {
-        color: var(--color-gray-500);
-    }
-
-    .text-red-500 {
-        color: var(--color-red-500);
-    }
-
-    .lowercase {
-        text-transform: lowercase;
-    }
-
-    .underline {
-        text-decoration-line: underline;
-    }
-
-    .opacity-30 {
-        opacity: 30%;
-    }
-
-    .shadow {
-        --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
-        box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
-    }
-
-    .ring {
-        --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentColor);
-        box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
-    }
-
-    .outline {
-        outline-style: var(--tw-outline-style);
-        outline-width: 1px;
-    }
-
-    .filter {
-        filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
-    }
-
-    .select-none {
-        -webkit-user-select: none;
-        user-select: none;
-    }
-
-    .xl\:h-\[calc\(100dvh-319px\)\] {
-        @media (width >= 80rem) {
-            height: calc(100dvh - 319px);
-        }
-    }
-
-    .xl\:h-\[calc\(100vh-319px\)\] {
-        @media (width >= 80rem) {
-            height: calc(100vh - 319px);
-        }
-    }
+  .collapse {
+    visibility: collapse;
+  }
+  .invisible {
+    visibility: hidden;
+  }
+  .visible {
+    visibility: visible;
+  }
+  .fixed {
+    position: fixed;
+  }
+  .relative {
+    position: relative;
+  }
+  .static {
+    position: static;
+  }
+  .sticky {
+    position: sticky;
+  }
+  .container {
+    width: 100%;
+    @media (width >= 40rem) {
+      max-width: 40rem;
+    }
+    @media (width >= 48rem) {
+      max-width: 48rem;
+    }
+    @media (width >= 64rem) {
+      max-width: 64rem;
+    }
+    @media (width >= 80rem) {
+      max-width: 80rem;
+    }
+    @media (width >= 96rem) {
+      max-width: 96rem;
+    }
+  }
+  .m-1\.5 {
+    margin: calc(var(--spacing) * 1.5);
+  }
+  .m-\[5px\] {
+    margin: 5px;
+  }
+  .mx-2 {
+    margin-inline: calc(var(--spacing) * 2);
+  }
+  .mx-3 {
+    margin-inline: calc(var(--spacing) * 3);
+  }
+  .mx-\[5px\] {
+    margin-inline: 5px;
+  }
+  .mx-auto {
+    margin-inline: auto;
+  }
+  .my-2 {
+    margin-block: calc(var(--spacing) * 2);
+  }
+  .my-3 {
+    margin-block: calc(var(--spacing) * 3);
+  }
+  .ms-2 {
+    margin-inline-start: calc(var(--spacing) * 2);
+  }
+  .ms-auto {
+    margin-inline-start: auto;
+  }
+  .mt-1 {
+    margin-top: calc(var(--spacing) * 1);
+  }
+  .mt-2 {
+    margin-top: calc(var(--spacing) * 2);
+  }
+  .mt-3 {
+    margin-top: calc(var(--spacing) * 3);
+  }
+  .mt-4 {
+    margin-top: calc(var(--spacing) * 4);
+  }
+  .mt-8 {
+    margin-top: calc(var(--spacing) * 8);
+  }
+  .mr-2 {
+    margin-right: calc(var(--spacing) * 2);
+  }
+  .mb-1 {
+    margin-bottom: calc(var(--spacing) * 1);
+  }
+  .mb-2 {
+    margin-bottom: calc(var(--spacing) * 2);
+  }
+  .mb-3 {
+    margin-bottom: calc(var(--spacing) * 3);
+  }
+  .mb-\[5px\] {
+    margin-bottom: 5px;
+  }
+  .ml-1 {
+    margin-left: calc(var(--spacing) * 1);
+  }
+  .box-border {
+    box-sizing: border-box;
+  }
+  .block {
+    display: block;
+  }
+  .flex {
+    display: flex;
+  }
+  .grid {
+    display: grid;
+  }
+  .hidden {
+    display: none;
+  }
+  .inline {
+    display: inline;
+  }
+  .table {
+    display: table;
+  }
+  .aspect-\[6\/1\] {
+    aspect-ratio: 6/1;
+  }
+  .aspect-\[6\/5\] {
+    aspect-ratio: 6/5;
+  }
+  .aspect-square {
+    aspect-ratio: 1 / 1;
+  }
+  .h-\[50px\] {
+    height: 50px;
+  }
+  .h-\[398px\] {
+    height: 398px;
+  }
+  .h-\[400px\] {
+    height: 400px;
+  }
+  .h-auto {
+    height: auto;
+  }
+  .h-full {
+    height: 100%;
+  }
+  .w-80 {
+    width: calc(var(--spacing) * 80);
+  }
+  .w-\[100px\] {
+    width: 100px;
+  }
+  .w-\[300px\] {
+    width: 300px;
+  }
+  .w-full {
+    width: 100%;
+  }
+  .max-w-80 {
+    max-width: calc(var(--spacing) * 80);
+  }
+  .max-w-full {
+    max-width: 100%;
+  }
+  .min-w-0 {
+    min-width: calc(var(--spacing) * 0);
+  }
+  .flex-1 {
+    flex: 1;
+  }
+  .flex-shrink {
+    flex-shrink: 1;
+  }
+  .grow {
+    flex-grow: 1;
+  }
+  .transform {
+    transform: var(--tw-rotate-x) var(--tw-rotate-y) var(--tw-rotate-z) var(--tw-skew-x) var(--tw-skew-y);
+  }
+  .cursor-pointer {
+    cursor: pointer;
+  }
+  .grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+  .grid-cols-4 {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+  .grid-cols-6 {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+  .grid-rows-2 {
+    grid-template-rows: repeat(2, minmax(0, 1fr));
+  }
+  .grid-rows-5 {
+    grid-template-rows: repeat(5, minmax(0, 1fr));
+  }
+  .grid-rows-\[repeat\(167\,80px\)\] {
+    grid-template-rows: repeat(167,80px);
+  }
+  .flex-wrap {
+    flex-wrap: wrap;
+  }
+  .items-center {
+    align-items: center;
+  }
+  .justify-center {
+    justify-content: center;
+  }
+  .justify-items-center {
+    justify-items: center;
+  }
+  .gap-0 {
+    gap: calc(var(--spacing) * 0);
+  }
+  .gap-1 {
+    gap: calc(var(--spacing) * 1);
+  }
+  .gap-2 {
+    gap: calc(var(--spacing) * 2);
+  }
+  .gap-\[25px\] {
+    gap: 25px;
+  }
+  .overflow-hidden {
+    overflow: hidden;
+  }
+  .overflow-x-hidden {
+    overflow-x: hidden;
+  }
+  .overflow-y-auto {
+    overflow-y: auto;
+  }
+  .rounded {
+    border-radius: 0.25rem;
+  }
+  .border {
+    border-style: var(--tw-border-style);
+    border-width: 1px;
+  }
+  .border-gray-300 {
+    border-color: var(--color-gray-300);
+  }
+  .border-transparent {
+    border-color: transparent;
+  }
+  .object-contain {
+    object-fit: contain;
+  }
+  .p-0 {
+    padding: calc(var(--spacing) * 0);
+  }
+  .p-1\.5 {
+    padding: calc(var(--spacing) * 1.5);
+  }
+  .p-\[5px\] {
+    padding: 5px;
+  }
+  .px-2 {
+    padding-inline: calc(var(--spacing) * 2);
+  }
+  .px-3 {
+    padding-inline: calc(var(--spacing) * 3);
+  }
+  .px-\[5px\] {
+    padding-inline: 5px;
+  }
+  .py-0 {
+    padding-block: calc(var(--spacing) * 0);
+  }
+  .py-1 {
+    padding-block: calc(var(--spacing) * 1);
+  }
+  .py-8 {
+    padding-block: calc(var(--spacing) * 8);
+  }
+  .pt-3 {
+    padding-top: calc(var(--spacing) * 3);
+  }
+  .pt-\[3px\] {
+    padding-top: 3px;
+  }
+  .pb-1 {
+    padding-bottom: calc(var(--spacing) * 1);
+  }
+  .pb-4 {
+    padding-bottom: calc(var(--spacing) * 4);
+  }
+  .text-center {
+    text-align: center;
+  }
+  .text-\[3\.0rem\] {
+    font-size: 3.0rem;
+  }
+  .leading-none {
+    --tw-leading: 1;
+    line-height: 1;
+  }
+  .text-black {
+    color: var(--color-black);
+  }
+  .text-blue-500 {
+    color: var(--color-blue-500);
+  }
+  .text-gray-500 {
+    color: var(--color-gray-500);
+  }
+  .text-red-500 {
+    color: var(--color-red-500);
+  }
+  .lowercase {
+    text-transform: lowercase;
+  }
+  .underline {
+    text-decoration-line: underline;
+  }
+  .opacity-30 {
+    opacity: 30%;
+  }
+  .shadow {
+    --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .ring {
+    --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentColor);
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .outline {
+    outline-style: var(--tw-outline-style);
+    outline-width: 1px;
+  }
+  .filter {
+    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
+  }
+  .transition {
+    transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to, opacity, box-shadow, transform, translate, scale, rotate, filter, -webkit-backdrop-filter, backdrop-filter;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+  }
+  .select-none {
+    -webkit-user-select: none;
+    user-select: none;
+  }
+  .xl\:h-\[calc\(100dvh-319px\)\] {
+    @media (width >= 80rem) {
+      height: calc(100dvh - 319px);
+    }
+  }
+  .xl\:h-\[calc\(100vh-319px\)\] {
+    @media (width >= 80rem) {
+      height: calc(100vh - 319px);
+    }
+  }
 }
-
 @property --tw-rotate-x {
-    syntax: "*";
-    inherits: false;
-    initial-value: rotateX(0);
+  syntax: "*";
+  inherits: false;
+  initial-value: rotateX(0);
 }
-
 @property --tw-rotate-y {
-    syntax: "*";
-    inherits: false;
-    initial-value: rotateY(0);
+  syntax: "*";
+  inherits: false;
+  initial-value: rotateY(0);
 }
-
 @property --tw-rotate-z {
-    syntax: "*";
-    inherits: false;
-    initial-value: rotateZ(0);
+  syntax: "*";
+  inherits: false;
+  initial-value: rotateZ(0);
 }
-
 @property --tw-skew-x {
-    syntax: "*";
-    inherits: false;
-    initial-value: skewX(0);
+  syntax: "*";
+  inherits: false;
+  initial-value: skewX(0);
 }
-
 @property --tw-skew-y {
-    syntax: "*";
-    inherits: false;
-    initial-value: skewY(0);
+  syntax: "*";
+  inherits: false;
+  initial-value: skewY(0);
 }
-
 @property --tw-border-style {
-    syntax: "*";
-    inherits: false;
-    initial-value: solid;
+  syntax: "*";
+  inherits: false;
+  initial-value: solid;
 }
-
 @property --tw-leading {
-    syntax: "*";
-    inherits: false;
+  syntax: "*";
+  inherits: false;
 }
-
 @property --tw-shadow {
-    syntax: "*";
-    inherits: false;
-    initial-value: 0 0 #0000;
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
 }
-
 @property --tw-shadow-color {
-    syntax: "*";
-    inherits: false;
+  syntax: "*";
+  inherits: false;
 }
-
 @property --tw-inset-shadow {
-    syntax: "*";
-    inherits: false;
-    initial-value: 0 0 #0000;
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
 }
-
 @property --tw-inset-shadow-color {
-    syntax: "*";
-    inherits: false;
+  syntax: "*";
+  inherits: false;
 }
-
 @property --tw-ring-color {
-    syntax: "*";
-    inherits: false;
+  syntax: "*";
+  inherits: false;
 }
-
 @property --tw-ring-shadow {
-    syntax: "*";
-    inherits: false;
-    initial-value: 0 0 #0000;
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
 }
-
 @property --tw-inset-ring-color {
-    syntax: "*";
-    inherits: false;
+  syntax: "*";
+  inherits: false;
 }
-
 @property --tw-inset-ring-shadow {
-    syntax: "*";
-    inherits: false;
-    initial-value: 0 0 #0000;
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
 }
-
 @property --tw-ring-inset {
-    syntax: "*";
-    inherits: false;
+  syntax: "*";
+  inherits: false;
 }
-
 @property --tw-ring-offset-width {
-    syntax: "<length>";
-    inherits: false;
-    initial-value: 0px;
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 0px;
 }
-
 @property --tw-ring-offset-color {
-    syntax: "*";
-    inherits: false;
-    initial-value: #fff;
+  syntax: "*";
+  inherits: false;
+  initial-value: #fff;
 }
-
 @property --tw-ring-offset-shadow {
-    syntax: "*";
-    inherits: false;
-    initial-value: 0 0 #0000;
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
 }
-
 @property --tw-outline-style {
-    syntax: "*";
-    inherits: false;
-    initial-value: solid;
+  syntax: "*";
+  inherits: false;
+  initial-value: solid;
 }
-
 @property --tw-blur {
-    syntax: "*";
-    inherits: false;
+  syntax: "*";
+  inherits: false;
 }
-
 @property --tw-brightness {
-    syntax: "*";
-    inherits: false;
+  syntax: "*";
+  inherits: false;
 }
-
 @property --tw-contrast {
-    syntax: "*";
-    inherits: false;
+  syntax: "*";
+  inherits: false;
 }
-
 @property --tw-grayscale {
-    syntax: "*";
-    inherits: false;
+  syntax: "*";
+  inherits: false;
 }
-
 @property --tw-hue-rotate {
-    syntax: "*";
-    inherits: false;
+  syntax: "*";
+  inherits: false;
 }
-
 @property --tw-invert {
-    syntax: "*";
-    inherits: false;
+  syntax: "*";
+  inherits: false;
 }
-
 @property --tw-opacity {
-    syntax: "*";
-    inherits: false;
+  syntax: "*";
+  inherits: false;
 }
-
 @property --tw-saturate {
-    syntax: "*";
-    inherits: false;
+  syntax: "*";
+  inherits: false;
 }
-
 @property --tw-sepia {
-    syntax: "*";
-    inherits: false;
+  syntax: "*";
+  inherits: false;
 }
-
 @property --tw-drop-shadow {
-    syntax: "*";
-    inherits: false;
+  syntax: "*";
+  inherits: false;
 }


### PR DESCRIPTION
Closes #777

Adds two complementary ways to bank Pokémon from a save file:

1. "Bank" button in the edit form — one-click add for the currently open Pokémon.
2. "Add to Bank" toolbar button — opens a multi-select dialog with scope radio (Party / Current Box / All Boxes), duplicate warning icons, and a skip/add-anyway toggle.

Both flows detect unsaved edits (byte-level stored-data comparison) and warn before proceeding.
Let's Go shows only box storage with Party chip markers on party Pokémon.

Generated with [Claude Code](https://claude.ai/code)