### PR TITLE
feat: browser-based embedded host mock PoC (#798)

### DIFF
--- a/EMBEDDED_HOST_GUIDE.md
+++ b/EMBEDDED_HOST_GUIDE.md
@@ -138,6 +138,12 @@ The same code path works in any browser. Run `./watch.ps1` and visit `http://loc
 
 Build your Swift bridge against this observable shim before you have a working `WKURLSchemeHandler` — the contract is identical.
 
+### Browser-based mock host page (PoC)
+
+For a more complete end-to-end demonstration — including mock Done/Cancel chrome, a file picker outside PKMDS, and a live message log — see [`tools/embedded-host-poc/`](tools/embedded-host-poc/README.md).
+
+The mock host page embeds PKMDS in an `<iframe src="/?host=poc">` and drives it entirely through `window.postMessage`, simulating exactly what a native host app must do. It runs without Xcode, a device, or a real `WKWebView`. Open `tools/embedded-host-poc/index.html` directly in a browser while the dev server is running (`./watch.ps1`).
+
 ## 7. Getting a publishable bundle
 
 ```bash

--- a/Pkmds.Web/wwwroot/js/app.js
+++ b/Pkmds.Web/wwwroot/js/app.js
@@ -50,6 +50,50 @@ if (pkmdsIsEmbedded()) {
     window._swRegistrationPromise = Promise.resolve(null);
 }
 
+// Embedded PoC polyfill — active only when ?host=poc.
+//
+// Routes PKMDS outbound messages (ready, saveExport) to the parent page via
+// window.parent.postMessage, and handles inbound method calls (loadSave,
+// requestExport) arriving as postMessages from the parent.
+//
+// This makes the standalone tools/embedded-host-poc/index.html page work
+// cross-origin without requiring same-origin iframe access or Xcode.
+// All other host values and standalone mode are completely unaffected.
+(function () {
+    var params;
+    try { params = new URLSearchParams(window.location.search); } catch (e) { return; }
+    if (params.get('host') !== 'poc') return;
+
+    // Polyfill window.webkit.messageHandlers.pkmds to route outbound messages
+    // to the parent page. host.js reads window.webkit at call time (not at
+    // definition time), so this is safe to set even after host.js has loaded.
+    window.webkit = window.webkit || {};
+    window.webkit.messageHandlers = window.webkit.messageHandlers || {};
+    window.webkit.messageHandlers.pkmds = {
+        postMessage: function (msg) {
+            window.parent.postMessage(msg, '*');
+        }
+    };
+
+    // Handle inbound method calls from the parent page.
+    // Protocol: parent sends { type: 'pkmds-host-call', method, args, id }
+    //           iframe responds { type: 'pkmds-host-result', id, result }
+    // The parent should only call loadSave / requestExport after receiving the
+    // 'ready' outbound message, at which point window.PKMDS.host is available.
+    window.addEventListener('message', function (event) {
+        var data = event.data;
+        if (!data || data.type !== 'pkmds-host-call') return;
+        var method = data.method;
+        var args = data.args || [];
+        var id = data.id;
+        var src = event.source || window.parent;
+        Promise.resolve()
+            .then(function () { return window.PKMDS.host[method].apply(window.PKMDS.host, args); })
+            .then(function (result) { src.postMessage({ type: 'pkmds-host-result', id: id, result: result }, '*'); })
+            .catch(function (err) { src.postMessage({ type: 'pkmds-host-result', id: id, result: false, error: String(err) }, '*'); });
+    });
+})();
+
 // Listen for update events and forward to Blazor
 window.addUpdateListener = () => {
     window.addEventListener('updateAvailable', () => {

--- a/tools/embedded-host-poc/README.md
+++ b/tools/embedded-host-poc/README.md
@@ -1,0 +1,98 @@
+# Embedded Host PoC — Browser-based mock host page
+
+Proof-of-concept for issue [#798](https://github.com/codemonkey85/PKMDS-Blazor/issues/798): a standalone HTML page that simulates what a native host (iOS/iPadOS `WKWebView` app) has to build, using only browser APIs. Lets you verify the embedded JS bridge end-to-end without Xcode, a device, or a real `WKWebView`.
+
+See [`EMBEDDED_HOST_GUIDE.md`](../../EMBEDDED_HOST_GUIDE.md) for the full integration contract this PoC exercises.
+
+## What's in here
+
+```
+tools/embedded-host-poc/
+├── index.html     # Mock host page — rendered in a browser tab
+└── mock-host.js   # Parent-page JS (file picker, Done/Cancel, log panel)
+```
+
+The companion to this PoC is the `?host=poc` polyfill added to `Pkmds.Web/wwwroot/js/app.js`, which activates only when `?host=poc` is in the URL and routes PKMDS outbound messages via `window.parent.postMessage`.
+
+## How it works
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Browser tab  —  tools/embedded-host-poc/index.html         │
+│                                                              │
+│  ┌──── Mock native chrome ────────────────────────────────┐ │
+│  │  [Cancel]    PKMDS (Mock Host PoC)    [Done]           │ │
+│  │  Load save: [Choose .sav…]  status text                │ │
+│  └────────────────────────────────────────────────────────┘ │
+│                                                              │
+│  ┌──── PKMDS iframe (?host=poc) ──────────┐ ┌─ Log panel ┐ │
+│  │                                         │ │  ready     │ │
+│  │   (Blazor WASM save editor)             │ │  loadSave  │ │
+│  │                                         │ │  saveExport│ │
+│  └─────────────────────────────────────────┘ └────────────┘ │
+└─────────────────────────────────────────────────────────────┘
+```
+
+All communication goes through `window.postMessage` — the same cross-origin mechanism a real `WKWebView` uses for `webkit.messageHandlers`. No same-origin requirement, no build step.
+
+## End-to-end flow
+
+1. Page loads → iframe boots PKMDS with `?host=poc`.
+2. PKMDS boots, posts `ready` → parent enables the file picker and Cancel/Done buttons.
+3. Pick a `.sav` → parent reads it, base64-encodes it, sends `loadSave` to the iframe.
+4. PKMDS decodes and renders the save (boxes/party appear).
+5. Tap **Done** → parent calls `requestExport()` in the iframe → PKMDS posts `saveExport` with base64 bytes → parent decodes and triggers a browser download.
+6. Tap **Cancel** → parent resets state; save is not exported.
+
+## How to run
+
+### Option A — same-origin serve (recommended, relative iframe URL)
+
+Start the PKMDS dev server and open the PoC from the same origin:
+
+```powershell
+# From repo root (PowerShell)
+./watch.ps1
+```
+
+Then copy the PoC files alongside the dev site temporarily, or access them from a server that shares the same origin as `localhost:5283`. The simplest approach:
+
+```powershell
+# Copy PoC files into wwwroot so they're served from the same origin
+Copy-Item tools/embedded-host-poc/index.html   Pkmds.Web/wwwroot/embedded-poc/index.html -Force
+Copy-Item tools/embedded-host-poc/mock-host.js Pkmds.Web/wwwroot/embedded-poc/mock-host.js -Force
+```
+
+Then open `http://localhost:5283/embedded-poc/` in your browser.
+
+### Option B — open directly as a local file
+
+The PoC works without any server. Open `index.html` directly in your browser (`File → Open…`). The page defaults to `http://localhost:5283/?host=poc` for the iframe, so the PKMDS dev server must be running at that address.
+
+```powershell
+./watch.ps1          # keep running
+# then open tools/embedded-host-poc/index.html in your browser
+```
+
+To point the iframe at a different PKMDS URL, append `?pkmds=<url>`:
+
+```
+file:///path/to/index.html?pkmds=http://localhost:5283
+```
+
+## Two different developer tools — why not just use `?host=test`?
+
+| | `?host=test` | Mock host page |
+|---|---|---|
+| **Lives** | Inside PKMDS | Outside PKMDS |
+| **Audience** | PKMDS contributors smoke-testing the bridge | Downstream integrators learning what their app must build |
+| **File picker** | PKMDS renders its own picker | Mock host renders the picker (as a native app would) |
+| **Done/Cancel chrome** | Not present | Shown (demonstrating the host's responsibility) |
+| **Message log** | DevTools console only | Visible UI panel |
+
+## Known PoC limitations
+
+- **No real WKWebView** — this is a browser-on-browser simulation. Cross-origin policy, postMessage timing, and browser file-picker behaviour differ from a native WKWebView host.
+- **One-shot session** — no save persistence between page reloads (same as real embed mode).
+- **Export is raw bytes** — Manic EMU `.zip` wrapper is not rebuilt (see `EMBEDDED_HOST_GUIDE.md` § 5).
+- **Not a polished UI** — developer-facing demo only; production host chrome is your app's responsibility.

--- a/tools/embedded-host-poc/index.html
+++ b/tools/embedded-host-poc/index.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>PKMDS — Embedded Host PoC</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #1a1a1a;
+      color: #f5f5f5;
+      height: 100dvh;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    /* ── Mock native navigation bar ── */
+    .nav-bar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 10px 16px;
+      background: #2c2c2e;
+      border-bottom: 1px solid #3a3a3c;
+      flex-shrink: 0;
+    }
+    .nav-title {
+      font-size: 17px;
+      font-weight: 600;
+      color: #f5f5f5;
+    }
+    .nav-subtitle {
+      font-size: 11px;
+      color: #8e8e93;
+      text-align: center;
+      margin-top: 1px;
+    }
+    .btn {
+      padding: 7px 16px;
+      border: none;
+      border-radius: 8px;
+      font-size: 15px;
+      font-weight: 500;
+      cursor: pointer;
+      transition: opacity 0.15s;
+    }
+    .btn:disabled { opacity: 0.35; cursor: not-allowed; }
+    .btn-done   { background: #0a84ff; color: #fff; }
+    .btn-cancel { background: transparent; color: #ff453a; border: 1px solid #ff453a; }
+
+    /* ── Toolbar ── */
+    .toolbar {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 8px 16px;
+      background: #2c2c2e;
+      border-bottom: 1px solid #3a3a3c;
+      flex-shrink: 0;
+      flex-wrap: wrap;
+    }
+    .toolbar-label { font-size: 13px; color: #aeaeb2; white-space: nowrap; }
+    .file-btn {
+      padding: 5px 12px;
+      font-size: 13px;
+      background: #3a3a3c;
+      color: #f5f5f5;
+      border: none;
+      border-radius: 6px;
+      cursor: pointer;
+    }
+    .file-btn:disabled { opacity: 0.35; cursor: not-allowed; }
+    .file-input { display: none; }
+    .status {
+      font-size: 12px;
+      color: #aeaeb2;
+      font-style: italic;
+      flex: 1;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    /* ── Main area ── */
+    .main {
+      display: flex;
+      flex: 1;
+      min-height: 0;
+    }
+
+    /* ── PKMDS iframe ── */
+    #pkmds-frame {
+      flex: 1;
+      border: none;
+      background: #fff;
+      min-width: 0;
+    }
+
+    /* ── Message log panel ── */
+    .log-panel {
+      width: 300px;
+      display: flex;
+      flex-direction: column;
+      background: #1c1c1e;
+      border-left: 1px solid #3a3a3c;
+      flex-shrink: 0;
+    }
+    .log-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 8px 12px;
+      background: #2c2c2e;
+      border-bottom: 1px solid #3a3a3c;
+      font-size: 11px;
+      font-weight: 600;
+      color: #8e8e93;
+      text-transform: uppercase;
+      letter-spacing: 0.4px;
+      flex-shrink: 0;
+    }
+    .log-clear {
+      font-size: 11px;
+      font-weight: 400;
+      text-transform: none;
+      letter-spacing: 0;
+      color: #0a84ff;
+      cursor: pointer;
+    }
+    .log-entries {
+      flex: 1;
+      overflow-y: auto;
+      padding: 8px;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+    .log-empty {
+      color: #3a3a3c;
+      font-size: 12px;
+      text-align: center;
+      padding-top: 20px;
+    }
+    .log-entry {
+      padding: 7px 9px;
+      border-radius: 6px;
+      background: #2c2c2e;
+      font-family: 'SF Mono', 'Menlo', 'Consolas', monospace;
+      font-size: 11px;
+      line-height: 1.5;
+      border-left: 3px solid transparent;
+    }
+    .log-entry.kind-ready   { border-left-color: #30d158; }
+    .log-entry.kind-export  { border-left-color: #0a84ff; }
+    .log-entry.kind-call    { border-left-color: #ffd60a; }
+    .log-entry.kind-error   { border-left-color: #ff453a; }
+    .log-time   { color: #636366; font-size: 10px; }
+    .log-kind   { font-weight: 700; color: #f5f5f5; }
+    .log-detail { color: #aeaeb2; word-break: break-all; white-space: pre-wrap; margin-top: 2px; }
+
+    @media (max-width: 700px) {
+      .log-panel { display: none; }
+    }
+  </style>
+</head>
+<body>
+
+  <!-- Mock native navigation bar (Done / Cancel chrome) -->
+  <div class="nav-bar">
+    <button class="btn btn-cancel" id="btn-cancel" disabled>Cancel</button>
+    <div>
+      <div class="nav-title">PKMDS</div>
+      <div class="nav-subtitle">Mock Host PoC</div>
+    </div>
+    <button class="btn btn-done" id="btn-done" disabled>Done</button>
+  </div>
+
+  <!-- File picker toolbar -->
+  <div class="toolbar">
+    <span class="toolbar-label">Load save:</span>
+    <button class="file-btn" id="file-btn" disabled>Choose .sav…</button>
+    <input type="file" class="file-input" id="file-input" accept="*/*"/>
+    <span class="status" id="status">Waiting for PKMDS to boot…</span>
+  </div>
+
+  <div class="main">
+    <!-- PKMDS embedded in an iframe with ?host=poc -->
+    <iframe id="pkmds-frame" title="PKMDS save editor"></iframe>
+
+    <!-- Bridge message log panel -->
+    <div class="log-panel">
+      <div class="log-header">
+        Bridge messages
+        <span class="log-clear" id="log-clear">Clear</span>
+      </div>
+      <div class="log-entries" id="log-entries">
+        <div class="log-empty">No messages yet</div>
+      </div>
+    </div>
+  </div>
+
+  <script src="mock-host.js"></script>
+</body>
+</html>

--- a/tools/embedded-host-poc/mock-host.js
+++ b/tools/embedded-host-poc/mock-host.js
@@ -1,0 +1,295 @@
+'use strict';
+
+// Determine the PKMDS base URL.
+//
+// When this page is served from the same origin as the PKMDS dev server
+// (the normal case — both at http://localhost:5283), a relative URL works
+// perfectly. When opened directly as a local file (file://), default to the
+// standard dev-server address. Override either case with ?pkmds=<url>.
+var pkmdsParam = new URLSearchParams(location.search).get('pkmds');
+var pkmdsOrigin = pkmdsParam ||
+    (location.protocol !== 'file:' ? location.origin : 'http://localhost:5283');
+document.getElementById('pkmds-frame').src = pkmdsOrigin + '/?host=poc';
+
+// ── DOM references ─────────────────────────────────────────────────────────
+
+var frame     = document.getElementById('pkmds-frame');
+var btnDone   = document.getElementById('btn-done');
+var btnCancel = document.getElementById('btn-cancel');
+var fileBtn   = document.getElementById('file-btn');
+var fileInput = document.getElementById('file-input');
+var statusEl  = document.getElementById('status');
+var logEl     = document.getElementById('log-entries');
+var logClear  = document.getElementById('log-clear');
+
+// ── State ──────────────────────────────────────────────────────────────────
+
+var callIdSeq = 0;
+var pendingCalls = {};       // id → { resolve, reject }
+var saveLoaded = false;
+var saveExportResolver = null; // resolves when saveExport arrives
+
+// ── Utilities ──────────────────────────────────────────────────────────────
+
+function nextId() {
+    return 'c' + (++callIdSeq);
+}
+
+function timestamp() {
+    var d = new Date();
+    return d.toTimeString().slice(0, 8) + '.'
+        + String(d.getMilliseconds()).padStart(3, '0');
+}
+
+function setStatus(text) {
+    statusEl.textContent = text;
+}
+
+// Append a message to the log panel.
+function log(cssKind, label, detail) {
+    var empty = logEl.querySelector('.log-empty');
+    if (empty) empty.remove();
+
+    var entry = document.createElement('div');
+    entry.className = 'log-entry kind-' + cssKind;
+
+    var head = document.createElement('div');
+    head.innerHTML =
+        '<span class="log-time">' + timestamp() + '</span>'
+        + ' <span class="log-kind">' + escapeHtml(label) + '</span>';
+    entry.appendChild(head);
+
+    if (detail) {
+        var det = document.createElement('div');
+        det.className = 'log-detail';
+        det.textContent = detail;
+        entry.appendChild(det);
+    }
+
+    logEl.insertBefore(entry, logEl.firstChild); // newest on top
+}
+
+function escapeHtml(str) {
+    return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+}
+
+// ── Bridge: inbound (parent → iframe) ─────────────────────────────────────
+
+// Send a method call to window.PKMDS.host inside the iframe.
+// Returns a Promise that resolves with the call's return value.
+// The iframe's ?host=poc polyfill (in app.js) handles these messages.
+function callIframe(method, args) {
+    return new Promise(function (resolve, reject) {
+        var id = nextId();
+        pendingCalls[id] = { resolve: resolve, reject: reject };
+
+        // Safety net: reject if the iframe never responds
+        var timer = setTimeout(function () {
+            if (pendingCalls[id]) {
+                delete pendingCalls[id];
+                reject(new Error('Timeout waiting for response to ' + method));
+            }
+        }, 30000);
+
+        pendingCalls[id].timer = timer;
+
+        frame.contentWindow.postMessage(
+            { type: 'pkmds-host-call', method: method, args: args || [], id: id },
+            '*'
+        );
+    });
+}
+
+// ── Bridge: outbound (iframe → parent) ────────────────────────────────────
+
+// Handle a message posted by PKMDS (via the ?host=poc webkit polyfill).
+function handleOutbound(msg) {
+    switch (msg.kind) {
+
+        case 'ready':
+            log('ready', 'ready', null);
+            setStatus('PKMDS ready — pick a .sav file to load.');
+            fileBtn.disabled = false;
+            btnCancel.disabled = false;
+            break;
+
+        case 'saveExport':
+            log('export', 'saveExport',
+                'fileName: ' + msg.fileName + '\n'
+                + 'data: ' + msg.data.slice(0, 40) + '… ('
+                + msg.data.length + ' base64 chars)');
+            if (saveExportResolver) {
+                var resolver = saveExportResolver;
+                saveExportResolver = null;
+                resolver(msg);
+            }
+            break;
+
+        default:
+            log('call', msg.kind || '(unknown)', JSON.stringify(msg));
+    }
+}
+
+// ── Unified message listener ───────────────────────────────────────────────
+
+window.addEventListener('message', function (event) {
+    var data = event.data;
+    if (!data) return;
+
+    // Outbound from PKMDS — has a 'kind' field
+    if (typeof data.kind === 'string') {
+        handleOutbound(data);
+        return;
+    }
+
+    // Response to an inbound call — has type + id
+    if (data.type === 'pkmds-host-result' && data.id) {
+        var pending = pendingCalls[data.id];
+        if (pending) {
+            clearTimeout(pending.timer);
+            delete pendingCalls[data.id];
+            pending.resolve(data.result);
+        }
+    }
+});
+
+// ── File picker → loadSave ─────────────────────────────────────────────────
+
+fileBtn.addEventListener('click', function () {
+    fileInput.click();
+});
+
+fileInput.addEventListener('change', function () {
+    var file = fileInput.files && fileInput.files[0];
+    if (!file) return;
+    fileInput.value = '';
+
+    setStatus('Reading ' + file.name + '…');
+
+    var reader = new FileReader();
+    reader.onload = function (ev) {
+        var buffer = ev.target.result;
+        var bytes = new Uint8Array(buffer);
+
+        // Chunked base64 encoding avoids call-stack overflow on large saves
+        // (Gen 9 saves can exceed 4 MB; String.fromCharCode.apply has a
+        // ~64 K argument limit in most engines).
+        var bin = '';
+        var chunk = 0x8000;
+        for (var i = 0; i < bytes.length; i += chunk) {
+            bin += String.fromCharCode.apply(null, bytes.subarray(i, i + chunk));
+        }
+        var b64 = btoa(bin);
+
+        log('call', 'loadSave →', 'file: ' + file.name + ' (' + bytes.length + ' bytes)');
+        setStatus('Loading ' + file.name + ' via bridge…');
+
+        callIframe('loadSave', [b64, file.name])
+            .then(function (result) {
+                if (result) {
+                    saveLoaded = true;
+                    btnDone.disabled = false;
+                    setStatus('Loaded ' + file.name + '. Edit and tap Done to export.');
+                    log('call', '← loadSave', 'result: true');
+                } else {
+                    setStatus('Load failed — see browser console for details.');
+                    log('error', '← loadSave', 'result: false');
+                }
+            })
+            .catch(function (err) {
+                setStatus('Load error: ' + err.message);
+                log('error', 'loadSave error', String(err));
+            });
+    };
+    reader.onerror = function () {
+        setStatus('Could not read file.');
+        log('error', 'FileReader error', String(reader.error));
+    };
+    reader.readAsArrayBuffer(file);
+});
+
+// ── Done button → requestExport ────────────────────────────────────────────
+
+btnDone.addEventListener('click', function () {
+    if (!saveLoaded) return;
+    btnDone.disabled = true;
+    setStatus('Requesting export…');
+    log('call', 'requestExport →', null);
+
+    // Set up a promise that resolves when the saveExport message arrives.
+    // saveExport is posted by PKMDS before requestExport() resolves, but we
+    // guard both orderings: the promise resolves whichever arrives second.
+    var saveExportPromise = new Promise(function (resolve, reject) {
+        saveExportResolver = resolve;
+        setTimeout(function () {
+            if (saveExportResolver) {
+                saveExportResolver = null;
+                reject(new Error('Timeout waiting for saveExport'));
+            }
+        }, 15000);
+    });
+
+    callIframe('requestExport', [])
+        .then(function (result) {
+            log('call', '← requestExport', 'result: ' + result);
+            if (!result) {
+                saveExportResolver = null;
+                setStatus('Export failed — see browser console for details.');
+                btnDone.disabled = !saveLoaded;
+                return;
+            }
+            return saveExportPromise;
+        })
+        .then(function (exportMsg) {
+            if (!exportMsg) return; // already handled the !result branch
+            triggerDownload(exportMsg);
+            setStatus('Export complete — download started.');
+            btnDone.disabled = !saveLoaded;
+        })
+        .catch(function (err) {
+            saveExportResolver = null;
+            setStatus('Export error: ' + err.message);
+            log('error', 'export error', String(err));
+            btnDone.disabled = !saveLoaded;
+        });
+});
+
+// ── Cancel button ──────────────────────────────────────────────────────────
+
+btnCancel.addEventListener('click', function () {
+    log('call', 'Cancel', 'Host dismissed without exporting.');
+    setStatus('Cancelled. Pick another save to continue.');
+    // In a real native app this would dismiss the sheet/modal.
+    // In the PoC we reset the host-side state without touching the iframe.
+    saveLoaded = false;
+    btnDone.disabled = true;
+    saveExportResolver = null;
+});
+
+// ── Log clear ─────────────────────────────────────────────────────────────
+
+logClear.addEventListener('click', function () {
+    logEl.innerHTML = '<div class="log-empty">No messages yet</div>';
+});
+
+// ── Download helper ────────────────────────────────────────────────────────
+
+function triggerDownload(exportMsg) {
+    var bin = atob(exportMsg.data);
+    var bytes = new Uint8Array(bin.length);
+    for (var i = 0; i < bin.length; i++) {
+        bytes[i] = bin.charCodeAt(i);
+    }
+    var blob = new Blob([bytes], { type: 'application/octet-stream' });
+    var url = URL.createObjectURL(blob);
+    var a = document.createElement('a');
+    a.href = url;
+    a.download = exportMsg.fileName || 'save.sav';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    setTimeout(function () { URL.revokeObjectURL(url); }, 5000);
+}


### PR DESCRIPTION
Closes #798

Adds `tools/embedded-host-poc/` — a standalone HTML + JS page that embeds PKMDS in an iframe with `?host=poc` and drives it through the JS bridge using `window.postMessage`, simulating what a native WKWebView host must build.

Generated with [Claude Code](https://claude.ai/code)