### PR TITLE
Support importing Gen 3 Wonder Card (.wc3) files

### DIFF
--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
@@ -804,8 +804,29 @@ public partial class MainLayout : IDisposable
             var data = memoryStream.ToArray();
             Logger.LogDebug("Read {ByteCount} bytes from Mystery Gift file", data.Length);
 
-            if (!FileUtil.TryGetMysteryGift(data, out var mysteryGift,
-                    Path.GetExtension(browserLoadMysteryGiftFile.Name)))
+            var fileExtension = Path.GetExtension(browserLoadMysteryGiftFile.Name);
+
+            // .wc3 files are not DataMysteryGift-compatible — WonderCard3 lives directly in the
+            // save's wonder card slot, so route them to the dedicated WC3 import path before
+            // reaching FileUtil.TryGetMysteryGift (which would reject them).
+            if (string.Equals(fileExtension, ".wc3", StringComparison.OrdinalIgnoreCase))
+            {
+                await AppService.ImportWonderCard3(data, out var wc3ImportSuccessful, out var wc3ImportMessage);
+                if (wc3ImportSuccessful)
+                {
+                    Logger.LogInformation("WC3 Wonder Card imported successfully: {Message}", wc3ImportMessage);
+                    Snackbar.Add(wc3ImportMessage, Severity.Success);
+                }
+                else
+                {
+                    Logger.LogWarning("WC3 Wonder Card import failed: {Message}", wc3ImportMessage);
+                    Snackbar.Add(wc3ImportMessage, Severity.Error);
+                }
+
+                return;
+            }
+
+            if (!FileUtil.TryGetMysteryGift(data, out var mysteryGift, fileExtension))
             {
                 Logger.LogError("Failed to load Mystery Gift file: {FileName} - Not a supported format",
                     browserLoadMysteryGiftFile.Name);
@@ -814,7 +835,7 @@ public partial class MainLayout : IDisposable
             }
 
             // Import the gift card to the mystery gift album when the save supports it.
