### PR TITLE
feat: embedded host mode for in-app integration (#787)

### DIFF
--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
@@ -136,6 +136,22 @@ public partial class MainLayout : IDisposable
         RefreshService.Refresh();
 
         StateHasChanged();
+
+        // Signal embedded-host readiness AFTER settings load and theme apply
+        // so the host can call window.PKMDS.host.loadSave() without racing the
+        // Blazor boot sequence. Without this, hosts would have to poll for
+        // window.PKMDS.host existence before calling in. See #787.
+        if (HostService.IsEmbedded)
+        {
+            try
+            {
+                await JSRuntime.InvokeVoidAsync("PKMDS.host._sendMessage", "ready", new { });
+            }
+            catch (JSException ex)
+            {
+                Logger.LogWarning(ex, "Failed to fire host ready signal");
+            }
+        }
     }
 
     private async void OnSystemPreferenceChanged(bool newValue)


### PR DESCRIPTION
Brings the embedded host mode work from #787 to main. Standalone web app behaviour is unaffected when no \`?host=\` query string is present.

## Summary

Adds a runtime flag (\`?host=<name>\`) that adapts PKMDS for hosting inside a \`WKWebView\` or any other JS-capable container. The host drives PKMDS via a small JS bridge instead of the file picker / File System Access API, and PKMDS hides standalone-only chrome (drawer, file ops, theme picker, sprite overlay, etc.) when embedded.

## What's in this PR

**Embedded host mode (#787):**
- \`IHostService\` + \`HostKind\` enum reading \`?host=\` from \`NavigationManager\`
- \`window.PKMDS.host\` JS bridge (\`loadSave\`, \`requestExport\`, \`loadSaveFromUrl\` test helper) backed by \`EmbeddedHostBridge\` \`[JSInvokable]\` static methods
- Outbound \`ready\` message posted once Blazor finishes booting; \`saveExport\` posted in response to \`requestExport()\`
- Service worker registration skipped when embedded (avoids competing with host-bundled assets)
- Drawer + most of \`MudAppBar\` hidden; replaced by an overflow menu (Settings / Save Info / Repair / Report a Bug)
- Theme forced to \`System\` so the host's appearance via \`prefers-color-scheme\` wins; theme picker hidden, \`pkmds_theme\` localStorage skipped
- \`AppSettingsDialog\` hides Theme, Sprite Style, Haptics, and the entire Advanced tab in embed mode
- New About tab in Settings (always visible, mirrors drawer footer)
- Pokémon Bank and Trade tabs hidden in embed mode
- PokeAPI sprite overlay suppressed in \`PokemonSlotComponent\`, \`TradeSlot\`, and the six form-picker dialogs (Alcremie, Vivillon, Furfrou, Minior, Pumpkaboo, FlowerColor)
- Browser-only \`?host=test\` test affordance: file picker on the empty-state for ad-hoc smoke tests, never visible for production hosts

**Bundled bonus improvements:**
- PKHeX.Core version included in bug report submissions (was missing; surfaces in the GitHub issue body)
- Test infrastructure fix: \`Pkmds.Tests\` hadn't compiled since #766 because eight \`TestAppState\` fakes were missing \`HapticsEnabled\`, and CI ran \`dotnet test --no-build\` after only building \`Pkmds.Web\` so nothing actually ran. Both fixed; CI now genuinely tests on dev pushes.

## Test plan

- [ ] Open standalone in any browser (no \`?host=\`) — file picker, drawer, theme buttons, Bank/Trade tabs, sprite overlays all behave as before
- [ ] Open with \`?host=test\` — drawer hidden, AppBar shows only the overflow menu, "Waiting for save file…" empty state with file picker button
- [ ] Pick a save via the test picker — boxes/party render, all editor tabs work
- [ ] Run \`window.PKMDS.host.requestExport()\` from DevTools — console logs \`[PKMDS.host] → saveExport { data, fileName }\` with intact bytes
- [ ] Settings dialog in embed mode — Theme, Sprite Style, Haptics sections hidden; Advanced tab hidden; About tab present
- [ ] Toggle OS dark/light — embed mode tracks it live without user action
- [ ] DevTools network tab in embed mode — no requests to \`raw.githubusercontent.com\`
- [ ] DevTools console in embed mode — \`Service worker registration skipped: embedded host mode.\`
- [ ] Submit a bug report after this lands and \`main.yml\` deploys — verify the \`**PKHeX.Core version:**\` line appears in the issue body

## Known follow-ups (not blocking)

- \`EmbeddedHostBridge.LoadSaveFromHostInternal\` duplicates the load-finalization logic from \`MainLayout.razor.cs\`'s \`FinishLoadingSaveFile\`. Worth extracting into a shared service if either side changes.
- \`RequestExportFromHost\` emits raw save bytes only — no Manic EMU ZIP rebuild. Deliberate; revisit if a future host needs the wrapper.
- The six form-picker dialogs lose their HOME sprite previews in embed mode (the embedded sprite set doesn't enumerate every form variant). Acceptable per the original scoping; option 2 (bundling a curated subset) remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)