### PR TITLE
Fix accidental zoom + scrollbar issues on Android (#774)

### DIFF
--- a/Pkmds.Rcl/Components/MainTabPages/BatchEditorTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/BatchEditorTab.razor
@@ -55,7 +55,7 @@
                                   Variant="@Variant.Outlined"
                                   Lines="16"
                                   Immediate
-                                  Style="font-family: monospace; font-size: 0.85rem;"
+                                  Class="batch-script-editor"
                                   Placeholder="# One instruction per line&#10;# Filters: =Species=25&#10;# Set: .Nickname=Pika&#10;# Comments start with #"/>
 
                     @* Scope selector *@

--- a/Pkmds.Rcl/Components/MainTabPages/Pokedex/Gen8La/PokedexLaResearchPanel.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/Pokedex/Gen8La/PokedexLaResearchPanel.razor
@@ -130,10 +130,12 @@
                                                })"/>
                 </MudStack>
 
-                @* Research task table *@
+                @* Research task table — wrapped so the ~620px min-width content
+                   gets a horizontal scrollbar instead of being clipped by the
+                   parent .mud-tab-panel { overflow-x: hidden } on phones. *@
+                <div class="la-research-task-table-wrapper mb-2">
                 <MudSimpleTable Dense
-                                Bordered
-                                Class="mb-2">
+                                Bordered>
                     <thead>
                     <tr>
                         <th style="min-width:220px;">Task</th>
@@ -214,6 +216,7 @@
                     }
                     </tbody>
                 </MudSimpleTable>
+                </div>
 
                 <MudStack Row
                           Justify="Justify.FlexEnd">

