### PR TITLE
Add iOS / iPadOS embedded host PoC (#799)

### DIFF
--- a/EMBEDDED_HOST_GUIDE.md
+++ b/EMBEDDED_HOST_GUIDE.md
@@ -32,7 +32,7 @@ The published site uses `<base href="/" />`, so it must be served from the root 
   - `.json`, `.js`, `.css`, `.html`, `.png`, `.svg`, `.woff2` → standard
 - Reference: .NET MAUI's `BlazorWebView` iOS implementation (`SchemeHandler.cs` in the maui repo) is the canonical example of this pattern.
 
-Then `webView.load(URLRequest(url: URL(string: "app://pkmds/index.html?host=delta")!))`.
+Then `webView.load(URLRequest(url: URL(string: "app://pkmds/?host=delta")!))`. Load the **root path**, not `/index.html` — Blazor's router only registers `@page "/"`, so `/index.html` falls through to PKMDS's `NotFound` component. Map empty paths in your scheme handler to `index.html` server-side; let the URL Blazor sees stay at `/`.
 
 ### b) `WKScriptMessageHandler` for outbound messages
 
@@ -143,6 +143,10 @@ Build your Swift bridge against this observable shim before you have a working `
 For a more complete end-to-end demonstration — including mock Done/Cancel chrome, a file picker outside PKMDS, and a live message log — see [`tools/embedded-host-poc/`](tools/embedded-host-poc/README.md).
 
 The mock host page embeds PKMDS in an `<iframe src="/?host=poc">` and drives it entirely through `window.postMessage`, simulating exactly what a native host app must do. It runs without Xcode, a device, or a real `WKWebView`. Open `tools/embedded-host-poc/index.html` directly in a browser while the dev server is running (`./watch.ps1`).
+
+### iOS / iPadOS PoC (real `WKWebView` + `WKURLSchemeHandler`)
+
+For the native-app version of the same round-trip — a minimal SwiftUI app that hosts PKMDS via `WKWebView`, bundles `wwwroot/` under a custom URL scheme, and exercises the bridge end-to-end on the iOS Simulator — see [`tools/embedded-host-ios-poc/`](tools/embedded-host-ios-poc/README.md). That PoC is where to look for working Swift implementations of `WKURLSchemeHandler` (Brotli + WASM MIME handling) and `WKScriptMessageHandler` for `ready` / `saveExport`.
 
 ## 7. Getting a publishable bundle
 

--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor
@@ -113,6 +113,23 @@
                              Disabled="@(AppState.SaveFile is null)">
                     Repair
                 </MudMenuItem>
+                <MudDivider/>
+                <MudMenuItem Icon="@Icons.Material.Filled.Share"
+                             OnClick="@ExportPartyAsShowdown"
+                             Disabled="@(AppState.SaveFile is null)">
+                    Export Party As Showdown
+                </MudMenuItem>
+                <MudMenuItem Icon="@Icons.Material.Filled.CloudUpload"
+                             OnClick="@ExportToPokePaste"
+                             Disabled="@(AppState.SaveFile is null)">
+                    Export to PokePaste
+                </MudMenuItem>
+                <MudMenuItem Icon="@Icons.Material.Filled.FileUpload"
+                             OnClick="@ImportFromShowdown"
+                             Disabled="@(AppState.SaveFile is null)">
+                    Import from Showdown
+                </MudMenuItem>
+                <MudDivider/>
                 <MudMenuItem Icon="@Icons.Material.Filled.BugReport"
                              OnClick="@ShowBugReportDialog">
                     Report a Bug

--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
@@ -298,6 +298,30 @@ public partial class MainLayout : IDisposable
         await DialogService.ShowAsync<SaveFileRepairDialog>("Repair Save File", parameters, options);
     }
 
+    private async Task ExportPartyAsShowdown()
+    {
+        var options = await DialogOptionsHelper.BuildAsync(MaxWidth.Small);
+        await DialogService.ShowAsync<ShowdownExportDialog>("Showdown Export", options);
+    }
+
+    private async Task ExportToPokePaste()
+    {
+        var options = await DialogOptionsHelper.BuildAsync(MaxWidth.Medium);
+        await DialogService.ShowAsync<PokePasteExportDialog>(
+            "Export to PokePaste",
+            new DialogParameters<PokePasteExportDialog>(),
+            options);
+    }
+
+    private async Task ImportFromShowdown()
+    {
+        var options = await DialogOptionsHelper.BuildAsync(MaxWidth.Medium);
+        await DialogService.ShowAsync<ShowdownImportDialog>(
+            "Import from Showdown / PokePaste",
+            new DialogParameters<ShowdownImportDialog>(),
+            options);
+    }
+
     private async Task ShowBackupManagerDialog()
     {
         var parameters = new DialogParameters { { nameof(BackupManagerDialog.SaveFile), AppState.SaveFile }, { nameof(BackupManagerDialog.FileName), AppState.SaveFileName }, { nameof(BackupManagerDialog.IsManicEmu), AppState.ManicEmuSaveContext is not null }, { nameof(BackupManagerDialog.ManicEmuContext), AppState.ManicEmuSaveContext } };

--- a/Pkmds.Rcl/Components/PartyGrid.razor
+++ b/Pkmds.Rcl/Components/PartyGrid.razor
@@ -21,27 +21,30 @@
             }
         </MudGrid>
     </div>
-    <div class="flex flex-wrap gap-2 my-3">
-        <MudButton OnClick="@ExportAsShowdown"
-                   ButtonType="@ButtonType.Button"
-                   Variant="@Variant.Filled"
-                   StartIcon="@Icons.Material.Filled.Share"
-                   Color="@Color.Default">
-            Export Party As Showdown
-        </MudButton>
-        <MudButton OnClick="@ExportToPokePaste"
-                   ButtonType="@ButtonType.Button"
-                   Variant="@Variant.Filled"
-                   StartIcon="@Icons.Material.Filled.CloudUpload"
-                   Color="@Color.Default">
-            Export to PokePaste
-        </MudButton>
-        <MudButton OnClick="@ImportFromShowdown"
-                   ButtonType="@ButtonType.Button"
-                   Variant="@Variant.Filled"
-                   StartIcon="@Icons.Material.Filled.FileUpload"
-                   Color="@Color.Default">
-            Import from Showdown
-        </MudButton>
-    </div>
+    @if (!HostService.IsEmbedded)
+    {
+        <div class="flex flex-wrap gap-2 my-3">
+            <MudButton OnClick="@ExportAsShowdown"
+                       ButtonType="@ButtonType.Button"
+                       Variant="@Variant.Filled"
+                       StartIcon="@Icons.Material.Filled.Share"
+                       Color="@Color.Default">
+                Export Party As Showdown
+            </MudButton>
+            <MudButton OnClick="@ExportToPokePaste"
+                       ButtonType="@ButtonType.Button"
+                       Variant="@Variant.Filled"
+                       StartIcon="@Icons.Material.Filled.CloudUpload"
+                       Color="@Color.Default">
+                Export to PokePaste
+            </MudButton>
+            <MudButton OnClick="@ImportFromShowdown"
+                       ButtonType="@ButtonType.Button"
+                       Variant="@Variant.Filled"
+                       StartIcon="@Icons.Material.Filled.FileUpload"
+                       Color="@Color.Default">
+                Import from Showdown
+            </MudButton>
+        </div>
+    }
 }

--- a/Pkmds.Rcl/wwwroot/css/app.css
+++ b/Pkmds.Rcl/wwwroot/css/app.css
@@ -418,6 +418,11 @@ body, html {
 
     .mud-main-content {
         height: 100dvh;
+        /* iOS WKWebView with viewport-fit=cover counts the home-indicator zone in
+           100dvh, so the inner tab panel's overflow:auto can't scroll to reveal
+           content covered by the indicator. Reserve safe-area space at the bottom;
+           env(...) is 0 on browsers without a safe area. */
+        padding-bottom: env(safe-area-inset-bottom, 0px);
         box-sizing: border-box;
         display: flex;
         flex-direction: column;

--- a/tools/embedded-host-ios-poc/.gitignore
+++ b/tools/embedded-host-ios-poc/.gitignore
@@ -1,0 +1,4 @@
+xcode/build/
+xcode/PkmdsHost.xcodeproj/
+xcode/PkmdsHost/Resources/PKMDS/
+xcode/PkmdsHost/Info.plist

--- a/tools/embedded-host-ios-poc/README.md
+++ b/tools/embedded-host-ios-poc/README.md
@@ -1,0 +1,157 @@
+# iOS Embedded Host PoC
+
+Proof-of-concept for issue [#799](https://github.com/codemonkey85/PKMDS-Blazor/issues/799): a minimal iOS / iPadOS app that hosts PKMDS via `WKWebView` + `WKURLSchemeHandler` and round-trips a `.sav` through the [embedded host bridge](../../EMBEDDED_HOST_GUIDE.md).
+
+The goal is an end-to-end existence proof — PKMDS really can be embedded in a native iOS app driven entirely by the JS bridge, not just the browser-based mock host in [`tools/embedded-host-poc/`](../embedded-host-poc/).
+
+## What's in here
+
+```
+tools/embedded-host-ios-poc/
+├── refresh-pkmds.sh                    # dotnet publish → strip PWA files → stage bundle
+├── build-and-run.sh                    # refresh + xcodegen + xcodebuild + simulator
+└── xcode/
+    ├── project.yml                     # xcodegen spec
+    └── PkmdsHost/
+        ├── PkmdsHostApp.swift          # @main SwiftUI App
+        ├── ContentView.swift           # Files-picker entry screen
+        ├── EditorSheet.swift           # Sheet wrapping WebView + Done/Cancel toolbar
+        ├── PkmdsWebView.swift          # UIViewRepresentable for WKWebView
+        ├── PkmdsSchemeHandler.swift    # app://pkmds/ → bundle file lookup
+        ├── PkmdsBridge.swift           # WKScriptMessageHandler + ready/saveExport
+        ├── PickedSave.swift            # Plain-data structs
+        └── Resources/PKMDS/            # ← populated by refresh-pkmds.sh (gitignored)
+```
+
+## Prerequisites
+
+- **Xcode** with the iOS Simulator runtime installed (`xcode-select -p` must point at `/Applications/Xcode.app/Contents/Developer`).
+- **.NET SDK** matching `global.json` (net10.0).
+- **xcodegen** — `brew install xcodegen`.
+- **wasm tools workload** — `dotnet workload install wasm-tools` (one-time).
+
+## Build & run
+
+```sh
+./build-and-run.sh
+```
+
+Generates the Xcode project, builds the app for the iOS Simulator, and launches it. On first run (or with `--refresh`) it also runs `refresh-pkmds.sh` to publish PKMDS and stage the WASM bundle into the app's resources.
+
+```sh
+# Re-publish PKMDS after changing Web/Rcl/Core code
+./refresh-pkmds.sh
+
+# Pick a different simulator
+SIM_NAME="iPhone 15 Pro" ./build-and-run.sh
+```
+
+To get a `.sav` into the simulator, drag one from Finder onto the Simulator window — it lands in **Files → On My iPhone**, where the in-app picker can reach it.
+
+## How it works
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  iOS app (SwiftUI)                                          │
+│                                                              │
+│  ┌─── ContentView ───────────────────────────────────────┐ │
+│  │  [ Pick a save… ]   ← .fileImporter([.data])          │ │
+│  └────────────────────────────────────────────────────────┘ │
+│                          │                                   │
+│                          ▼ (PickedSave: Data + filename)    │
+│  ┌─── EditorSheet ───────────────────────────────────────┐ │
+│  │  [Cancel]   <save filename>           [Done]           │ │
+│  │  ┌── WKWebView ───────────────────────────────────┐  │ │
+│  │  │  app://pkmds/index.html?host=poc-ios           │  │ │
+│  │  │                                                 │  │ │
+│  │  │  PkmdsSchemeHandler  →  bundle file lookup     │  │ │
+│  │  │  PkmdsBridge         →  ready / saveExport     │  │ │
+│  │  └─────────────────────────────────────────────────┘  │ │
+│  └────────────────────────────────────────────────────────┘ │
+│                          │                                   │
+│                          ▼ (Done → requestExport → bytes)   │
+│              UIActivityViewController (share sheet)          │
+└─────────────────────────────────────────────────────────────┘
+```
+
+The share sheet stands in for the real-world handoff: in a native host integration, the exported bytes would be returned to the host app's storage (emulator save slot, file manager, whatever) instead of going through the share sheet.
+
+## Architecture decisions
+
+### Why xcodegen
+
+Same reasons as `tools/macos-quicklook-poc/`: `project.yml` is reviewable in PRs, doesn't merge-conflict the way `.pbxproj` does, and `wwwroot/` can be added with `type: folder` so it becomes a **folder reference** (blue folder in Xcode). That preserves the published bundle's directory structure and file extensions through Xcode's resource processing — directly addresses the "Xcode resource processing" gotcha called out in #799.
+
+### Why iOS 14.0 deployment target
+
+Matches the lowest target of the canonical downstream consumer class (iOS retro emulators with native save management). `WKURLSchemeHandler` (iOS 11+), `WKScriptMessageHandler` (iOS 8+), SwiftUI App lifecycle (iOS 14+), and `.fileImporter` (iOS 14+) all work there.
+
+### Why Files-picker only (no bundled sample save)
+
+Keeps the PoC honest about what the integration actually exercises. Bundling a sample `.sav` would skip the security-scoped URL access dance — which a real host integration handles via its own storage layer, not via `.fileImporter`, but the file I/O surface is closer to reality this way.
+
+### Why `app://pkmds/` and not `pkmds://`
+
+WebKit refuses to install a `WKURLSchemeHandler` for any HTTP-like scheme it considers built-in. `app` is short, descriptive, and free of conflicts; the handler keys off the scheme prefix and ignores the host/path beyond mapping to bundle files.
+
+## The not-yet-broke-us-but-likely-to gotchas
+
+These are the things we know from the issue + `EMBEDDED_HOST_GUIDE.md` that this PoC has to get right:
+
+### 1. Brotli `.br` compressed assets
+
+Blazor publishes `*.dll.br` and `*.wasm.br` and the runtime references them via integrity-guarded loaders. The scheme handler must:
+- Strip the `.br` suffix when computing the `Content-Type` (so `App.dll.br` returns `application/octet-stream`, not `application/x-brotli`).
+- Set `Content-Encoding: br` on the response so WebKit decompresses transparently.
+
+Same pattern for `.gz`. Reference: .NET MAUI `BlazorWebView/iOS/SchemeHandler.cs`.
+
+### 2. WASM MIME type
+
+`.wasm` must be served as `application/wasm`. Anything else and modern WebKit refuses to instantiate the module — the failure surface is a generic JS error from inside Blazor's loader, with the actual MIME-type check buried in `Microsoft.AspNetCore.Components.WebAssembly`.
+
+### 3. Folder reference vs group
+
+Xcode silently reformats certain files (`.json`, `.xml`, asset catalogs) when copied into a bundle as part of a regular group ("yellow folder"). `project.yml` adds the PKMDS bundle with `type: folder` so it's a folder reference ("blue folder") — Xcode treats the directory as opaque and copies it byte-for-byte.
+
+### 4. Pre-Blazor service-worker gate
+
+`Pkmds.Web/wwwroot/js/app.js` already skips SW registration when `?host=` is present, so we shouldn't see any SW registration attempts. Verify in Web Inspector → Application → Service Workers (empty).
+
+### 5. Fingerprinted asset paths
+
+Blazor 9/10 emits filenames like `blazor.webassembly.[hash].js`. Published `index.html` already embeds the fingerprinted path, so the scheme handler's straightforward path-to-file mapping just works — no regex needed. If a future release changes that, the handler is the place to add the rewrite.
+
+### 6. Theme follows `prefers-color-scheme`
+
+PKMDS forces theme to `System` in embed mode (per `EMBEDDED_HOST_GUIDE.md`), so the WebView inherits the simulator's light/dark setting through `traitCollection.userInterfaceStyle` automatically. No Swift-side wiring needed.
+
+## Diagnostic toolbox
+
+Useful while iterating:
+
+| Command | Purpose |
+|---|---|
+| `xcrun simctl list devices available` | Find a simulator UUID |
+| `xcrun simctl io booted recordVideo demo.mp4` | Screen-record the simulator |
+| `xcrun simctl spawn booted log stream --level debug --predicate 'process == "PkmdsHost"'` | Stream app logs from the simulator |
+| Web Inspector (Safari → Develop → Simulator → PKMDS Host) | DOM, JS console, network panel for `WKWebView` |
+| `xcrun simctl uninstall booted com.bondcodes.pkmds.host.ios` | Force-clean install state |
+
+Web Inspector is the load-bearing tool here — that's where you verify (a) `ready` posted, (b) no HTTP requests fire, (c) `saveExport` payload looks right.
+
+## Out of scope
+
+- App Store / signing / TestFlight — this is a developer demo.
+- Multi-save management UI — single round-trip only.
+- Persisting saves between launches — the share sheet hands bytes off and we forget.
+- Wiring up to a real emulator — that's a downstream consumer's job.
+
+## Macros for next session
+
+If this PoC graduates to a real `tools/embedded-host-ios/` (no `-poc` suffix):
+
+1. Real Apple Developer signing instead of `CODE_SIGNING_ALLOWED=NO`.
+2. Replace the share sheet with a host-app-style storage handoff.
+3. Decide whether to ship the PKMDS bundle baked into the app or as a downloadable asset pack (the published bundle is several MB).
+4. Extract the `PkmdsSchemeHandler` + `PkmdsBridge` into a Swift package so downstream consumers can drop the bridge in without copying source.

--- a/tools/embedded-host-ios-poc/build-and-run.sh
+++ b/tools/embedded-host-ios-poc/build-and-run.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Generates the Xcode project, builds for the iOS Simulator, installs + launches.
+# Refreshes the PKMDS bundle on first run (or when --refresh is passed).
+#
+#   ./build-and-run.sh                 # build + run on default simulator
+#   ./build-and-run.sh --refresh       # re-publish PKMDS first
+#   SIM_NAME="iPhone 15" ./build-and-run.sh
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+XCODE_DIR="$SCRIPT_DIR/xcode"
+PROJECT="$XCODE_DIR/PkmdsHost.xcodeproj"
+DERIVED="$XCODE_DIR/build"
+BUNDLE_DIR="$XCODE_DIR/PkmdsHost/Resources/PKMDS"
+
+APP_NAME="PkmdsHost"
+BUNDLE_ID="com.bondcodes.pkmds.host.ios"
+# Default: first available iPhone simulator. Override with SIM_NAME="iPhone 15 Pro".
+SIM_NAME="${SIM_NAME:-}"
+
+if [[ "${1:-}" == "--refresh" ]] || [[ ! -d "$BUNDLE_DIR" ]] || [[ -z "$(ls -A "$BUNDLE_DIR" 2>/dev/null)" ]]; then
+    echo "==> refresh PKMDS bundle"
+    "$SCRIPT_DIR/refresh-pkmds.sh"
+fi
+
+echo "==> xcodegen generate"
+( cd "$XCODE_DIR" && xcodegen generate --quiet )
+
+if [[ -n "$SIM_NAME" ]]; then
+    SIM_LINE=$(xcrun simctl list devices available 2>/dev/null \
+        | grep -E "^\s+$SIM_NAME \(" \
+        | head -1)
+else
+    SIM_LINE=$(xcrun simctl list devices available 2>/dev/null \
+        | grep -E "^\s+iPhone " \
+        | head -1)
+fi
+
+SIM_UUID=$(echo "$SIM_LINE" | sed -E 's/.*\(([A-F0-9-]+)\).*/\1/')
+SIM_NAME=$(echo "$SIM_LINE" | sed -E 's/^\s+(.*) \([A-F0-9-]+\).*/\1/')
+
+if [[ -z "$SIM_UUID" ]]; then
+    echo "no iPhone simulator found. Available:" >&2
+    xcrun simctl list devices available | grep -E "^\s+iPhone|^\s+iPad" | sed -E 's/^\s+//' >&2
+    exit 1
+fi
+
+echo "==> using simulator $SIM_NAME ($SIM_UUID)"
+xcrun simctl boot "$SIM_UUID" 2>/dev/null || true
+open -a Simulator
+
+echo "==> xcodebuild (Debug, simulator)"
+xcodebuild \
+    -project "$PROJECT" \
+    -scheme "$APP_NAME" \
+    -configuration Debug \
+    -destination "id=$SIM_UUID" \
+    -derivedDataPath "$DERIVED" \
+    CODE_SIGNING_ALLOWED=NO \
+    -quiet \
+    build
+
+APP_PATH="$DERIVED/Build/Products/Debug-iphonesimulator/$APP_NAME.app"
+[[ -d "$APP_PATH" ]] || { echo "missing built app at $APP_PATH" >&2; exit 1; }
+
+echo "==> install + launch"
+xcrun simctl install "$SIM_UUID" "$APP_PATH"
+xcrun simctl launch "$SIM_UUID" "$BUNDLE_ID"
+
+echo
+echo "Launched $APP_NAME on $SIM_NAME."
+echo "Tap 'Pick a save…' and choose a .sav from the simulator's Files app."
+echo "(In the simulator: Files → Browse → On My iPhone — drag a .sav into Finder's Simulator window to add one.)"

--- a/tools/embedded-host-ios-poc/refresh-pkmds.sh
+++ b/tools/embedded-host-ios-poc/refresh-pkmds.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Publishes Pkmds.Web and stages the wwwroot/ bundle into the iOS app's resources.
+# Strips PWA-only files that aren't reachable in embed mode (per EMBEDDED_HOST_GUIDE.md §7).
+#
+# Run after editing anything under Pkmds.Web / Pkmds.Rcl / Pkmds.Core.
+# build-and-run.sh invokes this automatically when Resources/PKMDS is missing.
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_ROOT="$( cd "$SCRIPT_DIR/../.." && pwd )"
+
+PUBLISH_OUT="$REPO_ROOT/release"
+PUBLISH_WWWROOT="$PUBLISH_OUT/wwwroot"
+DEST="$SCRIPT_DIR/xcode/PkmdsHost/Resources/PKMDS"
+
+PWA_ONLY_FILES=(
+    "manifest.webmanifest"
+    "service-worker.js"
+    "service-worker.published.js"
+    "BrowserNotSupported.html"
+    "staticwebapp.config.json"
+)
+
+echo "==> dotnet publish Pkmds.Web (Release)"
+dotnet publish "$REPO_ROOT/Pkmds.Web/Pkmds.Web.csproj" \
+    -c Release \
+    -o "$PUBLISH_OUT" \
+    --nologo
+
+[[ -d "$PUBLISH_WWWROOT" ]] || { echo "missing $PUBLISH_WWWROOT" >&2; exit 1; }
+
+echo "==> stage bundle at $DEST"
+rm -rf "$DEST"
+mkdir -p "$DEST"
+# -a preserves perms + recurses; trailing /. copies contents not the parent dir
+cp -a "$PUBLISH_WWWROOT/." "$DEST/"
+
+echo "==> strip PWA-only files"
+for f in "${PWA_ONLY_FILES[@]}"; do
+    if [[ -f "$DEST/$f" ]]; then
+        rm "$DEST/$f"
+        echo "    removed $f"
+    fi
+done
+
+BUNDLE_SIZE=$(du -sh "$DEST" | awk '{print $1}')
+FILE_COUNT=$(find "$DEST" -type f | wc -l | tr -d ' ')
+echo
+echo "Staged $FILE_COUNT files ($BUNDLE_SIZE) at $DEST"

--- a/tools/embedded-host-ios-poc/xcode/PkmdsHost/ContentView.swift
+++ b/tools/embedded-host-ios-poc/xcode/PkmdsHost/ContentView.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct ContentView: View {
+    @State private var pickerPresented = false
+    @State private var pickedSave: PickedSave?
+    @State private var errorMessage: String?
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 24) {
+                Spacer()
+
+                Image(systemName: "square.and.pencil")
+                    .font(.system(size: 64))
+                    .foregroundColor(.accentColor)
+
+                VStack(spacing: 8) {
+                    Text("PKMDS Host (PoC)")
+                        .font(.title2.bold())
+                    Text("Pick a Pokémon save file. Bytes round-trip through the embedded WKWebView bridge.")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal)
+                }
+
+                Button {
+                    pickerPresented = true
+                } label: {
+                    Label("Pick a save…", systemImage: "doc.badge.plus")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.accentColor)
+                        .foregroundColor(.white)
+                        .cornerRadius(12)
+                }
+                .padding(.horizontal)
+
+                if let errorMessage {
+                    Text(errorMessage)
+                        .font(.caption)
+                        .foregroundColor(.red)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal)
+                }
+
+                Spacer()
+            }
+            .navigationBarHidden(true)
+        }
+        .navigationViewStyle(.stack)
+        .fileImporter(
+            isPresented: $pickerPresented,
+            allowedContentTypes: [.data],
+            allowsMultipleSelection: false
+        ) { result in
+            switch result {
+            case .success(let urls):
+                if let url = urls.first {
+                    load(url: url)
+                }
+            case .failure(let error):
+                errorMessage = "File picker failed: \(error.localizedDescription)"
+            }
+        }
+        .sheet(item: $pickedSave) { picked in
+            EditorSheet(save: picked) {
+                pickedSave = nil
+            }
+        }
+    }
+
+    private func load(url: URL) {
+        let granted = url.startAccessingSecurityScopedResource()
+        defer { if granted { url.stopAccessingSecurityScopedResource() } }
+        do {
+            let bytes = try Data(contentsOf: url)
+            pickedSave = PickedSave(bytes: bytes, fileName: url.lastPathComponent)
+            errorMessage = nil
+        } catch {
+            errorMessage = "Couldn't read file: \(error.localizedDescription)"
+        }
+    }
+}