-            await AppService.ImportMysteryGift(data, Path.GetExtension(browserLoadMysteryGiftFile.Name),
+            await AppService.ImportMysteryGift(data, fileExtension,
                 out var albumImportSuccessful, out var albumImportMessage);
 
             if (albumImportSuccessful)

--- a/Pkmds.Rcl/Services/AppService.cs
+++ b/Pkmds.Rcl/Services/AppService.cs
@@ -755,6 +755,84 @@ public class AppService(IAppState appState, IRefreshService refreshService, ILeg
         return Task.CompletedTask;
     }
 
+    public Task ImportWonderCard3(byte[] data, out bool isSuccessful, out string resultsMessage)
+    {
+        // WC3 files are not handled by FileUtil.TryGetMysteryGift / MysteryGift.GetMysteryGift —
+        // WonderCard3 is stored verbatim in the save's wonder card slot rather than as a generic
+        // DataMysteryGift. Emulate the WC3Plugin import sequence: write the card, optionally the
+        // link-stats extra block, and the accompanying MysteryEvent3 script.
+        if (AppState.SaveFile is not SAV3 sav)
+        {
+            isSuccessful = false;
+            resultsMessage =
+                "The loaded save file does not support WC3 Wonder Cards. Only Generation 3 saves accept WC3 files.";
+            return Task.CompletedTask;
+        }
+
+        if (sav.LargeBlock is not ISaveBlock3LargeExpansion expansion)
+        {
+            isSuccessful = false;
+            resultsMessage =
+                "The loaded save file does not support WC3 Wonder Cards. Only Emerald and FireRed/LeafGreen saves accept WC3 files.";
+            return Task.CompletedTask;
+        }
+
+        var cardSize = sav.Japanese ? WonderCard3.SIZE_JAP : WonderCard3.SIZE;
+        var scriptOffset = cardSize + (WonderCard3Extra.SIZE * 2);
+        var expectedSize = scriptOffset + MysteryEvent3.SIZE;
+
+        if (data.Length != expectedSize)
+        {
+            // The other locale's expected size, used to detect a locale mismatch (e.g. a JPN
+            // .wc3 loaded into an International save) and surface a clearer error than a raw
+            // byte-count mismatch.
+            var otherCardSize = sav.Japanese ? WonderCard3.SIZE : WonderCard3.SIZE_JAP;
+            var otherExpectedSize = otherCardSize + (WonderCard3Extra.SIZE * 2) + MysteryEvent3.SIZE;
+
+            isSuccessful = false;
+            resultsMessage = data.Length == otherExpectedSize
+                ? $"This is a {(sav.Japanese ? "International" : "Japanese")} Wonder Card ({data.Length} bytes), " +
+                  $"but the loaded save is {(sav.Japanese ? "Japanese" : "International")}. " +
+                  $"Use a {(sav.Japanese ? "Japanese" : "International")} ({expectedSize}-byte) WC3 file."
+                : $"Invalid WC3 file size ({data.Length} bytes; expected {expectedSize} bytes for this save).";
+            return Task.CompletedTask;
+        }
+
+        try
+        {
+            Memory<byte> memory = data;
+
+            var card = new WonderCard3(memory[..cardSize]);
+            card.FixChecksum();
+            expansion.SetWonderCard(sav.Japanese, card.Data);
+
+            // Type 2 = link-stats card; the first WonderCard3Extra block records wins/losses/trades.
+            const byte CardTypeLinkStats = 2;
+            if (card.Type == CardTypeLinkStats)
+            {
+                var extra = new WonderCard3Extra(memory.Slice(cardSize, WonderCard3Extra.SIZE));
+                expansion.SetWonderCardExtra(sav.Japanese, extra.Data);
+            }
+
+            var script = new MysteryEvent3(memory[scriptOffset..]);
+            script.FixChecksum();
+            expansion.MysteryData = script;
+
+            var title = card.Title.Trim();
+            isSuccessful = true;
+            resultsMessage = string.IsNullOrEmpty(title)
+                ? "Wonder Card imported successfully."
+                : $"Wonder Card \"{title}\" imported successfully.";
+            return Task.CompletedTask;
+        }
+        catch (Exception ex)
+        {
+            isSuccessful = false;
+            resultsMessage = ex.Message;
+            return Task.CompletedTask;
+        }
+    }
+
     public void MovePokemon(int? sourceBoxNumber, int sourceSlotNumber, bool isSourceParty,
         int? destBoxNumber, int destSlotNumber, bool isDestParty)
     {

--- a/Pkmds.Rcl/Services/IAppService.cs
+++ b/Pkmds.Rcl/Services/IAppService.cs
@@ -282,6 +282,20 @@ public interface IAppService
     Task ImportMysteryGift(byte[] data, string fileExtension, out bool isSuccessful, out string resultsMessage);
 
     /// <summary>
+    /// Imports a Generation 3 Wonder Card (<c>.wc3</c>) file into the loaded save file.
+    /// WC3 files are not <see cref="DataMysteryGift" />-compatible because <see cref="WonderCard3" />
+    /// is stored as a raw save-slot struct rather than a generic mystery gift; this method writes
+    /// the card, the optional <see cref="WonderCard3Extra" /> link-stats block, and the accompanying
+    /// <see cref="MysteryEvent3" /> script directly into the save's wonder card slots.
+    /// Only Emerald and FireRed/LeafGreen saves are supported (Ruby/Sapphire have no wonder card slot).
+    /// </summary>
+    /// <param name="data">The raw <c>.wc3</c> file bytes.</param>
+    /// <param name="isSuccessful">Output parameter indicating whether the import was successful.</param>
+    /// <param name="resultsMessage">Output parameter containing a message describing the result.</param>
+    /// <returns>A completed task.</returns>
+    Task ImportWonderCard3(byte[] data, out bool isSuccessful, out string resultsMessage);
+
+    /// <summary>
     /// Moves or swaps a Pokémon between slots (box-to-box, party-to-box, box-to-party, or party-to-party).
     /// Handles special cases like Gen 1/2 box compacting and party compacting.
     /// </summary>


### PR DESCRIPTION
## Summary
- Add `IAppService.ImportWonderCard3` that writes a `.wc3` file's `WonderCard3`, optional `WonderCard3Extra` (for type 2 link-stats cards), and accompanying `MysteryEvent3` script into Emerald / FireRed / LeafGreen saves via `ISaveBlock3LargeExpansion`. Each piece gets `FixChecksum()` first.
- Intercept `.wc3` in `MainLayout.LoadMysteryGiftFile` before the generic `FileUtil.TryGetMysteryGift` call (which would reject WC3 — `WonderCard3` is not a `DataMysteryGift`).
- Surface a clear locale-mismatch error when the file size matches the *other* locale (e.g. a JPN 1252-byte WC3 loaded into an International save expecting 1420 bytes).

Closes #423.

## Test plan
- [ ] Load an Emerald (US) save and import a 1420-byte International `.wc3` — succeeds, snackbar shows the card title.
- [ ] Load a Japanese Emerald save and import the included `TestFiles/E - Item Old Sea Map (JPN).wc3` (1252 bytes) — succeeds.
- [ ] Load a JPN `.wc3` into an English save (or vice versa) — fails with the new locale-mismatch message rather than a raw byte-count error.
- [ ] Load a `.wc3` into a Ruby/Sapphire save — fails with the unsupported-save message (RS lacks `ISaveBlock3LargeExpansion`).
- [ ] After import, in-game Mystery Gift receive flow on the save delivers the gift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)