### PR TITLE
feat(bank): export Pokémon from Bank as .pk* files (single file or ZIP)

### DIFF
--- a/Pkmds.Rcl/Components/Dialogs/BankExportDialog.razor
+++ b/Pkmds.Rcl/Components/Dialogs/BankExportDialog.razor
@@ -1,0 +1,50 @@
+<MudDialog>
+    <TitleContent>
+        <MudText Typo="@Typo.h6">Export Pokémon as .pk* Files</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudStack Spacing="3">
+            <MudText Typo="@Typo.body2"
+                     Color="@Color.Secondary">
+                Downloads a zip containing a .pk* file for each Pokémon (@Entries.Count total).
+            </MudText>
+
+            @if (isExporting)
+            {
+                <MudStack Spacing="1">
+                    <MudText Typo="@Typo.body2">@statusText</MudText>
+                    <MudProgressLinear Color="@Color.Primary"
+                                       Value="@progressPercent"
+                                       Max="100"/>
+                </MudStack>
+            }
+        </MudStack>
+    </DialogContent>
+    <DialogActions>
+        @if (isExporting)
+        {
+            <MudButton OnClick="@CancelExport"
+                       StartIcon="@Icons.Material.Filled.Cancel"
+                       Variant="@Variant.Filled"
+                       Color="@Color.Default">
+                Cancel
+            </MudButton>
+        }
+        else
+        {
+            <MudButton OnClick="@Cancel"
+                       StartIcon="@Icons.Material.Filled.Clear"
+                       Variant="@Variant.Filled"
+                       Color="@Color.Default">
+                Cancel
+            </MudButton>
+            <MudButton OnClick="@ExportAsync"
+                       StartIcon="@Icons.Material.Filled.Download"
+                       Variant="@Variant.Filled"
+                       Color="@Color.Primary"
+                       Disabled="@(Entries.Count == 0)">
+                Export
+            </MudButton>
+        }
+    </DialogActions>
+</MudDialog>