--- a/tools/embedded-host-ios-poc/xcode/PkmdsHost/EditorSheet.swift
+++ b/tools/embedded-host-ios-poc/xcode/PkmdsHost/EditorSheet.swift
@@ -1,0 +1,102 @@
+import SwiftUI
+import UIKit
+
+struct EditorSheet: View {
+    let save: PickedSave
+    let onDismiss: () -> Void
+
+    @StateObject private var bridge: PkmdsBridge
+    @State private var exportItem: ExportItem?
+    @State private var isExporting = false
+    @State private var errorMessage: String?
+
+    init(save: PickedSave, onDismiss: @escaping () -> Void) {
+        self.save = save
+        self.onDismiss = onDismiss
+        _bridge = StateObject(wrappedValue: PkmdsBridge(save: save))
+    }
+
+    var body: some View {
+        NavigationView {
+            ZStack(alignment: .bottom) {
+                PkmdsWebView(bridge: bridge)
+                    .ignoresSafeArea(.container, edges: .bottom)
+
+                if let errorMessage {
+                    Text(errorMessage)
+                        .font(.footnote)
+                        .padding()
+                        .background(Color.red.opacity(0.85))
+                        .foregroundColor(.white)
+                        .cornerRadius(8)
+                        .padding()
+                }
+            }
+            .navigationTitle(save.fileName)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { onDismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(action: done) {
+                        if isExporting {
+                            ProgressView()
+                        } else {
+                            Text("Done").bold()
+                        }
+                    }
+                    .disabled(!bridge.isReady || isExporting)
+                }
+            }
+            .sheet(item: $exportItem) { item in
+                ActivityView(activityItems: [item.url]) {
+                    onDismiss()
+                }
+            }
+        }
+        .navigationViewStyle(.stack)
+    }
+
+    private func done() {
+        errorMessage = nil
+        isExporting = true
+        bridge.requestExport { result in
+            isExporting = false
+            switch result {
+            case .success(let exported):
+                do {
+                    let tempURL = FileManager.default.temporaryDirectory
+                        .appendingPathComponent(exported.fileName)
+                    try? FileManager.default.removeItem(at: tempURL)
+                    try exported.bytes.write(to: tempURL, options: .atomic)
+                    exportItem = ExportItem(url: tempURL)
+                } catch {
+                    errorMessage = "Couldn't stage exported file: \(error.localizedDescription)"
+                }
+            case .failure(let error):
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+}
+
+private struct ExportItem: Identifiable {
+    let id = UUID()
+    let url: URL
+}
+
+private struct ActivityView: UIViewControllerRepresentable {
+    let activityItems: [Any]
+    let onComplete: () -> Void
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        let vc = UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
+        vc.completionWithItemsHandler = { _, _, _, _ in
+            onComplete()
+        }
+        return vc
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+}

--- a/tools/embedded-host-ios-poc/xcode/PkmdsHost/PickedSave.swift
+++ b/tools/embedded-host-ios-poc/xcode/PkmdsHost/PickedSave.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+struct PickedSave: Identifiable {
+    let id = UUID()
+    let bytes: Data
+    let fileName: String
+}
+
+struct ExportedSave {
+    let bytes: Data
+    let fileName: String
+}

--- a/tools/embedded-host-ios-poc/xcode/PkmdsHost/PkmdsBridge.swift
+++ b/tools/embedded-host-ios-poc/xcode/PkmdsHost/PkmdsBridge.swift
@@ -1,0 +1,124 @@
+import Foundation
+import WebKit
+
+enum BridgeError: Error, LocalizedError {
+    case notAttached
+    case invalidExport
+    case timeout
+    case loadSaveFailed(String)
+    case requestExportFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .notAttached: return "WKWebView not attached"
+        case .invalidExport: return "Couldn't decode exported save bytes"
+        case .timeout: return "Export timed out (no saveExport message received)"
+        case .loadSaveFailed(let msg): return "loadSave failed: \(msg)"
+        case .requestExportFailed(let msg): return "requestExport failed: \(msg)"
+        }
+    }
+}
+
+@MainActor
+final class PkmdsBridge: NSObject, ObservableObject {
+    @Published private(set) var isReady = false
+    @Published private(set) var lastError: String?
+
+    private let save: PickedSave
+    private weak var webView: WKWebView?
+
+    private var exportCallback: ((Result<ExportedSave, Error>) -> Void)?
+    private var exportTimeoutTask: Task<Void, Never>?
+
+    init(save: PickedSave) {
+        self.save = save
+    }
+
+    func attach(webView: WKWebView) {
+        self.webView = webView
+    }
+
+    func handle(kind: String, payload: [String: Any]) {
+        switch kind {
+        case "ready":
+            isReady = true
+            loadSave()
+        case "saveExport":
+            guard let dataB64 = payload["data"] as? String,
+                  let data = Data(base64Encoded: dataB64) else {
+                completeExport(.failure(BridgeError.invalidExport))
+                return
+            }
+            let fileName = (payload["fileName"] as? String) ?? save.fileName
+            completeExport(.success(ExportedSave(bytes: data, fileName: fileName)))
+        default:
+            print("[PKMDS bridge] ignoring unknown kind: \(kind)")
+        }
+    }
+
+    private func loadSave() {
+        guard let webView else { return }
+        let b64 = save.bytes.base64EncodedString()
+        let escapedName = save.fileName
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "'", with: "\\'")
+        let js = "window.PKMDS.host.loadSave('\(b64)', '\(escapedName)')"
+        webView.evaluateJavaScript(js) { [weak self] _, error in
+            if let error {
+                Task { @MainActor in
+                    self?.lastError = "loadSave failed: \(error.localizedDescription)"
+                }
+            }
+        }
+    }
+
+    func requestExport(timeout: TimeInterval = 5,
+                       completion: @escaping (Result<ExportedSave, Error>) -> Void) {
+        guard let webView else {
+            completion(.failure(BridgeError.notAttached))
+            return
+        }
+        exportCallback = completion
+        exportTimeoutTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                self?.completeExport(.failure(BridgeError.timeout))
+            }
+        }
+        webView.evaluateJavaScript("window.PKMDS.host.requestExport()") { [weak self] _, error in
+            if let error {
+                Task { @MainActor in
+                    self?.completeExport(
+                        .failure(BridgeError.requestExportFailed(error.localizedDescription))
+                    )
+                }
+            }
+        }
+    }
+
+    private func completeExport(_ result: Result<ExportedSave, Error>) {
+        exportTimeoutTask?.cancel()
+        exportTimeoutTask = nil
+        let cb = exportCallback
+        exportCallback = nil
+        cb?(result)
+    }
+}
+
+final class PkmdsMessageHandler: NSObject, WKScriptMessageHandler {
+    weak var bridge: PkmdsBridge?
+
+    init(bridge: PkmdsBridge) {
+        self.bridge = bridge
+    }
+
+    func userContentController(_ controller: WKUserContentController,
+                               didReceive message: WKScriptMessage) {
+        guard let body = message.body as? [String: Any],
+              let kind = body["kind"] as? String else { return }
+        Task { @MainActor in
+            self.bridge?.handle(kind: kind, payload: body)
+        }
+    }
+}