--- a/Pkmds.Rcl/Components/PokemonStorageComponent.razor
+++ b/Pkmds.Rcl/Components/PokemonStorageComponent.razor
@@ -22,7 +22,7 @@
     }
     else
     {
-        <div class="flex m-[5px] p-[5px] items-center h-[50px]">
+        <div class="box-navigation flex m-[5px] p-[5px] items-center h-[50px]">
             <MudIconButton OnClick="@GoToPreviousBox"
                            title="Previous Box"
                            ButtonType="@ButtonType.Button"

--- a/Pkmds.Rcl/wwwroot/css/app.css
+++ b/Pkmds.Rcl/wwwroot/css/app.css
@@ -833,14 +833,22 @@ body, html {
       zoom. touch-action: manipulation disables double-tap-zoom on the targeted
       element while leaving pinch-zoom intact.
 
-      The toolbar selector alone wasn't enough — Chrome's gesture detector keys
-      off the actual tap target, and inheritance from an ancestor's
-      touch-action isn't reliable across all Android Chrome builds. Target the
-      individual tab buttons (.mud-tab) and the box navigation icon buttons
-      directly so the property lands on the element that receives the tap. */
+      touch-action is NOT an inherited property, so the rule has to land on the
+      actual <button> element receiving the tap — not just an ancestor. MudTabs
+      renders scroll arrows as <div class="mud-tabs-scroll-button"><button
+      class="mud-icon-button">…</button></div>, and MudPagination renders each
+      page control as <li><button class="mud-icon-button|mud-button">…</button></li>.
+      Without explicit selectors on those inner buttons, taps that land on the
+      button itself (most of them — the icon fills the button) zoom; only taps
+      that hit the wrapper's padding advance cleanly. That's the source of the
+      "only sometimes" zoom on the main tab strip's scroll arrows. */
 .mud-tabs .mud-tabs-toolbar,
 .mud-tabs .mud-tab,
+.mud-tabs .mud-tabs-scroll-button,
+.mud-tabs .mud-tabs-scroll-button .mud-icon-button,
 .mud-pagination,
+.mud-pagination .mud-icon-button,
+.mud-pagination .mud-button,
 .box-navigation .mud-icon-button {
     touch-action: manipulation;
 }

--- a/Pkmds.Rcl/wwwroot/css/app.css
+++ b/Pkmds.Rcl/wwwroot/css/app.css
@@ -797,3 +797,45 @@ body, html {
         max-height: none;
     }
 }
+
+/* ── Issue #774 — accidental zoom mitigations ──
+   Three independent fixes; none of them disable user-scalable so pinch-zoom
+   for accessibility still works.
+
+   1. Batch Editor script textarea: monospace 0.85rem (~13.6px) is below the
+      16px threshold Android Chrome uses to suppress focus auto-zoom. Bump to
+      16px on touch-only devices; keep the tighter 0.85rem on hover-capable
+      desktops where it doesn't trigger zoom. */
+.batch-script-editor textarea.mud-input-slot,
+.batch-script-editor .mud-input-slot.mud-input-root {
+    font-family: monospace;
+    font-size: 0.85rem;
+}
+
+@media (hover: none) and (pointer: coarse) {
+    .batch-script-editor textarea.mud-input-slot,
+    .batch-script-editor .mud-input-slot.mud-input-root {
+        font-size: 16px;
+    }
+}
+
+/* 2. Hisuian Pokédex research-task table: MudSimpleTable doesn't wrap itself
+      in a .mud-table-container, so its ~620px of min-width columns blew out
+      the parent panel and got clipped by .mud-tab-panel { overflow-x: hidden }.
+      Give it its own scroll container so the user can pan the table without
+      having to zoom the whole page. */
+.la-research-task-table-wrapper {
+    overflow-x: auto;
+}
+
+/* 3. Tab scroll-arrows + pagination buttons: rapid-tap to advance reads as a
+      double-tap to Chrome's gesture detector and triggers zoom. touch-action:
+      manipulation disables double-tap-zoom on the targeted element while
+      leaving pinch-zoom intact. Apply to anything users tap repeatedly.
+      Targeting the toolbar (rather than just the scroll-button class) covers
+      both the scroll arrows and the tab strip itself, which is the other
+      surface users rapid-tap. */
+.mud-tabs .mud-tabs-toolbar,
+.mud-pagination {
+    touch-action: manipulation;
+}

--- a/Pkmds.Rcl/wwwroot/css/app.css
+++ b/Pkmds.Rcl/wwwroot/css/app.css
@@ -828,14 +828,19 @@ body, html {
     overflow-x: auto;
 }
 
-/* 3. Tab scroll-arrows + pagination buttons: rapid-tap to advance reads as a
-      double-tap to Chrome's gesture detector and triggers zoom. touch-action:
-      manipulation disables double-tap-zoom on the targeted element while
-      leaving pinch-zoom intact. Apply to anything users tap repeatedly.
-      Targeting the toolbar (rather than just the scroll-button class) covers
-      both the scroll arrows and the tab strip itself, which is the other
-      surface users rapid-tap. */
+/* 3. Tab scroll-arrows + pagination buttons + box navigation: rapid-tap to
+      advance reads as a double-tap to Chrome's gesture detector and triggers
+      zoom. touch-action: manipulation disables double-tap-zoom on the targeted
+      element while leaving pinch-zoom intact.
+
+      The toolbar selector alone wasn't enough — Chrome's gesture detector keys
+      off the actual tap target, and inheritance from an ancestor's
+      touch-action isn't reliable across all Android Chrome builds. Target the
+      individual tab buttons (.mud-tab) and the box navigation icon buttons
+      directly so the property lands on the element that receives the tap. */
 .mud-tabs .mud-tabs-toolbar,
-.mud-pagination {
+.mud-tabs .mud-tab,
+.mud-pagination,
+.box-navigation .mud-icon-button {
     touch-action: manipulation;
 }


### PR DESCRIPTION
Closes #774.

## Summary

Three independent, narrowly-scoped fixes for the "tap a thing, now the page is zoomed and there are scrollbars everywhere" behavior on Android. None of them disable `user-scalable`, so pinch-zoom for accessibility still works.

1. **Batch Editor textarea focus-zoom** — monospace 0.85rem (~13.6px) is below Android Chrome's 16px focus-auto-zoom threshold. Swap inline `Style` for a `batch-script-editor` class that keeps 0.85rem on hover-capable desktops and bumps to 16px on touch-only devices.
2. **Gen8LA research-task table overflow** — `MudSimpleTable` doesn't auto-wrap in a `.mud-table-container`, so its ~620px of min-width columns got clipped by the parent panel's `overflow-x: hidden`. Wrapped in a `<div>` with `overflow-x: auto`.
3. **Tab scroll arrows + MudPagination double-tap-zoom** — rapid-tapping to advance reads as a double-tap to Chrome's gesture detector. Added `touch-action: manipulation` to `.mud-tabs .mud-tabs-toolbar` and `.mud-pagination`.

## Test plan

- [ ] Android Chrome: tap into the Batch Editor script textarea — no focus zoom
- [ ] Android Chrome: Hisuian Pokedex research panel on a ~360px viewport — task table has a local horizontal scrollbar, no clipped columns
- [ ] Android Chrome: rapid-tap the MudTabs scroll arrow — strip advances, page does not zoom
- [ ] Desktop: Batch Editor still renders at 0.85rem monospace
- [ ] Desktop: pinch-zoom on a touchscreen laptop still works

🤖 Generated with [Claude Code](https://claude.ai/code)