--- a/Pkmds.Rcl/Components/Dialogs/BankExportDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/BankExportDialog.razor.cs
@@ -1,0 +1,179 @@
+using System.IO.Compression;
+
+namespace Pkmds.Rcl.Components.Dialogs;
+
+public partial class BankExportDialog : IDisposable
+{
+    public enum BankExportScope
+    {
+        Selected,
+        All
+    }
+
+    // Yield cadence inside the zip-build loop. WASM is single-threaded — without periodic
+    // yields the UI freezes for noticeable hitches on large bank dumps.
+    private const int YieldEveryN = 16;
+
+    private CancellationTokenSource? cts;
+    private bool isExporting;
+    private double progressPercent;
+    private string statusText = string.Empty;
+
+    [CascadingParameter]
+    private IMudDialogInstance? MudDialog { get; set; }
+
+    [Parameter]
+    public IReadOnlyList<BankEntry> Entries { get; set; } = [];
+
+    [Parameter]
+    public BankExportScope Scope { get; set; } = BankExportScope.All;
+
+    public void Dispose()
+    {
+        cts?.Cancel();
+        cts?.Dispose();
+        cts = null;
+    }
+
+    private async Task ExportAsync()
+    {
+        if (Entries.Count == 0)
+        {
+            Snackbar.Add("No Pokémon to export.", Severity.Warning);
+            return;
+        }
+
+        cts?.Dispose();
+        cts = new CancellationTokenSource();
+        var ct = cts.Token;
+
+        isExporting = true;
+        progressPercent = 0;
+        statusText = $"Building zip ({Entries.Count} Pokémon)…";
+        StateHasChanged();
+        await Task.Yield();
+
+        try
+        {
+            var zipBytes = await BuildZipAsync(Entries, ct);
+            var fileName = Scope == BankExportScope.Selected
+                ? "pkmds_bank_selected.zip"
+                : "pkmds_bank_export.zip";
+
+            statusText = "Saving…";
+            progressPercent = 100;
+            StateHasChanged();
+
+            await WriteZipAsync(zipBytes, fileName, ct);
+
+            Snackbar.Add($"Exported {Entries.Count} Pokémon.", Severity.Success);
+            MudDialog?.Close();
+        }
+        catch (OperationCanceledException)
+        {
+            Snackbar.Add("Export cancelled.", Severity.Info);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Export failed: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            // Capture before nulling so a concurrent component Dispose (which also nulls
+            // cts) can't cause us to leak the CTS — exactly one path disposes it.
+            var localCts = cts;
+            cts = null;
+            localCts?.Dispose();
+            isExporting = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task<byte[]> BuildZipAsync(IReadOnlyList<BankEntry> entries, CancellationToken ct)
+    {
+        using var ms = new MemoryStream();
+        using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var usedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            for (var i = 0; i < entries.Count; i++)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                var pkm = entries[i].Pokemon;
+                pkm.RefreshChecksum();
+                var bytes = new byte[pkm.SIZE_PARTY];
+                pkm.WriteDecryptedDataParty(bytes);
+
+                var entryName = GetUniqueEntryName(usedNames, AppService.GetCleanFileName(pkm));
+                var entry = zip.CreateEntry(entryName, CompressionLevel.Fastest);
+                using (var es = entry.Open())
+                {
+                    es.Write(bytes);
+                }
+
+                // Reserve 0→95% for zip building; the final 5% covers the save dialog.
+                progressPercent = (double)(i + 1) / entries.Count * 95;
+                statusText = $"Adding {i + 1}/{entries.Count}: {entryName}";
+
+                if ((i + 1) % YieldEveryN == 0 || i == entries.Count - 1)
+                {
+                    StateHasChanged();
+                    await Task.Delay(1, ct);
+                }
+            }
+        }
+
+        return ms.ToArray();
+    }
+
+    private static string GetUniqueEntryName(HashSet<string> used, string desired)
+    {
+        if (used.Add(desired))
+        {
+            return desired;
+        }
+
+        var ext = Path.GetExtension(desired);
+        var stem = Path.GetFileNameWithoutExtension(desired);
+        for (var i = 2; ; i++)
+        {
+            var candidate = $"{stem}_{i}{ext}";
+            if (used.Add(candidate))
+            {
+                return candidate;
+            }
+        }
+    }
+
+    private async Task WriteZipAsync(byte[] data, string fileName, CancellationToken ct)
+    {
+        // Mirror BulkExportDialog: prefer File System Access API, fall back to anchor.
+        if (await FileSystemAccessService.IsSupportedAsync())
+        {
+            try
+            {
+                await JSRuntime.InvokeVoidAsync(
+                    "showFilePickerAndWrite",
+                    ct,
+                    fileName,
+                    data,
+                    ".zip",
+                    "Pokémon Export");
+                return;
+            }
+            catch (JSException ex) when (ex.Message.Contains("AbortError", StringComparison.OrdinalIgnoreCase) ||
+                                         ex.Message.Contains("aborted a request", StringComparison.OrdinalIgnoreCase))
+            {
+                // User dismissed the picker — surface as cancellation so callers show
+                // "Export cancelled." rather than a false success.
+                throw new OperationCanceledException("Save dialog dismissed.");
+            }
+        }
+
+        await JSRuntime.InvokeVoidAsync("downloadBlob", ct, fileName, data, "application/zip");
+    }
+
+    private void CancelExport() => cts?.Cancel();
+
+    private void Cancel() => MudDialog?.Close(DialogResult.Cancel());
+}

--- a/Pkmds.Rcl/Components/MainTabPages/PokemonBankTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/PokemonBankTab.razor
@@ -64,6 +64,13 @@
                 Export All
             </MudButton>
 
+            <MudButton Variant="@Variant.Outlined"
+                       StartIcon="@Icons.Material.Filled.Download"
+                       OnClick="@ExportAllAsync"
+                       Disabled="@(isBusy || entries.Count == 0 || isLoading)">
+                Export .pk* Files
+            </MudButton>
+
             @if (selectedIds.Count > 0)
             {
                 <MudDivider Vertical
@@ -79,6 +86,14 @@
                         Send to Save (@selectedIds.Count)
                     </MudButton>
                 }
+
+                <MudButton Variant="@Variant.Filled"
+                           Color="@Color.Primary"
+                           StartIcon="@Icons.Material.Filled.Download"
+                           OnClick="@ExportSelectedAsync"
+                           Disabled="@isBusy">
+                    Export .pk* (@selectedIds.Count)
+                </MudButton>
 
                 <MudButton Variant="@Variant.Filled"
                            Color="@Color.Error"
@@ -224,6 +239,15 @@
                                         Send
                                     </MudButton>
                                 }