--- a/tools/embedded-host-ios-poc/xcode/PkmdsHost/PkmdsHostApp.swift
+++ b/tools/embedded-host-ios-poc/xcode/PkmdsHost/PkmdsHostApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct PkmdsHostApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/tools/embedded-host-ios-poc/xcode/PkmdsHost/PkmdsSchemeHandler.swift
+++ b/tools/embedded-host-ios-poc/xcode/PkmdsHost/PkmdsSchemeHandler.swift
@@ -1,0 +1,101 @@
+import Foundation
+import WebKit
+
+final class PkmdsSchemeHandler: NSObject, WKURLSchemeHandler {
+    static let scheme = "app"
+    static let host = "pkmds"
+
+    private let bundleRoot: URL
+
+    init(bundleRoot: URL) {
+        self.bundleRoot = bundleRoot
+    }
+
+    func webView(_ webView: WKWebView, start urlSchemeTask: WKURLSchemeTask) {
+        guard let url = urlSchemeTask.request.url else {
+            urlSchemeTask.didFailWithError(URLError(.badURL))
+            return
+        }
+
+        var path = url.path
+        if path.hasPrefix("/") { path.removeFirst() }
+        if path.isEmpty { path = "index.html" }
+
+        let resolved = bundleRoot.appendingPathComponent(path)
+
+        guard FileManager.default.fileExists(atPath: resolved.path),
+              let response = HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: nil),
+              let data = try? Data(contentsOf: resolved)
+        else {
+            let notFound = HTTPURLResponse(
+                url: url,
+                statusCode: 404,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "text/plain"])!
+            urlSchemeTask.didReceive(notFound)
+            urlSchemeTask.didReceive(Data("Not found: \(url.path)".utf8))
+            urlSchemeTask.didFinish()
+            return
+        }
+
+        let (mimeType, encoding) = mimeAndEncoding(for: resolved)
+        var headers: [String: String] = [
+            "Content-Type": mimeType,
+            "Content-Length": "\(data.count)",
+            "Cache-Control": "no-store"
+        ]
+        if let encoding {
+            headers["Content-Encoding"] = encoding
+        }
+        let final = HTTPURLResponse(
+            url: response.url ?? url,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: headers)!
+        urlSchemeTask.didReceive(final)
+        urlSchemeTask.didReceive(data)
+        urlSchemeTask.didFinish()
+    }
+
+    func webView(_ webView: WKWebView, stop urlSchemeTask: WKURLSchemeTask) {}
+
+    private func mimeAndEncoding(for url: URL) -> (String, String?) {
+        var path = url.path
+        var encoding: String?
+        if path.hasSuffix(".br") {
+            path = String(path.dropLast(3))
+            encoding = "br"
+        } else if path.hasSuffix(".gz") {
+            path = String(path.dropLast(3))
+            encoding = "gzip"
+        }
+        let ext = (path as NSString).pathExtension.lowercased()
+        let mime: String
+        switch ext {
+        case "html", "htm": mime = "text/html; charset=utf-8"
+        case "js", "mjs": mime = "application/javascript; charset=utf-8"
+        case "css": mime = "text/css; charset=utf-8"
+        case "json": mime = "application/json; charset=utf-8"
+        case "wasm": mime = "application/wasm"
+        case "dll", "pdb", "blat", "dat", "bin": mime = "application/octet-stream"
+        case "png": mime = "image/png"
+        case "jpg", "jpeg": mime = "image/jpeg"
+        case "gif": mime = "image/gif"
+        case "svg": mime = "image/svg+xml"
+        case "ico": mime = "image/x-icon"
+        case "webp": mime = "image/webp"
+        case "woff": mime = "font/woff"
+        case "woff2": mime = "font/woff2"
+        case "ttf": mime = "font/ttf"
+        case "otf": mime = "font/otf"
+        case "txt", "map": mime = "text/plain; charset=utf-8"
+        case "xml": mime = "application/xml; charset=utf-8"
+        default: mime = "application/octet-stream"
+        }
+        return (mime, encoding)
+    }
+}

