### PR TITLE
feat(macos-quicklook): native AOT Quick Look extension proof-of-concept

### DIFF
--- a/tools/macos-quicklook-poc/.gitignore
+++ b/tools/macos-quicklook-poc/.gitignore
@@ -1,0 +1,2 @@
+swift-cli/pkmds-poc
+swift-cli/*.dSYM/

--- a/tools/macos-quicklook-poc/.gitignore
+++ b/tools/macos-quicklook-poc/.gitignore
@@ -1,2 +1,7 @@
 swift-cli/pkmds-poc
 swift-cli/*.dSYM/
+build-resources/PkmdsNative.dylib
+xcode/PkmdsQuickLook.xcodeproj/
+xcode/build/
+xcode/PkmdsHost/Info.plist
+xcode/PkmdsQuickLook/Info.plist

--- a/tools/macos-quicklook-poc/PkmdsNative/Exports.cs
+++ b/tools/macos-quicklook-poc/PkmdsNative/Exports.cs
@@ -47,6 +47,47 @@ public static unsafe class Exports
         }
     }
 
+    [UnmanagedCallersOnly(EntryPoint = "pkmds_render_pkm_html")]
+    public static int RenderPkmHtml(byte* data, int length, byte* outHtml, int outCap)
+    {
+        try
+        {
+            if (data is null || outHtml is null || length <= 0 || outCap <= 0)
+                return -1;
+
+            var bytes = CopyIn(data, length);
+            var pkm = EntityFormat.GetFromBytes(bytes);
+            if (pkm is null)
+                return -2;
+
+            return WriteJson(HtmlRenderer.RenderPkm(pkm), outHtml, outCap);
+        }
+        catch
+        {
+            return -99;
+        }
+    }
+
+    [UnmanagedCallersOnly(EntryPoint = "pkmds_render_save_html")]
+    public static int RenderSaveHtml(byte* data, int length, byte* outHtml, int outCap)
+    {
+        try
+        {
+            if (data is null || outHtml is null || length <= 0 || outCap <= 0)
+                return -1;
+
+            var bytes = CopyIn(data, length);
+            if (!SaveUtil.TryGetSaveFile(bytes, out var sav))
+                return -2;
+
+            return WriteJson(HtmlRenderer.RenderSave(sav), outHtml, outCap);
+        }
+        catch
+        {
+            return -99;
+        }
+    }
+
     private static byte[] CopyIn(byte* data, int length)
     {
         var bytes = new byte[length];

--- a/tools/macos-quicklook-poc/PkmdsNative/Exports.cs
+++ b/tools/macos-quicklook-poc/PkmdsNative/Exports.cs
@@ -1,0 +1,198 @@
+using System.Runtime.InteropServices;
+using System.Text;
+using PKHeX.Core;
+
+namespace Pkmds.Native;
+
+public static unsafe class Exports
+{
+    [UnmanagedCallersOnly(EntryPoint = "pkmds_describe_pkm")]
+    public static int DescribePkm(byte* data, int length, byte* outJson, int outCap)
+    {
+        try
+        {
+            if (data is null || outJson is null || length <= 0 || outCap <= 0)
+                return -1;
+
+            var bytes = CopyIn(data, length);
+            var pkm = EntityFormat.GetFromBytes(bytes);
+            if (pkm is null)
+                return -2;
+
+            return WriteJson(BuildPkmJson(pkm), outJson, outCap);
+        }
+        catch
+        {
+            return -99;
+        }
+    }
+
+    [UnmanagedCallersOnly(EntryPoint = "pkmds_describe_save")]
+    public static int DescribeSave(byte* data, int length, byte* outJson, int outCap)
+    {
+        try
+        {
+            if (data is null || outJson is null || length <= 0 || outCap <= 0)
+                return -1;
+
+            var bytes = CopyIn(data, length);
+            if (!SaveUtil.TryGetSaveFile(bytes, out var sav))
+                return -2;
+
+            return WriteJson(BuildSaveJson(sav), outJson, outCap);
+        }
+        catch
+        {
+            return -99;
+        }
+    }
+
+    private static byte[] CopyIn(byte* data, int length)
+    {
+        var bytes = new byte[length];
+        Marshal.Copy((nint)data, bytes, 0, length);
+        return bytes;
+    }
+
+    private static int WriteJson(string json, byte* outJson, int outCap)
+    {
+        var encoded = Encoding.UTF8.GetBytes(json);
+        if (encoded.Length + 1 > outCap)
+            return -3;
+
+        Marshal.Copy(encoded, 0, (nint)outJson, encoded.Length);
+        outJson[encoded.Length] = 0;
+        return encoded.Length;
+    }
+
+    private static string BuildPkmJson(PKM pkm)
+    {
+        var s = GameInfo.Strings;
+        var sb = new StringBuilder(1024);
+        sb.Append('{');
+        AppendInt(sb, "format", pkm.Format); sb.Append(',');
+        AppendInt(sb, "species", pkm.Species); sb.Append(',');
+        AppendString(sb, "speciesName", Lookup(s.specieslist, pkm.Species)); sb.Append(',');
+        AppendInt(sb, "form", pkm.Form); sb.Append(',');
+        AppendInt(sb, "level", pkm.CurrentLevel); sb.Append(',');
+        AppendInt(sb, "ability", pkm.Ability); sb.Append(',');
+        AppendString(sb, "abilityName", Lookup(s.abilitylist, pkm.Ability)); sb.Append(',');
+        AppendInt(sb, "nature", (int)pkm.Nature); sb.Append(',');
+        AppendString(sb, "natureName", Lookup(s.natures, (int)pkm.Nature)); sb.Append(',');
+        AppendInt(sb, "tid", pkm.TID16); sb.Append(',');
+        AppendInt(sb, "sid", pkm.SID16); sb.Append(',');
+        AppendBool(sb, "isShiny", pkm.IsShiny); sb.Append(',');
+        AppendString(sb, "ot", pkm.OriginalTrainerName ?? string.Empty); sb.Append(',');
+        AppendString(sb, "nickname", pkm.Nickname ?? string.Empty); sb.Append(',');
+        AppendIntArray(sb, "ivs", [pkm.IV_HP, pkm.IV_ATK, pkm.IV_DEF, pkm.IV_SPA, pkm.IV_SPD, pkm.IV_SPE]); sb.Append(',');
+        AppendIntArray(sb, "evs", [pkm.EV_HP, pkm.EV_ATK, pkm.EV_DEF, pkm.EV_SPA, pkm.EV_SPD, pkm.EV_SPE]); sb.Append(',');
+        AppendIntArray(sb, "moves", [pkm.Move1, pkm.Move2, pkm.Move3, pkm.Move4]); sb.Append(',');
+        AppendStringArray(sb, "moveNames",
+            Lookup(s.movelist, pkm.Move1),
+            Lookup(s.movelist, pkm.Move2),
+            Lookup(s.movelist, pkm.Move3),
+            Lookup(s.movelist, pkm.Move4));
+        sb.Append('}');
+        return sb.ToString();
+    }
+
+    private static string BuildSaveJson(SaveFile sav)
+    {
+        var sb = new StringBuilder(512);
+        sb.Append('{');
+        AppendString(sb, "type", sav.GetType().Name); sb.Append(',');
+        AppendString(sb, "version", sav.Version.ToString()); sb.Append(',');
+        AppendInt(sb, "generation", sav.Generation); sb.Append(',');
+        AppendString(sb, "ot", sav.OT ?? string.Empty); sb.Append(',');
+        AppendInt(sb, "tid", sav.TID16); sb.Append(',');
+        AppendInt(sb, "sid", sav.SID16); sb.Append(',');
+        AppendInt(sb, "language", sav.Language); sb.Append(',');
+        AppendInt(sb, "boxCount", sav.BoxCount); sb.Append(',');
+        AppendInt(sb, "boxSlotCount", sav.BoxSlotCount); sb.Append(',');
+        AppendInt(sb, "partyCount", sav.HasParty ? sav.PartyCount : 0); sb.Append(',');
+        sb.Append("\"party\":[");
+        if (sav.HasParty)
+        {
+            var count = Math.Min(sav.PartyCount, 6);
+            var s = GameInfo.Strings;
+            for (var i = 0; i < count; i++)
+            {
+                var pkm = sav.GetPartySlotAtIndex(i);
+                if (i > 0) sb.Append(',');
+                sb.Append('{');
+                AppendInt(sb, "species", pkm.Species); sb.Append(',');
+                AppendString(sb, "speciesName", Lookup(s.specieslist, pkm.Species)); sb.Append(',');
+                AppendInt(sb, "level", pkm.CurrentLevel); sb.Append(',');
+                AppendString(sb, "nickname", pkm.Nickname ?? string.Empty);
+                sb.Append('}');
+            }
+        }
+        sb.Append(']');
+        sb.Append('}');
+        return sb.ToString();
+    }
+
+    private static string Lookup(IReadOnlyList<string> list, int index)
+        => (uint)index < (uint)list.Count ? list[index] : string.Empty;
+
+    private static void AppendInt(StringBuilder sb, string key, int value)
+    {
+        sb.Append('"').Append(key).Append("\":").Append(value);
+    }
+
+    private static void AppendBool(StringBuilder sb, string key, bool value)
+    {
+        sb.Append('"').Append(key).Append("\":").Append(value ? "true" : "false");
+    }
+
+    private static void AppendString(StringBuilder sb, string key, string value)
+    {
+        sb.Append('"').Append(key).Append("\":");
+        AppendStringValue(sb, value);
+    }
+
+    private static void AppendStringValue(StringBuilder sb, string value)
+    {
+        sb.Append('"');
+        foreach (var c in value)
+        {
+            switch (c)
+            {
+                case '"': sb.Append("\\\""); break;
+                case '\\': sb.Append("\\\\"); break;
+                case '\n': sb.Append("\\n"); break;
+                case '\r': sb.Append("\\r"); break;
+                case '\t': sb.Append("\\t"); break;
+                default:
+                    if (c < 0x20)
+                        sb.Append("\\u").Append(((int)c).ToString("x4"));
+                    else
+                        sb.Append(c);
+                    break;
+            }
+        }
+        sb.Append('"');
+    }
+
+    private static void AppendIntArray(StringBuilder sb, string key, ReadOnlySpan<int> values)
+    {
+        sb.Append('"').Append(key).Append("\":[");
+        for (var i = 0; i < values.Length; i++)
+        {
+            if (i > 0) sb.Append(',');
+            sb.Append(values[i]);
+        }
+        sb.Append(']');
+    }
+
+    private static void AppendStringArray(StringBuilder sb, string key, params string[] values)
+    {
+        sb.Append('"').Append(key).Append("\":[");
+        for (var i = 0; i < values.Length; i++)
+        {
+            if (i > 0) sb.Append(',');
+            AppendStringValue(sb, values[i]);
+        }
+        sb.Append(']');
+    }
+}

--- a/tools/macos-quicklook-poc/PkmdsNative/HtmlRenderer.cs
+++ b/tools/macos-quicklook-poc/PkmdsNative/HtmlRenderer.cs
@@ -1,0 +1,271 @@
+using System.Globalization;
+using System.Text;
+using PKHeX.Core;
+using Pkmds.Core.Extensions;
+
+namespace Pkmds.Native;
+
+internal static class HtmlRenderer
+{
+    private const string PokeApiHomeBaseUrl =
+        "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/";
+
+    public static string RenderPkm(PKM pkm)
+    {
+        var s = GameInfo.Strings;
+        var sb = new StringBuilder(4096);
+        AppendDocStart(sb, $"{Lookup(s.specieslist, pkm.Species)} (Lv. {pkm.CurrentLevel})");
+        sb.Append("<div class=\"pkm\">");
+
+        AppendSprite(sb, pkm.Species, pkm.IsShiny);
+
+        sb.Append("<div class=\"info\">");
+        var nickname = pkm.Nickname ?? string.Empty;
+        var speciesName = Lookup(s.specieslist, pkm.Species);
+        var displayName = nickname.Length > 0 && nickname != speciesName
+            ? $"{Escape(nickname)} <span class=\"muted\">({Escape(speciesName)})</span>"
+            : Escape(speciesName);
+
+        sb.Append("<h1>").Append(displayName);
+        if (pkm.IsShiny)
+        {
+            sb.Append(" <span class=\"shiny\" title=\"Shiny\">★</span>");
+        }
+        sb.Append("</h1>");
+
+        sb.Append("<div class=\"meta\">")
+            .Append("Lv. ").Append(pkm.CurrentLevel)
+            .Append(" &middot; ").Append(Escape(Lookup(s.natures, (int)pkm.Nature))).Append(" nature");
+        if (pkm.Form > 0)
+        {
+            sb.Append(" &middot; Form ").Append(pkm.Form);
+        }
+        sb.Append("</div>");
+
+        sb.Append("<dl class=\"details\">");
+        AppendDt(sb, "OT", $"{Escape(pkm.OriginalTrainerName ?? string.Empty)} <span class=\"muted\">({pkm.TID16}/{pkm.SID16})</span>");
+        AppendDt(sb, "Ability", Escape(Lookup(s.abilitylist, pkm.Ability)));
+        if (pkm.HeldItem > 0)
+        {
+            AppendDt(sb, "Item", Escape(Lookup(s.itemlist, pkm.HeldItem)));
+        }
+        AppendDt(sb, "Format", $"PK{pkm.Format} (Gen {pkm.Generation})");
+        sb.Append("</dl>");
+
+        AppendStatsTable(sb, pkm);
+        AppendMovesTable(sb, pkm, s);
+
+        sb.Append("</div>"); // .info
+        sb.Append("</div>"); // .pkm
+        AppendDocEnd(sb);
+        return sb.ToString();
+    }
+
+    public static string RenderSave(SaveFile sav)
+    {
+        var s = GameInfo.Strings;
+        var sb = new StringBuilder(4096);
+        var ot = sav.OT ?? string.Empty;
+        AppendDocStart(sb, $"{ot} – {sav.Version}");
+
+        sb.Append("<div class=\"sav\">");
+        sb.Append("<h1>").Append(Escape(ot.Length > 0 ? ot : "Trainer")).Append("</h1>");
+        sb.Append("<div class=\"meta\">")
+            .Append(Escape(sav.Version.ToString()))
+            .Append(" &middot; Gen ").Append(sav.Generation)
+            .Append(" &middot; ID ").Append(sav.TID16).Append('/').Append(sav.SID16)
+            .Append("</div>");
+
+        sb.Append("<dl class=\"details\">");
+        AppendDt(sb, "Save type", Escape(sav.GetType().Name));
+        AppendDt(sb, "Language", LanguageName(sav.Language));
+        AppendDt(sb, "Boxes", $"{sav.BoxCount} × {sav.BoxSlotCount}");
+        AppendDt(sb, "Party", (sav.HasParty ? sav.PartyCount : 0).ToString(CultureInfo.InvariantCulture));
+        sb.Append("</dl>");
+
+        if (sav.HasParty && sav.PartyCount > 0)
+        {
+            sb.Append("<h2>Party</h2><div class=\"party\">");
+            var count = Math.Min(sav.PartyCount, 6);
+            for (var i = 0; i < count; i++)
+            {
+                var pkm = sav.GetPartySlotAtIndex(i);
+                sb.Append("<div class=\"party-slot\">");
+                AppendSpriteSmall(sb, pkm.Species, pkm.IsShiny);
+                sb.Append("<div class=\"party-info\">");
+                sb.Append("<div class=\"party-name\">")
+                    .Append(Escape(Lookup(s.specieslist, pkm.Species)));
+                if (pkm.IsShiny)
+                {
+                    sb.Append(" <span class=\"shiny\" title=\"Shiny\">★</span>");
+                }
+                sb.Append("</div>");
+                sb.Append("<div class=\"muted\">Lv. ").Append(pkm.CurrentLevel);
+                var nick = pkm.Nickname ?? string.Empty;
+                if (nick.Length > 0 && nick != Lookup(s.specieslist, pkm.Species))
+                {
+                    sb.Append(" &middot; ").Append(Escape(nick));
+                }
+                sb.Append("</div>");
+                sb.Append("</div>");
+                sb.Append("</div>");
+            }
+            sb.Append("</div>");
+        }
+
+        sb.Append("</div>"); // .sav
+        AppendDocEnd(sb);
+        return sb.ToString();
+    }
+
+    private static void AppendSprite(StringBuilder sb, ushort species, bool isShiny)
+    {
+        sb.Append("<div class=\"sprite\"><img alt=\"\" src=\"")
+            .Append(BuildHomeSpriteUrl(species, isShiny))
+            .Append("\"></div>");
+    }
+
+    private static void AppendSpriteSmall(StringBuilder sb, ushort species, bool isShiny)
+    {
+        sb.Append("<img class=\"sprite-sm\" alt=\"\" src=\"")
+            .Append(BuildHomeSpriteUrl(species, isShiny))
+            .Append("\">");
+    }
+
+    // Minimal sprite URL: PokeAPI home sprite by species ID. Form/regional/Mega variants
+    // fall back to the base species sprite — promoted to ImageHelper-quality lookup if
+    // this POC graduates to a real extension.
+    private static string BuildHomeSpriteUrl(ushort species, bool isShiny) =>
+        species.IsValidSpecies()
+            ? $"{PokeApiHomeBaseUrl}{(isShiny ? "shiny/" : string.Empty)}{species}.png"
+            : $"{PokeApiHomeBaseUrl}0.png";
+
+    private static void AppendStatsTable(StringBuilder sb, PKM pkm)
+    {
+        sb.Append("<table class=\"stats\"><thead><tr>")
+            .Append("<th></th><th>HP</th><th>Atk</th><th>Def</th><th>SpA</th><th>SpD</th><th>Spe</th>")
+            .Append("</tr></thead><tbody>");
+        AppendStatRow(sb, "IVs", pkm.IV_HP, pkm.IV_ATK, pkm.IV_DEF, pkm.IV_SPA, pkm.IV_SPD, pkm.IV_SPE);
+        AppendStatRow(sb, "EVs", pkm.EV_HP, pkm.EV_ATK, pkm.EV_DEF, pkm.EV_SPA, pkm.EV_SPD, pkm.EV_SPE);
+        sb.Append("</tbody></table>");
+    }
+
+    private static void AppendStatRow(StringBuilder sb, string label, int hp, int atk, int def, int spa, int spd, int spe)
+    {
+        sb.Append("<tr><th>").Append(label).Append("</th>")
+            .Append("<td>").Append(hp).Append("</td>")
+            .Append("<td>").Append(atk).Append("</td>")
+            .Append("<td>").Append(def).Append("</td>")
+            .Append("<td>").Append(spa).Append("</td>")
+            .Append("<td>").Append(spd).Append("</td>")
+            .Append("<td>").Append(spe).Append("</td>")
+            .Append("</tr>");
+    }
+
+    private static void AppendMovesTable(StringBuilder sb, PKM pkm, GameStrings s)
+    {
+        sb.Append("<table class=\"moves\"><thead><tr><th>Move</th><th>PP</th></tr></thead><tbody>");
+        var pp = pkm.GetPP();
+        ReadOnlySpan<ushort> moves = [pkm.Move1, pkm.Move2, pkm.Move3, pkm.Move4];
+        for (var i = 0; i < moves.Length; i++)
+        {
+            var moveId = moves[i];
+            if (moveId == 0)
+            {
+                continue;
+            }
+            sb.Append("<tr><td>").Append(Escape(Lookup(s.movelist, moveId))).Append("</td>")
+                .Append("<td>").Append(pp[i]).Append('/').Append(pkm.GetMaxPP(i)).Append("</td></tr>");
+        }
+        sb.Append("</tbody></table>");
+    }
+
+    private static void AppendDt(StringBuilder sb, string key, string valueHtml)
+    {
+        sb.Append("<dt>").Append(key).Append("</dt><dd>").Append(valueHtml).Append("</dd>");
+    }
+
+    private static string Lookup(IReadOnlyList<string> list, int index) =>
+        (uint)index < (uint)list.Count ? list[index] : string.Empty;
+
+    private static string LanguageName(int language) => language switch
+    {
+        1 => "Japanese",
+        2 => "English",
+        3 => "French",
+        4 => "Italian",
+        5 => "German",
+        7 => "Spanish",
+        8 => "Korean",
+        9 => "Chinese (Simplified)",
+        10 => "Chinese (Traditional)",
+        _ => language.ToString(CultureInfo.InvariantCulture)
+    };
+
+    private static void AppendDocStart(StringBuilder sb, string title)
+    {
+        sb.Append("<!doctype html><html><head><meta charset=\"utf-8\"><title>")
+            .Append(Escape(title))
+            .Append("</title><style>")
+            .Append(Css)
+            .Append("</style></head><body>");
+    }
+
+    private static void AppendDocEnd(StringBuilder sb)
+    {
+        sb.Append("</body></html>");
+    }
+
+    private static string Escape(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        var sb = new StringBuilder(value.Length);
+        foreach (var c in value)
+        {
+            switch (c)
+            {
+                case '&': sb.Append("&amp;"); break;
+                case '<': sb.Append("&lt;"); break;
+                case '>': sb.Append("&gt;"); break;
+                case '"': sb.Append("&quot;"); break;
+                case '\'': sb.Append("&#39;"); break;
+                default: sb.Append(c); break;
+            }
+        }
+        return sb.ToString();
+    }
+
+    private const string Css = """
+        :root { color-scheme: light dark; }
+        body {
+            font: 13px -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
+            margin: 0; padding: 16px;
+            background: Canvas; color: CanvasText;
+        }
+        h1 { font-size: 18px; margin: 0 0 4px; font-weight: 600; }
+        h2 { font-size: 14px; margin: 16px 0 8px; font-weight: 600; opacity: 0.75; text-transform: uppercase; letter-spacing: 0.04em; }
+        .pkm { display: grid; grid-template-columns: 128px 1fr; gap: 16px; align-items: start; }
+        .sprite img { width: 128px; height: 128px; object-fit: contain; image-rendering: -webkit-optimize-contrast; }
+        .sprite-sm { width: 48px; height: 48px; object-fit: contain; flex-shrink: 0; }
+        .meta { opacity: 0.7; margin-bottom: 12px; }
+        .muted { opacity: 0.6; font-weight: normal; }
+        .shiny { color: #d4a017; }
+        dl.details { display: grid; grid-template-columns: max-content 1fr; gap: 4px 12px; margin: 0 0 12px; }
+        dl.details dt { font-weight: 600; opacity: 0.7; }
+        dl.details dd { margin: 0; }
+        table { border-collapse: collapse; margin: 8px 0; }
+        table.stats th, table.stats td { padding: 4px 8px; text-align: center; font-variant-numeric: tabular-nums; }
+        table.stats thead th { font-weight: 600; opacity: 0.6; font-size: 11px; }
+        table.moves { width: 100%; max-width: 320px; }
+        table.moves th, table.moves td { padding: 4px 8px; text-align: left; }
+        table.moves thead th { font-weight: 600; opacity: 0.6; font-size: 11px; border-bottom: 1px solid color-mix(in srgb, CanvasText 15%, transparent); }
+        table.moves td:last-child { text-align: right; font-variant-numeric: tabular-nums; opacity: 0.7; }
+        .party { display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px; }
+        .party-slot { display: flex; align-items: center; gap: 8px; padding: 8px; border: 1px solid color-mix(in srgb, CanvasText 12%, transparent); border-radius: 6px; }
+        .party-name { font-weight: 600; }
+        """;
+}

--- a/tools/macos-quicklook-poc/PkmdsNative/PkmdsNative.csproj
+++ b/tools/macos-quicklook-poc/PkmdsNative/PkmdsNative.csproj
@@ -14,6 +14,7 @@
 
     <ItemGroup>
         <PackageReference Include="PKHeX.Core"/>
+        <ProjectReference Include="..\..\..\Pkmds.Core\Pkmds.Core.csproj"/>
     </ItemGroup>
 
 </Project>

--- a/tools/macos-quicklook-poc/PkmdsNative/PkmdsNative.csproj
+++ b/tools/macos-quicklook-poc/PkmdsNative/PkmdsNative.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Library</OutputType>
+        <RootNamespace>Pkmds.Native</RootNamespace>
+        <AssemblyName>PkmdsNative</AssemblyName>
+        <PublishAot>true</PublishAot>
+        <NativeLib>Shared</NativeLib>
+        <InvariantGlobalization>true</InvariantGlobalization>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="PKHeX.Core"/>
+    </ItemGroup>
+
+</Project>

--- a/tools/macos-quicklook-poc/README.md
+++ b/tools/macos-quicklook-poc/README.md
@@ -1,0 +1,173 @@
+# macOS Quick Look POC
+
+Proof-of-concept for issue [#549](https://github.com/codemonkey85/PKMDS-Blazor/issues/549): a native macOS Quick Look extension that previews PKHeX-compatible files (`.pk1`–`.pk9`, `.pa8`, `.pb7`, `.pb8`, `.sav`) by calling PKHeX.Core through a NativeAOT-compiled dylib.
+
+This POC validates that the planned approach is viable end-to-end — from binary parsing in C# all the way to a styled HTML preview rendered in Finder's Quick Look UI.
+
+## What's in here
+
+```
+tools/macos-quicklook-poc/
+├── PkmdsNative/                 # C# NativeAOT library (PKHeX.Core wrapper)
+│   ├── Exports.cs               # C-exported pkmds_* entry points
+│   ├── HtmlRenderer.cs          # Self-contained HTML preview generator
+│   └── PkmdsNative.csproj       # PublishAot=true, references Pkmds.Core
+├── swift-cli/                   # Standalone CLI driver (kept for quick smoke-tests)
+│   └── main.swift               # dlopen + dlsym invocation of the dylib
+├── xcode/
+│   ├── project.yml              # xcodegen spec — host app + .appex extension
+│   ├── PkmdsHost/
+│   │   └── PkmdsHostApp.swift   # Minimal SwiftUI placeholder
+│   └── PkmdsQuickLook/
+│       ├── PreviewViewController.swift   # QLPreviewingController + WKWebView
+│       └── PkmdsQuickLook.entitlements   # Sandbox + library validation off
+├── build-and-run.sh             # CLI smoke test (no Xcode involved)
+└── build-extension.sh           # Full pipeline: dotnet → xcode → install → qlmanage
+```
+
+## Prerequisites
+
+- **Full Xcode** (not just Command Line Tools) — `xcode-select -p` must point at `/Applications/Xcode.app/Contents/Developer`. If it doesn't:
+  ```sh
+  sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+  ```
+- **.NET SDK** matching `global.json` (net10.0)
+- **xcodegen** — `brew install xcodegen`
+
+## Build & run
+
+### CLI smoke test (no extension involved)
+
+Builds the AOT dylib and a Swift CLI that loads it via `dlopen`. Useful when iterating on `HtmlRenderer.cs` without the Xcode/codesign cycle.
+
+```sh
+./build-and-run.sh
+# Outputs JSON + writes /tmp/pkmds-poc-pkm.html and /tmp/pkmds-poc-save.html
+```
+
+### Full Quick Look extension
+
+Builds the dylib, generates the Xcode project, builds + signs the host app, deploys to `/Applications`, registers with Launch Services + PluginKit, and runs `qlmanage -p` as a smoke test.
+
+```sh
+./build-extension.sh
+# Then in Finder, press Space on a .pk5/.sav file to preview.
+```
+
+After the first install, you can verify with:
+
+```sh
+qlmanage -p ../../TestFiles/Lucario_B06DDFAD.pk5
+```
+
+## Architecture decisions
+
+### Why NativeAOT, not a subprocess
+
+Tested both. NativeAOT wins for Quick Look's latency budget — Finder expects a preview within ~1s, and CLR cold-start eats most of that. Calling through `dlsym` with NativeAOT measures in single-digit milliseconds.
+
+### Why we don't reuse the Razor components
+
+The existing `Pkmds.Rcl` components require the Blazor runtime, MudBlazor's JS/CSS, and DI services (`IAppState`, `IRefreshService`). Even with `HtmlRenderer` for static SSR, the components are interactive editors wired to app state — not self-contained read-only previews. We hand-roll a small HTML template in `HtmlRenderer.cs` and pull in pure-C# helpers from `Pkmds.Core` (sprite URL resolution, `IsValidSpecies`, `GetMaxPP`, etc.).
+
+### Why `Pkmds.Core` and not `Pkmds.Rcl`
+
+`Pkmds.Core` only references `PKHeX.Core` and is AOT-clean. `Pkmds.Rcl` is a Razor Class Library that drags in MudBlazor, Tailwind, and the Blazor stack — none of which AOT-compiles cleanly. Long-term, the sprite URL helpers in `Pkmds.Rcl/ImageHelper.cs` should move into `Pkmds.Core` so both the web app and the QL extension share them.
+
+## The five non-obvious things that broke us (and how to spot them)
+
+These are in roughly the order we hit them.
+
+### 1. `xcode-select` pointing at Command Line Tools
+
+**Symptom:** `xcodebuild` fails with `tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance`.
+
+**Fix:** `sudo xcode-select -s /Applications/Xcode.app/Contents/Developer`. The build script can also set `DEVELOPER_DIR=...` per-invocation to avoid the global switch.
+
+### 2. Missing `QuickLookUI.framework` link
+
+**Symptom:** Quick Look silently falls back to the default file-icon preview. No crash, no log message — the extension just doesn't run.
+
+**Cause:** Swift's `import Quartz` brings in the module for typechecking but the linker only includes referenced symbols. Conformance to the `QLPreviewingController` protocol alone doesn't generate a strong reference, so the linker dead-strips the framework. At runtime the system tries to instantiate our class, can't resolve the protocol's symbols, gives up.
+
+**Fix:** Explicit `sdk: QuickLookUI.framework` (and `WebKit.framework`) in `project.yml`'s `dependencies`. Verify with `otool -L`.
+
+### 3. Build-directory registration leak
+
+**Symptom:** `pluginkit -mAvvv -i <bundle.id>` shows the extension at the build dir path even after `cp` to `/Applications`. Quick Look says "Extension <id> not found" because it tries to load from a now-deleted or unprivileged path.
+
+**Cause:** `lsregister -f $BUILD_DIR_APP` was creating the registration first; the later `lsregister -f /Applications/...` didn't supersede it.
+
+**Fix:** Build script now does `lsregister -u` on both old paths *before* installing, then registers only the `/Applications` copy.
+
+### 4. `lsregister` alone isn't enough — need `pluginkit -a`
+
+**Symptom:** Extension is in Launch Services (visible via `lsregister -dump`) and BTM marks it `disposition=[enabled, allowed, notified]`, but `pluginkit -mAvvv -i <id>` returns `(no matches)` and Quick Look doesn't dispatch.
+
+**Cause:** PluginKit's plugin database is separate from Launch Services. `lsregister -f` updates LS but doesn't always trigger pkd to pick up the extension.
+
+**Fix:** Build script explicitly runs `pluginkit -a /Applications/PkmdsHost.app/Contents/PlugIns/PkmdsQuickLook.appex` followed by `pluginkit -e use -i com.bondcodes.pkmds.host.quicklook`.
+
+### 5. Library validation rejects the AOT dylib
+
+**Symptom:** Extension crashes immediately (`~/Library/Logs/DiagnosticReports/PkmdsQuickLook-*.ips`) with:
+```
+Library not loaded: @rpath/PkmdsNative.dylib
+Reason: ... mapping process and mapped file (non-platform) have different Team IDs
+```
+
+**Cause:** Hardened runtime + ad-hoc-signed extension + ad-hoc-signed dylib. Each ad-hoc signature counts as its own "team", so amfid (Apple Mobile File Integrity Daemon) rejects loading the dylib into the extension's process.
+
+**Fix:** Add `com.apple.security.cs.disable-library-validation` to the extension's entitlements. **For Mac App Store / Developer ID distribution this entitlement isn't needed** — sign both the extension and the dylib with the same Team ID and library validation passes.
+
+## Diagnostic toolbox
+
+Commands that earned their keep during this POC.
+
+| Command | What it tells you |
+|---|---|
+| `pluginkit -mAvvv -i <bundle.id>` | Is PluginKit aware of our extension? At what path? |
+| `pluginkit -mAvvv -p com.apple.quicklook.preview` | All registered Quick Look extensions |
+| `/System/.../lsregister -dump \| grep <bundle.id>` | Launch Services view: claimed UTIs, plugin identifiers, version |
+| `codesign -d --entitlements - <path>` | What entitlements does the binary actually have? |
+| `codesign -d -v <path>` | Code signature flags (`adhoc`, `runtime`, etc.) |
+| `otool -L <executable>` | Linked frameworks/dylibs and their install names |
+| `otool -D <dylib>` | The dylib's own install name (e.g. `@rpath/...`) |
+| `qlmanage -p <file>` | Trigger a preview without Finder; useful for repeatable tests |
+| `qlmanage -r && qlmanage -r cache` | Reset quicklookd and clear thumbnail cache |
+| `killall pkd quicklookd` | Force PluginKit + Quick Look daemons to restart |
+| `ls -t ~/Library/Logs/DiagnosticReports/PkmdsQuickLook*` | Extension crash reports (`.ips` files) |
+| `/usr/bin/log show --last 30s --predicate 'process == "pkd"'` | PluginKit dispatch decisions in real time |
+
+The two log filters that broke this POC open:
+
+```sh
+# Why is the extension being filtered out?
+/usr/bin/log show --last 30s --predicate \
+  'process == "pkd" AND (composedMessage CONTAINS "Final plugin" OR composedMessage CONTAINS "Candidate plugin")'
+
+# Why did the extension crash on load?
+/usr/bin/log show --last 30s --predicate \
+  'composedMessage CONTAINS[c] "PkmdsNative.dylib" OR composedMessage CONTAINS[c] "PkmdsQuickLook"'
+```
+
+Note: `/usr/bin/log` rather than bare `log` — zsh has a builtin that intercepts the bare invocation.
+
+## Known POC limitations
+
+- **Sprite URL fallback** — `HtmlRenderer.BuildHomeSpriteUrl` only handles base species, not Mega/regional/gender variants. The full mapping lives in `Pkmds.Rcl/ImageHelper.cs`. When promoting this POC to a real extension, move that helper (and its `PokeApiFormSuffixes` / `PokeApiFormIds` dictionaries) into `Pkmds.Core` so both consumers share it.
+- **Ad-hoc signing only** — works for local install. Distribution (Mac App Store or Developer ID + notarization) requires a real signing identity and Team ID; once that's in place, drop `cs.disable-library-validation`.
+- **Trim warnings from PKHeX.Core** — IL2070 on `EntityBlank.GetBlank` and `ReflectUtil.GetAllProperties`, plus three "always throw" notes on `SaveBlock3*.PrintMembers`. Carried over from the original AOT POC findings; none affect the read-only decode path we exercise.
+- **POC outputs only the host display name** — `PkmdsHost` (literally), not branded. Cosmetic; address before any user-facing release.
+- **dylib is 17 MB** — includes resource string tables for all PKHeX-supported games. Acceptable for an extension bundled with a desktop app; would benefit from string-table trimming if size matters.
+
+## Macros for next session
+
+If this POC graduates to a real `tools/macos-quicklook/` (no `-poc` suffix):
+
+1. Promote `ImageHelper` and its form-mapping dictionaries from `Pkmds.Rcl` into `Pkmds.Core` so both Web and QL extension share them.
+2. Replace the inline `BuildHomeSpriteUrl` in `HtmlRenderer.cs` with `ImageHelper.GetPokeApiHomeSpriteUrl`.
+3. Set up Developer ID signing (drop `disable-library-validation`).
+4. Set up notarization in CI.
+5. Decide distribution channel (DMG / Homebrew cask / Mac App Store).
+6. Consider an iOS share extension using the same dylib and `HtmlRenderer`.

--- a/tools/macos-quicklook-poc/build-and-run.sh
+++ b/tools/macos-quicklook-poc/build-and-run.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Builds the AOT dylib and Swift driver, then runs against PKM and save fixtures.
+#
+#   ./build-and-run.sh                                       # default fixtures
+#   ./build-and-run.sh path/to/file.pk9                      # custom pkm fixture
+#   ./build-and-run.sh path/to/file.pk9 path/to/file.sav     # custom both
+#   ./build-and-run.sh "" "" osx-arm64                       # override RID, default fixtures
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_ROOT="$( cd "$SCRIPT_DIR/../.." && pwd )"
+
+PKM_FIXTURE="${1:-$REPO_ROOT/TestFiles/Lucario_B06DDFAD.pk5}"
+SAV_FIXTURE="${2:-$REPO_ROOT/TestFiles/Test-Save-Scarlet.sav}"
+RID="${3:-osx-arm64}"
+
+CSPROJ="$SCRIPT_DIR/PkmdsNative/PkmdsNative.csproj"
+PUBLISH_DIR="$SCRIPT_DIR/PkmdsNative/bin/Release/net10.0/$RID/publish"
+DYLIB="$PUBLISH_DIR/PkmdsNative.dylib"
+
+echo "==> dotnet publish ($RID, AOT)"
+dotnet publish "$CSPROJ" -c Release -r "$RID" --nologo
+
+if [[ ! -f "$DYLIB" ]]; then
+    echo "expected dylib not found at $DYLIB" >&2
+    exit 1
+fi
+
+ls -lh "$DYLIB"
+
+echo "==> swiftc swift-cli/main.swift"
+SWIFT_BIN="$SCRIPT_DIR/swift-cli/pkmds-poc"
+swiftc -O -o "$SWIFT_BIN" "$SCRIPT_DIR/swift-cli/main.swift"
+
+if [[ -n "$PKM_FIXTURE" && -f "$PKM_FIXTURE" ]]; then
+    echo "==> pkm: $PKM_FIXTURE"
+    "$SWIFT_BIN" "$DYLIB" pkm "$PKM_FIXTURE"
+fi
+
+if [[ -n "$SAV_FIXTURE" && -f "$SAV_FIXTURE" ]]; then
+    echo "==> save: $SAV_FIXTURE"
+    "$SWIFT_BIN" "$DYLIB" save "$SAV_FIXTURE"
+fi

--- a/tools/macos-quicklook-poc/build-and-run.sh
+++ b/tools/macos-quicklook-poc/build-and-run.sh
@@ -33,11 +33,15 @@ SWIFT_BIN="$SCRIPT_DIR/swift-cli/pkmds-poc"
 swiftc -O -o "$SWIFT_BIN" "$SCRIPT_DIR/swift-cli/main.swift"
 
 if [[ -n "$PKM_FIXTURE" && -f "$PKM_FIXTURE" ]]; then
-    echo "==> pkm: $PKM_FIXTURE"
+    echo "==> pkm json: $PKM_FIXTURE"
     "$SWIFT_BIN" "$DYLIB" pkm "$PKM_FIXTURE"
+    echo "==> pkm html: $PKM_FIXTURE -> /tmp/pkmds-poc-pkm.html"
+    "$SWIFT_BIN" "$DYLIB" pkm-html "$PKM_FIXTURE" > /tmp/pkmds-poc-pkm.html
 fi
 
 if [[ -n "$SAV_FIXTURE" && -f "$SAV_FIXTURE" ]]; then
-    echo "==> save: $SAV_FIXTURE"
+    echo "==> save json: $SAV_FIXTURE"
     "$SWIFT_BIN" "$DYLIB" save "$SAV_FIXTURE"
+    echo "==> save html: $SAV_FIXTURE -> /tmp/pkmds-poc-save.html"
+    "$SWIFT_BIN" "$DYLIB" save-html "$SAV_FIXTURE" > /tmp/pkmds-poc-save.html
 fi

--- a/tools/macos-quicklook-poc/build-extension.sh
+++ b/tools/macos-quicklook-poc/build-extension.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Builds the AOT dylib + Xcode host app + Quick Look extension, signs ad-hoc,
+# registers with Launch Services, and runs qlmanage on a fixture.
+#
+#   ./build-extension.sh                                  # default fixture
+#   ./build-extension.sh path/to/file.pk5
+#
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_ROOT="$( cd "$SCRIPT_DIR/../.." && pwd )"
+RID="osx-arm64"
+
+FIXTURE="${1:-$REPO_ROOT/TestFiles/Lucario_B06DDFAD.pk5}"
+
+CSPROJ="$SCRIPT_DIR/PkmdsNative/PkmdsNative.csproj"
+PUBLISH_DIR="$SCRIPT_DIR/PkmdsNative/bin/Release/net10.0/$RID/publish"
+DYLIB_SRC="$PUBLISH_DIR/PkmdsNative.dylib"
+DYLIB_DEST="$SCRIPT_DIR/build-resources/PkmdsNative.dylib"
+
+XCODE_DIR="$SCRIPT_DIR/xcode"
+PROJECT="$XCODE_DIR/PkmdsQuickLook.xcodeproj"
+DERIVED="$SCRIPT_DIR/xcode/build"
+APP_PATH="$DERIVED/Build/Products/Release/PkmdsHost.app"
+
+echo "==> dotnet publish ($RID, AOT)"
+dotnet publish "$CSPROJ" -c Release -r "$RID" --nologo
+
+[[ -f "$DYLIB_SRC" ]] || { echo "missing $DYLIB_SRC" >&2; exit 1; }
+
+echo "==> stage dylib at $DYLIB_DEST"
+cp "$DYLIB_SRC" "$DYLIB_DEST"
+
+echo "==> xcodegen generate"
+( cd "$XCODE_DIR" && xcodegen generate --quiet )
+
+echo "==> xcodebuild PkmdsHost (Release, ad-hoc signed)"
+xcodebuild \
+    -project "$PROJECT" \
+    -scheme PkmdsHost \
+    -configuration Release \
+    -derivedDataPath "$DERIVED" \
+    CODE_SIGN_IDENTITY=- \
+    CODE_SIGN_STYLE=Manual \
+    DEVELOPMENT_TEAM= \
+    -quiet \
+    build
+
+[[ -d "$APP_PATH" ]] || { echo "missing built app at $APP_PATH" >&2; exit 1; }
+
+echo "==> codesign extension with entitlements + bundle ad-hoc"
+ENTITLEMENTS="$XCODE_DIR/PkmdsQuickLook/PkmdsQuickLook.entitlements"
+APPEX="$APP_PATH/Contents/PlugIns/PkmdsQuickLook.appex"
+codesign --force --sign - --timestamp=none "$APPEX/Contents/Frameworks/PkmdsNative.dylib"
+codesign --force --sign - --timestamp=none --options runtime --entitlements "$ENTITLEMENTS" "$APPEX"
+codesign --force --sign - --timestamp=none "$APP_PATH"
+
+echo "==> deploy to /Applications and register only that copy"
+LSREGISTER=/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister
+INSTALLED=/Applications/PkmdsHost.app
+osascript -e 'quit app "PkmdsHost"' 2>/dev/null || true
+sleep 1
+"$LSREGISTER" -u "$APP_PATH" 2>/dev/null || true   # unregister the build-dir copy
+"$LSREGISTER" -u "$INSTALLED" 2>/dev/null || true
+rm -rf "$INSTALLED"
+cp -R "$APP_PATH" "$INSTALLED"
+"$LSREGISTER" -f "$INSTALLED"
+pluginkit -a "$INSTALLED/Contents/PlugIns/PkmdsQuickLook.appex"
+pluginkit -e use -i com.bondcodes.pkmds.host.quicklook
+killall pkd quicklookd 2>/dev/null || true
+sleep 1
+qlmanage -r >/dev/null 2>&1 || true
+qlmanage -r cache >/dev/null 2>&1 || true
+
+echo "==> qlmanage -p $FIXTURE"
+qlmanage -p "$FIXTURE" 2>&1 | tail -20 || true
+
+echo
+echo "Built and installed: $INSTALLED"
+echo "Press Space on a .pk5/.sav in Finder to preview."

--- a/tools/macos-quicklook-poc/swift-cli/main.swift
+++ b/tools/macos-quicklook-poc/swift-cli/main.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+func usage(_ name: String) -> Never {
+    FileHandle.standardError.write(Data("usage: \(name) <libPkmdsNative.dylib> <pkm|save> <file>\n".utf8))
+    exit(64)
+}
+
+let argv = CommandLine.arguments
+let progName = (argv.first as NSString?)?.lastPathComponent ?? "pkmds-poc"
+guard argv.count >= 4 else { usage(progName) }
+
+let dylibPath = argv[1]
+let kind = argv[2]
+let inputPath = argv[3]
+
+let symbolName: String
+switch kind {
+case "pkm":  symbolName = "pkmds_describe_pkm"
+case "save": symbolName = "pkmds_describe_save"
+default:     usage(progName)
+}
+
+guard let handle = dlopen(dylibPath, RTLD_NOW) else {
+    let err = dlerror().map { String(cString: $0) } ?? "unknown"
+    FileHandle.standardError.write(Data("dlopen failed: \(err)\n".utf8))
+    exit(1)
+}
+defer { dlclose(handle) }
+
+guard let symbol = dlsym(handle, symbolName) else {
+    FileHandle.standardError.write(Data("dlsym failed: \(symbolName) not exported\n".utf8))
+    exit(1)
+}
+
+typealias DescribeFn = @convention(c) (
+    UnsafePointer<UInt8>?, Int32, UnsafeMutablePointer<UInt8>?, Int32
+) -> Int32
+let describe = unsafeBitCast(symbol, to: DescribeFn.self)
+
+let data: Data
+do {
+    data = try Data(contentsOf: URL(fileURLWithPath: inputPath))
+} catch {
+    FileHandle.standardError.write(Data("read failed: \(error)\n".utf8))
+    exit(1)
+}
+
+let outCap = 64 * 1024
+var outBuf = [UInt8](repeating: 0, count: outCap)
+
+let written = data.withUnsafeBytes { (raw: UnsafeRawBufferPointer) -> Int32 in
+    let ptr = raw.bindMemory(to: UInt8.self).baseAddress
+    return outBuf.withUnsafeMutableBufferPointer { dst in
+        describe(ptr, Int32(data.count), dst.baseAddress, Int32(outCap))
+    }
+}
+
+if written < 0 {
+    FileHandle.standardError.write(Data("\(symbolName) failed: code \(written)\n".utf8))
+    exit(2)
+}
+
+let json = String(decoding: outBuf.prefix(Int(written)), as: UTF8.self)
+print(json)

--- a/tools/macos-quicklook-poc/swift-cli/main.swift
+++ b/tools/macos-quicklook-poc/swift-cli/main.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 func usage(_ name: String) -> Never {
-    FileHandle.standardError.write(Data("usage: \(name) <libPkmdsNative.dylib> <pkm|save> <file>\n".utf8))
+    FileHandle.standardError.write(Data("usage: \(name) <libPkmdsNative.dylib> <pkm|save|pkm-html|save-html> <file>\n".utf8))
     exit(64)
 }
 
@@ -14,10 +14,13 @@ let kind = argv[2]
 let inputPath = argv[3]
 
 let symbolName: String
+let outCap: Int
 switch kind {
-case "pkm":  symbolName = "pkmds_describe_pkm"
-case "save": symbolName = "pkmds_describe_save"
-default:     usage(progName)
+case "pkm":       symbolName = "pkmds_describe_pkm";    outCap = 64 * 1024
+case "save":      symbolName = "pkmds_describe_save";   outCap = 64 * 1024
+case "pkm-html":  symbolName = "pkmds_render_pkm_html"; outCap = 256 * 1024
+case "save-html": symbolName = "pkmds_render_save_html"; outCap = 256 * 1024
+default:          usage(progName)
 }
 
 guard let handle = dlopen(dylibPath, RTLD_NOW) else {
@@ -45,7 +48,6 @@ do {
     exit(1)
 }
 
-let outCap = 64 * 1024
 var outBuf = [UInt8](repeating: 0, count: outCap)
 
 let written = data.withUnsafeBytes { (raw: UnsafeRawBufferPointer) -> Int32 in

--- a/tools/macos-quicklook-poc/xcode/PkmdsHost/PkmdsHostApp.swift
+++ b/tools/macos-quicklook-poc/xcode/PkmdsHost/PkmdsHostApp.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+@main
+struct PkmdsHostApp: App {
+    var body: some Scene {
+        WindowGroup("PKMDS Quick Look (POC)") {
+            ContentView()
+                .frame(minWidth: 420, minHeight: 220)
+        }
+    }
+}
+
+struct ContentView: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("PKMDS Quick Look — Proof of Concept")
+                .font(.title2.bold())
+            Text("This host app exists so macOS will register the bundled Quick Look extension. Press Space on a `.pk*` or `.sav` file in Finder to preview.")
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(24)
+    }
+}

--- a/tools/macos-quicklook-poc/xcode/PkmdsQuickLook/PkmdsQuickLook.entitlements
+++ b/tools/macos-quicklook-poc/xcode/PkmdsQuickLook/PkmdsQuickLook.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.files.user-selected.read-only</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/tools/macos-quicklook-poc/xcode/PkmdsQuickLook/PreviewViewController.swift
+++ b/tools/macos-quicklook-poc/xcode/PkmdsQuickLook/PreviewViewController.swift
@@ -1,0 +1,64 @@
+import Cocoa
+import Quartz
+import WebKit
+
+@_silgen_name("pkmds_render_pkm_html")
+private func pkmds_render_pkm_html(
+    _ data: UnsafePointer<UInt8>?, _ length: Int32,
+    _ outHtml: UnsafeMutablePointer<UInt8>?, _ outCap: Int32
+) -> Int32
+
+@_silgen_name("pkmds_render_save_html")
+private func pkmds_render_save_html(
+    _ data: UnsafePointer<UInt8>?, _ length: Int32,
+    _ outHtml: UnsafeMutablePointer<UInt8>?, _ outCap: Int32
+) -> Int32
+
+private let outputCapacity = 256 * 1024
+
+final class PreviewViewController: NSViewController, QLPreviewingController {
+    private var webView: WKWebView!
+
+    override func loadView() {
+        let config = WKWebViewConfiguration()
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        webView.setValue(false, forKey: "drawsBackground")
+        self.webView = webView
+        self.view = webView
+    }
+
+    func preparePreviewOfFile(at url: URL, completionHandler: @escaping (Error?) -> Void) {
+        do {
+            let data = try Data(contentsOf: url)
+            let html = try render(data: data, url: url)
+            webView.loadHTMLString(html, baseURL: nil)
+            completionHandler(nil)
+        } catch {
+            completionHandler(error)
+        }
+    }
+
+    private func render(data: Data, url: URL) throws -> String {
+        let ext = url.pathExtension.lowercased()
+        let isSave = ext == "sav"
+        let renderer: (UnsafePointer<UInt8>?, Int32, UnsafeMutablePointer<UInt8>?, Int32) -> Int32 =
+            isSave ? pkmds_render_save_html : pkmds_render_pkm_html
+
+        var outBuf = [UInt8](repeating: 0, count: outputCapacity)
+        let written = data.withUnsafeBytes { (raw: UnsafeRawBufferPointer) -> Int32 in
+            let ptr = raw.bindMemory(to: UInt8.self).baseAddress
+            return outBuf.withUnsafeMutableBufferPointer { dst in
+                renderer(ptr, Int32(data.count), dst.baseAddress, Int32(outputCapacity))
+            }
+        }
+
+        guard written > 0 else {
+            throw NSError(
+                domain: "com.bondcodes.pkmds.quicklook",
+                code: Int(written),
+                userInfo: [NSLocalizedDescriptionKey: "renderer returned \(written)"])
+        }
+        return String(decoding: outBuf.prefix(Int(written)), as: UTF8.self)
+    }
+}

--- a/tools/macos-quicklook-poc/xcode/project.yml
+++ b/tools/macos-quicklook-poc/xcode/project.yml
@@ -1,0 +1,115 @@
+name: PkmdsQuickLook
+options:
+  bundleIdPrefix: com.bondcodes.pkmds
+  deploymentTarget:
+    macOS: "13.0"
+  createIntermediateGroups: true
+  groupSortPosition: top
+
+settings:
+  base:
+    SWIFT_VERSION: "5.0"
+    CODE_SIGN_STYLE: Manual
+    CODE_SIGN_IDENTITY: "-"
+    DEVELOPMENT_TEAM: ""
+    ENABLE_HARDENED_RUNTIME: NO
+    OTHER_CODE_SIGN_FLAGS: "--timestamp=none"
+
+targets:
+  PkmdsHost:
+    type: application
+    platform: macOS
+    sources:
+      - path: PkmdsHost
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.bondcodes.pkmds.host
+        INFOPLIST_KEY_NSHumanReadableCopyright: ""
+        INFOPLIST_KEY_LSApplicationCategoryType: "public.app-category.utilities"
+        INFOPLIST_KEY_NSPrincipalClass: NSApplication
+        ENABLE_USER_SCRIPT_SANDBOXING: YES
+        MARKETING_VERSION: "0.0.1"
+        CURRENT_PROJECT_VERSION: "1"
+    info:
+      path: PkmdsHost/Info.plist
+      properties:
+        CFBundleDisplayName: PKMDS Quick Look (POC)
+        CFBundleShortVersionString: "$(MARKETING_VERSION)"
+        CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
+        LSApplicationCategoryType: public.app-category.utilities
+        UTExportedTypeDeclarations:
+          - UTTypeIdentifier: com.bondcodes.pkmds.pkm-file
+            UTTypeDescription: Pokémon Entity File
+            UTTypeConformsTo:
+              - public.data
+            UTTypeTagSpecification:
+              public.filename-extension:
+                - pk1
+                - pk2
+                - pk3
+                - pk4
+                - pk5
+                - pk6
+                - pk7
+                - pk8
+                - pk9
+                - pa8
+                - pb7
+                - pb8
+          - UTTypeIdentifier: com.bondcodes.pkmds.save-file
+            UTTypeDescription: Pokémon Save File
+            UTTypeConformsTo:
+              - public.data
+            UTTypeTagSpecification:
+              public.filename-extension:
+                - sav
+        CFBundleDocumentTypes:
+          - CFBundleTypeName: Pokémon Entity File
+            CFBundleTypeRole: Viewer
+            LSItemContentTypes:
+              - com.bondcodes.pkmds.pkm-file
+            LSHandlerRank: Alternate
+          - CFBundleTypeName: Pokémon Save File
+            CFBundleTypeRole: Viewer
+            LSItemContentTypes:
+              - com.bondcodes.pkmds.save-file
+            LSHandlerRank: Alternate
+    dependencies:
+      - target: PkmdsQuickLook
+        embed: true
+        codeSign: true
+
+  PkmdsQuickLook:
+    type: app-extension
+    platform: macOS
+    sources:
+      - path: PkmdsQuickLook
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.bondcodes.pkmds.host.quicklook
+        LD_RUNPATH_SEARCH_PATHS: "@executable_path/../Frameworks"
+        SKIP_INSTALL: YES
+        MARKETING_VERSION: "0.0.1"
+        CURRENT_PROJECT_VERSION: "1"
+        ENABLE_HARDENED_RUNTIME: YES
+        CODE_SIGN_ENTITLEMENTS: PkmdsQuickLook/PkmdsQuickLook.entitlements
+    info:
+      path: PkmdsQuickLook/Info.plist
+      properties:
+        CFBundleDisplayName: PKMDS Quick Look
+        CFBundleShortVersionString: "$(MARKETING_VERSION)"
+        CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
+        NSExtension:
+          NSExtensionPointIdentifier: com.apple.quicklook.preview
+          NSExtensionPrincipalClass: $(PRODUCT_MODULE_NAME).PreviewViewController
+          NSExtensionAttributes:
+            QLSupportedContentTypes:
+              - com.bondcodes.pkmds.pkm-file
+              - com.bondcodes.pkmds.save-file
+            QLSupportsSearchableItems: false
+    dependencies:
+      - framework: ../build-resources/PkmdsNative.dylib
+        embed: true
+        codeSign: true
+      - sdk: QuickLookUI.framework
+      - sdk: WebKit.framework


### PR DESCRIPTION
## Summary

Closes #549.

End-to-end proof-of-concept that Finder can render rich previews for PKHeX-compatible files via a native macOS Quick Look extension calling PKHeX.Core through a NativeAOT-compiled dylib. Working today for `.pk1`–`.pk9`, `.pa8`, `.pb7`, `.pb8`, and `.sav`.

- **NativeAOT C# library** (`tools/macos-quicklook-poc/PkmdsNative/`) wraps `EntityFormat.GetFromBytes` / `SaveUtil.TryGetSaveFile` and emits self-contained HTML with inline CSS, system fonts, and `color-scheme: light dark` for auto appearance switching. References `Pkmds.Core` for shared helpers.
- **Quick Look extension** (`tools/macos-quicklook-poc/xcode/`) — xcodegen-described host app + `.appex` extension. `QLPreviewingController` subclass loads file bytes, calls into the dylib via `@_silgen_name` C interop, displays the returned HTML in a `WKWebView`. Custom UTI declarations cover all supported file extensions.
- **`build-extension.sh`** — full pipeline from `dotnet publish` through `xcodegen` → `xcodebuild` → entitlements signing → `/Applications` install → Launch Services + PluginKit registration → `qlmanage -p` smoke test.
- **`README.md`** captures architecture decisions, the five non-obvious gotchas we hit (xcode-select target, framework linkage, build-dir registration leak, `pluginkit -a` requirement, library validation under hardened runtime), and the diagnostic command toolbox.

The main app is unaffected — all changes live under `tools/macos-quicklook-poc/`.

## Screenshots

`.pk5` preview (Lucario): sprite, level/nature, OT/TID/SID, ability, item, format, IV/EV grid, moves with PP.

`.sav` preview (Sun): trainer header, save metadata, party with mini-sprites.

## Why "POC" not production

The README's _Known limitations_ section enumerates what's left before a real release:
- Sprite URL fallback handles only base species (Mega/regional/gender variants need `ImageHelper` promoted from `Pkmds.Rcl` to `Pkmds.Core` so both consumers share it)
- Ad-hoc signing only — Developer ID + notarization required for distribution; `cs.disable-library-validation` entitlement can be dropped at that point
- Carries over the original POC's IL2070 trim warnings on PKHeX.Core reflection paths not used by the read-only decode path

Closing the issue because the technical viability is proven and a clear next-steps macro is documented; productionization belongs in follow-up work.

## Test plan

- [ ] `dotnet build Pkmds.slnx -c Debug` passes (verified locally — main app untouched)
- [ ] `./tools/macos-quicklook-poc/build-and-run.sh` produces JSON + HTML to `/tmp/pkmds-poc-*.html` (CLI smoke test)
- [ ] `./tools/macos-quicklook-poc/build-extension.sh` builds, signs, installs, and the `qlmanage -p` smoke test renders our HTML
- [ ] Press Space on a `.pk5` in Finder — preview shows sprite + stats
- [ ] Press Space on a `.sav` in Finder — preview shows trainer + party

🤖 Generated with [Claude Code](https://claude.com/claude-code)