+                                <MudButton Size="@Size.Small"
+                                           Variant="@Variant.Outlined"
+                                           StartIcon="@Icons.Material.Filled.Download"
+                                           Color="@Color.Default"
+                                           OnClick="@(() => ExportSingleAsync(entry))"
+                                           Disabled="@isBusy"
+                                           title="Export as .pk* file">
+                                    Export
+                                </MudButton>
                                 <MudButton Size="@Size.Small"
                                            Variant="@Variant.Outlined"
                                            StartIcon="@Icons.Material.Filled.Delete"

--- a/Pkmds.Rcl/Components/MainTabPages/PokemonBankTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/PokemonBankTab.razor.cs
@@ -252,7 +252,7 @@ public partial class PokemonBankTab : RefreshAwareComponent
                 }
             }
 
-            await JSRuntime.InvokeVoidAsync("downloadBlob", fileName, bytes, "application/octet-stream");
+            await JSRuntime.InvokeVoidAsync("downloadBlob", fileName, bytes, "application/x-pokemon-savedata");
             Snackbar.Add($"{entry.SpeciesName} exported.", Severity.Success);
         }
         catch (Exception ex)

--- a/Pkmds.Rcl/Components/MainTabPages/PokemonBankTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/PokemonBankTab.razor.cs
@@ -221,6 +221,96 @@ public partial class PokemonBankTab : RefreshAwareComponent
 
     // ── Export ────────────────────────────────────────────────────────────
 
+    // Single-entry export: write the raw .pk* file directly, no dialog or zip.
+    private async Task ExportSingleAsync(BankEntry entry)
+    {
+        isBusy = true;
+        StateHasChanged();
+
+        try
+        {
+            var pkm = entry.Pokemon;
+            pkm.RefreshChecksum();
+            var bytes = new byte[pkm.SIZE_PARTY];
+            pkm.WriteDecryptedDataParty(bytes);
+            var fileName = AppService.GetCleanFileName(pkm);
+            var ext = $".{pkm.Extension}";
+
+            if (await FileSystemAccessService.IsSupportedAsync())
+            {
+                try
+                {
+                    await JSRuntime.InvokeVoidAsync("showFilePickerAndWrite", fileName, bytes, ext, "Pokémon File");
+                    Snackbar.Add($"{entry.SpeciesName} exported.", Severity.Success);
+                    return;
+                }
+                catch (JSException ex) when (ex.Message.Contains("AbortError", StringComparison.OrdinalIgnoreCase) ||
+                                             ex.Message.Contains("aborted a request", StringComparison.OrdinalIgnoreCase))
+                {
+                    Snackbar.Add("Export cancelled.", Severity.Info);
+                    return;
+                }
+            }
+
+            await JSRuntime.InvokeVoidAsync("downloadBlob", fileName, bytes, "application/octet-stream");
+            Snackbar.Add($"{entry.SpeciesName} exported.", Severity.Success);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Export failed: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            isBusy = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task ExportSelectedAsync()
+    {
+        var selected = entries.Where(e => selectedIds.Contains(e.Id)).ToList();
+        if (selected.Count == 0)
+        {
+            return;
+        }
+
+        if (selected.Count == 1)
+        {
+            await ExportSingleAsync(selected[0]);
+            return;
+        }
+
+        var options = await DialogOptionsHelper.BuildAsync(MaxWidth.Small);
+        var parameters = new DialogParameters<BankExportDialog>
+        {
+            { x => x.Entries, selected },
+            { x => x.Scope, BankExportDialog.BankExportScope.Selected }
+        };
+        await DialogService.ShowAsync<BankExportDialog>("Export Selected Pokémon", parameters, options);
+    }
+
+    private async Task ExportAllAsync()
+    {
+        if (entries.Count == 0)
+        {
+            return;
+        }
+
+        if (entries.Count == 1)
+        {
+            await ExportSingleAsync(entries[0]);
+            return;
+        }
+
+        var options = await DialogOptionsHelper.BuildAsync(MaxWidth.Small);
+        var parameters = new DialogParameters<BankExportDialog>
+        {
+            { x => x.Entries, entries },
+            { x => x.Scope, BankExportDialog.BankExportScope.All }
+        };
+        await DialogService.ShowAsync<BankExportDialog>("Export All Pokémon", parameters, options);
+    }
+
     private async Task ExportAsync()
     {
         isBusy = true;


### PR DESCRIPTION
Implements #779.

Adds three export entry points to the Pokémon Bank tab: per-card Export button (single .pk*), batch Export .pk* (N) button, and toolbar Export .pk* Files button.

Generated with [Claude Code](https://claude.ai/code)