--- a/tools/embedded-host-ios-poc/xcode/PkmdsHost/PkmdsWebView.swift
+++ b/tools/embedded-host-ios-poc/xcode/PkmdsHost/PkmdsWebView.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+import WebKit
+
+struct PkmdsWebView: UIViewRepresentable {
+    let bridge: PkmdsBridge
+
+    func makeUIView(context: Context) -> WKWebView {
+        let bundleRoot = Bundle.main.url(forResource: "PKMDS", withExtension: nil)!
+        let schemeHandler = PkmdsSchemeHandler(bundleRoot: bundleRoot)
+        let messageHandler = PkmdsMessageHandler(bridge: bridge)
+
+        let config = WKWebViewConfiguration()
+        config.setURLSchemeHandler(schemeHandler, forURLScheme: PkmdsSchemeHandler.scheme)
+        config.userContentController.add(messageHandler, name: "pkmds")
+
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.allowsBackForwardNavigationGestures = false
+        // PKMDS scrolls the document itself; let it use the full WebView bounds rather
+        // than reserving home-indicator inset that doesn't match the page's content size.
+        // Without this the inner scroll view rubberbands back from the bottom.
+        webView.scrollView.contentInsetAdjustmentBehavior = .never
+        if #available(iOS 16.4, *) {
+            webView.isInspectable = true
+        }
+        bridge.attach(webView: webView)
+
+        // WKWebViewConfiguration retains the scheme handler weakly in some iOS versions —
+        // pin both helpers to the SwiftUI coordinator so they live as long as the view.
+        context.coordinator.schemeHandler = schemeHandler
+        context.coordinator.messageHandler = messageHandler
+
+        // Load the root path, not /index.html — Blazor's router matches `@page "/"`,
+        // and `/index.html` falls through to PKMDS's 404 page. The scheme handler
+        // serves index.html for empty paths transparently.
+        let url = URL(string: "\(PkmdsSchemeHandler.scheme)://\(PkmdsSchemeHandler.host)/?host=poc-ios")!
+        webView.load(URLRequest(url: url))
+        return webView
+    }
+
+    func updateUIView(_ uiView: WKWebView, context: Context) {}
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    final class Coordinator {
+        var schemeHandler: PkmdsSchemeHandler?
+        var messageHandler: PkmdsMessageHandler?
+    }
+}

--- a/tools/embedded-host-ios-poc/xcode/project.yml
+++ b/tools/embedded-host-ios-poc/xcode/project.yml
@@ -1,0 +1,54 @@
+name: PkmdsHost
+options:
+  bundleIdPrefix: com.bondcodes.pkmds
+  deploymentTarget:
+    iOS: "14.0"
+  createIntermediateGroups: true
+  groupSortPosition: top
+
+settings:
+  base:
+    SWIFT_VERSION: "5.0"
+    CODE_SIGN_STYLE: Manual
+    CODE_SIGNING_ALLOWED: NO
+    DEVELOPMENT_TEAM: ""
+
+targets:
+  PkmdsHost:
+    type: application
+    platform: iOS
+    sources:
+      - path: PkmdsHost
+        excludes:
+          - "Resources/PKMDS"
+          - "Resources/PKMDS/**/*"
+      - path: PkmdsHost/Resources/PKMDS
+        type: folder
+        optional: true
+        buildPhase: resources
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.bondcodes.pkmds.host.ios
+        TARGETED_DEVICE_FAMILY: "1,2"
+        MARKETING_VERSION: "0.0.1"
+        CURRENT_PROJECT_VERSION: "1"
+        ASSETCATALOG_COMPILER_APPICON_NAME: ""
+        ENABLE_USER_SCRIPT_SANDBOXING: YES
+    info:
+      path: PkmdsHost/Info.plist
+      properties:
+        CFBundleDisplayName: PKMDS Host (PoC)
+        CFBundleShortVersionString: "$(MARKETING_VERSION)"
+        CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
+        LSApplicationCategoryType: public.app-category.utilities
+        UILaunchScreen:
+          UIColorName: ""
+        UISupportedInterfaceOrientations:
+          - UIInterfaceOrientationPortrait
+          - UIInterfaceOrientationLandscapeLeft
+          - UIInterfaceOrientationLandscapeRight
+        UISupportedInterfaceOrientations~ipad:
+          - UIInterfaceOrientationPortrait
+          - UIInterfaceOrientationPortraitUpsideDown
+          - UIInterfaceOrientationLandscapeLeft
+          - UIInterfaceOrientationLandscapeRight


### PR DESCRIPTION
Closes #799.

Native SwiftUI app under `tools/embedded-host-ios-poc/` that hosts PKMDS via `WKWebView` + `WKURLSchemeHandler` and round-trips a save through the embedded host bridge end-to-end. Mirrors the convention from `tools/macos-quicklook-poc/` — xcodegen spec for the project, refresh script for the published `wwwroot/`, single `build-and-run.sh` to boot the simulator.

## Summary

- **New:** `tools/embedded-host-ios-poc/` — SwiftUI app, `WKURLSchemeHandler` (Brotli + WASM MIME handling), `WKScriptMessageHandler` for `ready`/`saveExport`, `UIActivityViewController` share sheet for the export handoff, `.fileImporter` for save selection, README with prereqs/architecture/gotchas/diagnostics.
- **Embed-mode overflow menu** now hosts Showdown/PokePaste Export/Import (relocated from the inline row between party and box picker). Standalone web app is unchanged — still shows the inline row.
- **iOS WKWebView scroll fix** — added `padding-bottom: env(safe-area-inset-bottom)` on `.mud-main-content` for `<1280px`. The bottom of the scrollable tab panel was being clipped by the home-indicator zone in `viewport-fit=cover`. No-op on browsers without a safe area, beneficial on iOS Safari/PWA too.
- **`EMBEDDED_HOST_GUIDE.md`** — corrected example URL (`app://pkmds/?host=…` instead of `app://pkmds/index.html?host=…`); the latter falls through to PKMDS's `NotFound` page since only `@page \"/\"` is registered.

## UAT testing checklist

### iOS PoC (`tools/embedded-host-ios-poc/`)

Prereqs on the test machine: Xcode + iOS Simulator runtime, .NET SDK from `global.json`, `brew install xcodegen`, `dotnet workload install wasm-tools`.

- [ ] \`./build-and-run.sh\` from \`tools/embedded-host-ios-poc/\` publishes PKMDS, generates the Xcode project, builds for the iOS Simulator, installs, launches.
- [ ] \"Pick a save…\" opens the Files picker. Drag a \`.sav\` (e.g. \`TestFiles/Black - Full Completion.sav\`) onto the Simulator window first so it appears in **On My iPhone**.
- [ ] After picking, the editor sheet presents with native nav bar (Cancel / file name / Done).
- [ ] PKMDS boots inside the WebView; party + boxes render.
- [ ] **Theme follows the simulator's light/dark setting** (Settings → Developer → Dark Appearance toggle). PKMDS forces System theme in embed mode; verify a switch flips PKMDS's chrome live.
- [ ] **Done** triggers the export round-trip and presents the iOS share sheet with the exported \`.sav\` — saving to Files writes correct bytes back.
- [ ] **Cancel** dismisses the sheet without exporting (no share sheet appears).
- [ ] In the kebab overflow menu: **Settings**, **Save Info**, **Repair**, **Export Party As Showdown**, **Export to PokePaste**, **Import from Showdown**, **Report a Bug** all open the right dialogs. Save-dependent items disabled when no save loaded.
- [ ] Form scrolls cleanly to the bottom of the Pokémon edit form — no rubberband, no clipped \"Days\"/\"Shiny\" row at the bottom.
- [ ] **No HTTP requests fire** — Safari → Develop → Simulator → PKMDS Host → Network panel should show only \`app://pkmds/\` requests.
- [ ] **No service worker registered** — Safari Web Inspector → Storage → Service Workers (empty).

### Standalone web — iPhone Safari (the one place the CSS change matters)

- [ ] Load PKMDS in Safari on a real iPhone (or iOS Simulator's Safari).
- [ ] Open a save and navigate around the tabs. Scroll a long form.
- [ ] When Safari minimises its bottom URL bar (after scrolling), confirm the bottom of the form is still reachable — no awkward gap, no clipping.

### Standalone web — iPhone PWA

- [ ] \"Add to Home Screen\" the production build (or a local publish), launch it as a PWA (no Safari chrome).
- [ ] Open a save, scroll to the bottom of a long tab. Verify the last form field is fully visible above the home-indicator gesture area.

### Standalone web — iPad Safari

- [ ] Load PKMDS in iPad Safari. Verify nothing visually changed (iPads don't have a home indicator, so \`env(safe-area-inset-bottom)\` is 0 and the rule is a no-op).

### Standalone web — desktop

- [ ] Quick smoke test in desktop Chrome/Firefox: open a save, verify the inline **Export Party As Showdown / Export to PokePaste / Import from Showdown** buttons still appear between the party row and box picker (i.e. the embed-mode hide didn't accidentally apply).

### EMBEDDED_HOST_GUIDE.md

- [ ] Skim the guide; the iOS PoC is now linked in §6 and the example URL no longer references \`/index.html\`.

## Out of scope (per #799)

App Store / signing / TestFlight, multi-save UI, persistence between launches, real emulator integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)