### PR TITLE
Add in-app viewer for save-file Wonder Cards / Mystery Gifts

### DIFF
--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
@@ -816,6 +816,10 @@ public partial class MainLayout : IDisposable
                 {
                     Logger.LogInformation("WC3 Wonder Card imported successfully: {Message}", wc3ImportMessage);
                     Snackbar.Add(wc3ImportMessage, Severity.Success);
+                    // Notify subscribers (e.g. the Wonder Cards tab) that save state changed —
+                    // otherwise the viewer keeps rendering the pre-import slot until the user
+                    // navigates away and back.
+                    RefreshService.Refresh();
                 }
                 else
                 {
@@ -842,6 +846,8 @@ public partial class MainLayout : IDisposable
             {
                 Logger.LogInformation("Mystery Gift card imported to album successfully");
                 Snackbar.Add("Mystery Gift card added to Wonder Cards album.", Severity.Success);
+                // Notify subscribers (e.g. the Wonder Cards tab) that save state changed.
+                RefreshService.Refresh();
             }
             else
             {

--- a/Pkmds.Rcl/Components/MainTabPages/WonderCardsTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/WonderCardsTab.razor
@@ -30,6 +30,8 @@
                   Hover
                   Striped
                   Bordered
+                  FixedHeader
+                  Height="calc(100dvh - 260px)"
                   Class="wonder-cards-table">
             <HeaderContent>
                 <MudTh>#</MudTh>

--- a/Pkmds.Rcl/Components/MainTabPages/WonderCardsTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/WonderCardsTab.razor
@@ -1,0 +1,83 @@
+@inherits RefreshAwareComponent
+
+<MudStack Class="pa-2"
+          Spacing="3">
+
+    @if (AppState.SaveFile is null)
+    {
+        <MudAlert Severity="@Severity.Info">No save file is loaded.</MudAlert>
+    }
+    else if (!AppService.HasWonderCardSlots())
+    {
+        <MudAlert Severity="@Severity.Info">
+            The loaded save file does not expose Wonder Card / Mystery Gift slots that can be
+            displayed. (Supported: Generation 3 Emerald / FRLG and all Generation 4–7 saves
+            including Let's Go.)
+        </MudAlert>
+    }
+    else
+    {
+        var slots = Slots;
+        var occupiedCount = slots.Count(s => !s.IsEmpty);
+
+        <MudText Typo="@Typo.body2" Color="@Color.Default">
+            Showing @occupiedCount of @slots.Count slot(s) occupied.
+        </MudText>
+
+        <MudTable T="@WonderCardSlotInfo"
+                  Items="@slots"
+                  Dense
+                  Hover
+                  Striped
+                  Bordered
+                  Class="wonder-cards-table">
+            <HeaderContent>
+                <MudTh>#</MudTh>
+                <MudTh>Title</MudTh>
+                <MudTh>Type</MudTh>
+                <MudTh>Card ID</MudTh>
+                <MudTh>Species</MudTh>
+                <MudTh>Received</MudTh>
+                <MudTh>Notes</MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd DataLabel="#">@(context.Index + 1)</MudTd>
+                <MudTd DataLabel="Title">
+                    @if (context.IsEmpty)
+                    {
+                        <MudText Typo="@Typo.body2" Color="@Color.Default">@context.Title</MudText>
+                    }
+                    else
+                    {
+                        @context.Title
+                    }
+                </MudTd>
+                <MudTd DataLabel="Type">@context.CardType</MudTd>
+                <MudTd DataLabel="Card ID">
+                    @(context.CardId is { } id ? id.ToString("0000", CultureInfo.InvariantCulture) : "—")
+                </MudTd>
+                <MudTd DataLabel="Species">@SpeciesLabel(context)</MudTd>
+                <MudTd DataLabel="Received">
+                    @switch (context.Received)
+                    {
+                        case true:
+                            <MudIcon Icon="@Icons.Material.Filled.CheckCircle"
+                                     Color="@Color.Success"
+                                     Size="@Size.Small"/>
+                            break;
+                        case false:
+                            <MudIcon Icon="@Icons.Material.Outlined.RadioButtonUnchecked"
+                                     Color="@Color.Default"
+                                     Size="@Size.Small"/>
+                            break;
+                        default:
+                            <span>—</span>
+                            break;
+                    }
+                </MudTd>
+                <MudTd DataLabel="Notes">@(context.ExtraInfo ?? string.Empty)</MudTd>
+            </RowTemplate>
+        </MudTable>
+    }
+
+</MudStack>

--- a/Pkmds.Rcl/Components/MainTabPages/WonderCardsTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/WonderCardsTab.razor.cs
@@ -1,0 +1,16 @@
+namespace Pkmds.Rcl.Components.MainTabPages;
+
+public partial class WonderCardsTab : RefreshAwareComponent
+{
+    // Recomputed on every render. Cheap (≤49 slots) and avoids stale data after a save reload
+    // or a mystery-gift import — RefreshAwareComponent triggers StateHasChanged on AppState
+    // events, which re-runs the render path but does not invoke OnParametersSet.
+    private IReadOnlyList<WonderCardSlotInfo> Slots => AppService.HasWonderCardSlots()
+        ? AppService.GetWonderCardSlots()
+        : [];
+
+    private string SpeciesLabel(WonderCardSlotInfo slot) =>
+        slot.Species is { } species
+            ? AppService.GetPokemonSpeciesName(species) ?? species.ToString(CultureInfo.InvariantCulture)
+            : "—";
+}

--- a/Pkmds.Rcl/Components/SaveFileComponent.razor
+++ b/Pkmds.Rcl/Components/SaveFileComponent.razor
@@ -60,6 +60,15 @@ else
             </MudTabPanel>
         }
 
+        @if (AppService.HasWonderCardSlots())
+        {
+            <MudTabPanel Text="Wonder Cards">
+                <div class="mt-3">
+                    <WonderCardsTab/>
+                </div>
+            </MudTabPanel>
+        }
+
         @if (saveFile is SAV3 { Generation: 3 } sav3)
         {
             <MudTabPanel Text="Records">

--- a/Pkmds.Rcl/Models/WonderCardSlotInfo.cs
+++ b/Pkmds.Rcl/Models/WonderCardSlotInfo.cs
@@ -1,0 +1,41 @@
+namespace Pkmds.Rcl.Models;
+
+/// <summary>
+/// Generation-agnostic snapshot of a single wonder card / mystery gift slot stored in the
+/// loaded save file. Used by the Wonder Cards viewer to display Gen 3 (<see cref="WonderCard3" />)
+/// and Gen 4–7 (<see cref="DataMysteryGift" />) slots in a unified table.
+/// </summary>
+public sealed record WonderCardSlotInfo
+{
+    /// <summary>0-based slot index. For Gen 3 this is always 0; for Gen 4 HG/SS, the Lock
+    /// Capsule appears as the highest index.</summary>
+    public required int Index { get; init; }
+
+    /// <summary>Human-readable card title (e.g., the gift's name as shown in-game). For empty
+    /// slots this is the localized "(empty)" placeholder.</summary>
+    public required string Title { get; init; }
+
+    /// <summary>Concrete card type label — e.g. "WC6", "PGF", "WonderCard3". Useful for
+    /// distinguishing card formats inside a multi-format storage block.</summary>
+    public required string CardType { get; init; }
+
+    /// <summary>The card's in-game card ID, when the format exposes one. <see langword="null" />
+    /// for formats without IDs (e.g. <see cref="WR7" />) or for empty slots.</summary>
+    public int? CardId { get; init; }
+
+    /// <summary>Pokémon species delivered by the card, when the card is an entity gift.
+    /// <see langword="null" /> for item gifts, BP gifts, item-only WC3 cards, etc.</summary>
+    public ushort? Species { get; init; }
+
+    /// <summary>True when the slot has no card written. Empty rows still appear in the table
+    /// so the user can see the storage's full slot count.</summary>
+    public required bool IsEmpty { get; init; }
+
+    /// <summary>Received-flag state when the storage exposes <see cref="IMysteryGiftFlags" />.
+    /// <see langword="null" /> when the format has no received-flag bitmap (Gen 3).</summary>
+    public bool? Received { get; init; }
+
+    /// <summary>Optional one-line note (e.g. "Lock Capsule" for SAV4HGSS, "Mystery Event script
+    /// present" for Gen 3, "Link card" for WC3 type 2).</summary>
+    public string? ExtraInfo { get; init; }
+}

--- a/Pkmds.Rcl/Services/AppService.cs
+++ b/Pkmds.Rcl/Services/AppService.cs
@@ -836,6 +836,11 @@ public class AppService(IAppState appState, IRefreshService refreshService, ILeg
     public bool HasWonderCardSlots() => AppState.SaveFile switch
     {
         SAV3 sav => sav.LargeBlock is ISaveBlock3LargeExpansion,
+        // Intentionally probes the interface rather than hardcoding SAV4..SAV7b: in PKHeX 26.4.11
+        // only those generations implement IMysteryGiftStorageProvider (SAV8 / SAV9 deliberately
+        // do not — BDSP's MysteryBlock8b is a separate received-gift history block, tracked in
+        // #813). If upstream ever extends the interface to a future generation, this picks it up
+        // automatically rather than silently ignoring the new save format.
         IMysteryGiftStorageProvider => true,
         _ => false,
     };
@@ -890,7 +895,13 @@ public class AppService(IAppState appState, IRefreshService refreshService, ILeg
                     Species = null,
                     IsEmpty = isEmpty,
                     Received = null,
-                    ExtraInfo = isEmpty ? null : extra,
+                    // Surface the script-present note even for empty card slots: a Mystery Event
+                    // script can legitimately exist on its own (e.g. the user cleared the card
+                    // but the script remains from a prior import). Suppress only the link-card
+                    // sub-text when the card itself is empty, since "Type" comes from the card.
+                    ExtraInfo = isEmpty
+                        ? scriptPresent ? "Mystery Event script present" : null
+                        : extra,
                 },
             ];
         }

--- a/Pkmds.Rcl/Services/AppService.cs
+++ b/Pkmds.Rcl/Services/AppService.cs
@@ -833,6 +833,116 @@ public class AppService(IAppState appState, IRefreshService refreshService, ILeg
         }
     }
 
+    public bool HasWonderCardSlots() => AppState.SaveFile switch
+    {
+        SAV3 sav => sav.LargeBlock is ISaveBlock3LargeExpansion,
+        IMysteryGiftStorageProvider => true,
+        _ => false,
+    };
+
+    public IReadOnlyList<WonderCardSlotInfo> GetWonderCardSlots()
+    {
+        if (AppState.SaveFile is not { } saveFile)
+        {
+            return [];
+        }
+
+        if (saveFile is SAV3 sav3 && sav3.LargeBlock is ISaveBlock3LargeExpansion expansion)
+        {
+            return BuildGen3Slots(sav3, expansion);
+        }
+
+        if (saveFile is IMysteryGiftStorageProvider provider)
+        {
+            return BuildModernSlots(saveFile, provider);
+        }
+
+        return [];
+
+        static IReadOnlyList<WonderCardSlotInfo> BuildGen3Slots(SAV3 sav, ISaveBlock3LargeExpansion expansion)
+        {
+            var card = expansion.GetWonderCard(sav.Japanese);
+            // The wonder card slot is initialised to 0xFF / 0x00 padding on a fresh save.
+            // Treat any slot whose card body has no real bytes set as empty (mirrors WC3Plugin's
+            // HasWC3 check). CardID == 0 alone is not enough — some valid cards have ID 0.
+            var isEmpty = !card.Data.ContainsAnyExcept<byte>(0, 0xFF);
+            var title = card.Title.Replace('　', ' ').Trim();
+
+            // The Mystery Event script lives in a separate slot; surface its presence as an
+            // info note so users can confirm the script was written alongside the card.
+            var scriptPresent = expansion.MysteryData.Data.ContainsAnyExcept<byte>(0, 0xFF);
+            string? extra = (card.Type, scriptPresent) switch
+            {
+                (2, true) => "Link card; Mystery Event script present",
+                (2, false) => "Link card",
+                (_, true) => "Mystery Event script present",
+                _ => null,
+            };
+
+            return
+            [
+                new WonderCardSlotInfo
+                {
+                    Index = 0,
+                    Title = isEmpty ? "(empty)" : (string.IsNullOrEmpty(title) ? "(no title)" : title),
+                    CardType = nameof(WonderCard3),
+                    CardId = isEmpty ? null : card.CardID,
+                    Species = null,
+                    IsEmpty = isEmpty,
+                    Received = null,
+                    ExtraInfo = isEmpty ? null : extra,
+                },
+            ];
+        }
+
+        static IReadOnlyList<WonderCardSlotInfo> BuildModernSlots(SaveFile saveFile, IMysteryGiftStorageProvider provider)
+        {
+            var storage = provider.MysteryGiftStorage;
+            var flags = storage as IMysteryGiftFlags;
+            var count = storage.GiftCountMax;
+            var includeLockCapsule = saveFile is SAV4HGSS;
+            var slots = new List<WonderCardSlotInfo>(count + (includeLockCapsule ? 1 : 0));
+
+            for (var i = 0; i < count; i++)
+            {
+                slots.Add(BuildModernSlot(storage.GetMysteryGift(i), i, flags, extra: null));
+            }
+
+            if (includeLockCapsule && saveFile is SAV4HGSS hgss)
+            {
+                slots.Add(BuildModernSlot(hgss.LockCapsuleSlot, count, flags, extra: "Lock Capsule"));
+            }
+
+            return slots;
+        }
+
+        static WonderCardSlotInfo BuildModernSlot(DataMysteryGift gift, int index, IMysteryGiftFlags? flags, string? extra)
+        {
+            var isEmpty = gift.IsEmpty;
+            var title = isEmpty ? "(empty)" : gift.CardTitle.Replace('　', ' ').Trim();
+            ushort? species = isEmpty || !gift.IsEntity ? null : gift.Species;
+            var cardId = isEmpty ? (int?)null : gift.CardID;
+
+            bool? received = null;
+            if (!isEmpty && flags is not null && cardId is { } id && (uint)id < flags.MysteryGiftReceivedFlagMax)
+            {
+                received = flags.GetMysteryGiftReceivedFlag(id);
+            }
+
+            return new WonderCardSlotInfo
+            {
+                Index = index,
+                Title = string.IsNullOrEmpty(title) ? (isEmpty ? "(empty)" : "(no title)") : title,
+                CardType = gift.GetType().Name,
+                CardId = cardId,
+                Species = species,
+                IsEmpty = isEmpty,
+                Received = received,
+                ExtraInfo = extra,
+            };
+        }
+    }
+
     public void MovePokemon(int? sourceBoxNumber, int sourceSlotNumber, bool isSourceParty,
         int? destBoxNumber, int destSlotNumber, bool isDestParty)
     {

--- a/Pkmds.Rcl/Services/IAppService.cs
+++ b/Pkmds.Rcl/Services/IAppService.cs
@@ -282,6 +282,22 @@ public interface IAppService
     Task ImportMysteryGift(byte[] data, string fileExtension, out bool isSuccessful, out string resultsMessage);
 
     /// <summary>
+    /// Returns <see langword="true" /> if the loaded save file exposes any wonder card /
+    /// mystery gift slots that the in-app viewer can display. Mirrors the support matrix in
+    /// PKHeX WinForms' <c>SAV_Wondercard</c>: Generation 3 Emerald / FRLG, plus all Gen 4–7
+    /// saves that implement <see cref="IMysteryGiftStorageProvider" /> (DP/Pt/HGSS, BW/B2W2,
+    /// XY/ORAS, SM/USUM, LGPE).
+    /// </summary>
+    bool HasWonderCardSlots();
+
+    /// <summary>
+    /// Returns a generation-agnostic snapshot of every wonder card / mystery gift slot in
+    /// the loaded save file (including empty slots, so the viewer can show full storage
+    /// capacity). The list is empty when the save has no wonder card storage.
+    /// </summary>
+    IReadOnlyList<WonderCardSlotInfo> GetWonderCardSlots();
+
+    /// <summary>
     /// Imports a Generation 3 Wonder Card (<c>.wc3</c>) file into the loaded save file.
     /// WC3 files are not <see cref="DataMysteryGift" />-compatible because <see cref="WonderCard3" />
     /// is stored as a raw save-slot struct rather than a generic mystery gift; this method writes

--- a/Pkmds.Tests/AppServiceTests.cs
+++ b/Pkmds.Tests/AppServiceTests.cs
@@ -372,6 +372,97 @@ public class AppServiceTests
         appState.SelectedBoxNumber.Should().BeNull();
     }
 
+    [Fact]
+    public void HasWonderCardSlots_NoSaveLoaded_ReturnsFalse()
+    {
+        var appState = new TestAppState { SaveFile = null };
+        var appService = new AppService(appState, new TestRefreshService(), new LegalizationService());
+
+        appService.HasWonderCardSlots().Should().BeFalse();
+        appService.GetWonderCardSlots().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void HasWonderCardSlots_RubySave_ReturnsFalseBecauseRSLacksWonderCardStorage()
+    {
+        // SAV3RS uses SaveBlock3LargeRS which does NOT implement ISaveBlock3LargeExpansion —
+        // RS has no wonder card slot, so the viewer should hide the tab on Ruby/Sapphire saves.
+        var data = File.ReadAllBytes(Path.Combine(TestFilesPath, "POKEMON RUBY_AXVE-0.sav"));
+        SaveUtil.TryGetSaveFile(data, out var saveFile, "POKEMON RUBY_AXVE-0.sav").Should().BeTrue();
+
+        var appState = new TestAppState { SaveFile = saveFile };
+        var appService = new AppService(appState, new TestRefreshService(), new LegalizationService());
+
+        appService.HasWonderCardSlots().Should().BeFalse();
+        appService.GetWonderCardSlots().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GetWonderCardSlots_EmeraldWithImportedWC3_ReturnsSinglePopulatedSlot()
+    {
+        // The bundled JPN Emerald save has the Old Sea Map WC3 imported (see PR #810 / issue #423).
+        var data = File.ReadAllBytes(Path.Combine(TestFilesPath, "Pocket Monsters - Emerald (Japan).sav"));
+        SaveUtil.TryGetSaveFile(data, out var saveFile, "Pocket Monsters - Emerald (Japan).sav").Should().BeTrue();
+        saveFile.Should().BeOfType<SAV3E>();
+
+        var appState = new TestAppState { SaveFile = saveFile };
+        var appService = new AppService(appState, new TestRefreshService(), new LegalizationService());
+
+        appService.HasWonderCardSlots().Should().BeTrue();
+
+        var slots = appService.GetWonderCardSlots();
+        slots.Should().HaveCount(1);
+        var slot = slots[0];
+        slot.Index.Should().Be(0);
+        slot.CardType.Should().Be(nameof(WonderCard3));
+        slot.IsEmpty.Should().BeFalse();
+        slot.Title.Should().NotBe("(empty)");
+        slot.Title.Should().NotBeNullOrWhiteSpace();
+        slot.CardId.Should().NotBeNull();
+        // Gen 3 has no IMysteryGiftFlags-style bitmap, so Received is always null here.
+        slot.Received.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetWonderCardSlots_BlackSave_ReturnsTwelveSlotsAllEmpty()
+    {
+        // Black/White's MysteryBlock5 exposes 12 PGF slots via IMysteryGiftStorageProvider.
+        var data = File.ReadAllBytes(Path.Combine(TestFilesPath, "Black - Full Completion.sav"));
+        SaveUtil.TryGetSaveFile(data, out var saveFile, "Black - Full Completion.sav").Should().BeTrue();
+
+        var appState = new TestAppState { SaveFile = saveFile };
+        var appService = new AppService(appState, new TestRefreshService(), new LegalizationService());
+
+        appService.HasWonderCardSlots().Should().BeTrue();
+
+        var slots = appService.GetWonderCardSlots();
+        slots.Should().HaveCount(12);
+        slots.Select(s => s.Index).Should().Equal(Enumerable.Range(0, 12));
+        slots.Should().OnlyContain(s => s.CardType == nameof(PGF));
+        // The bundled save has no imported gifts; every slot should report empty + no Received flag.
+        slots.Should().OnlyContain(s => s.IsEmpty);
+        slots.Should().OnlyContain(s => s.Received == null || s.Received == false);
+    }
+
+    [Fact]
+    public void GetWonderCardSlots_LetsGoSave_ReturnsTenWR7Slots()
+    {
+        // SAV7b stores 10 WR7 records via WB7Records (the storage block is named after WB7 but
+        // actually casts to WR7 — see WB7Records.cs:50).
+        var data = File.ReadAllBytes(Path.Combine(TestFilesPath, "Lets-Go-Pikachu-All-Pokemon.bin"));
+        SaveUtil.TryGetSaveFile(data, out var saveFile, "Lets-Go-Pikachu-All-Pokemon.bin").Should().BeTrue();
+        saveFile.Should().BeOfType<SAV7b>();
+
+        var appState = new TestAppState { SaveFile = saveFile };
+        var appService = new AppService(appState, new TestRefreshService(), new LegalizationService());
+
+        appService.HasWonderCardSlots().Should().BeTrue();
+
+        var slots = appService.GetWonderCardSlots();
+        slots.Should().HaveCount(10);
+        slots.Should().OnlyContain(s => s.CardType == nameof(WR7));
+    }
+
     private class TestAppState : IAppState
     {
         public string CurrentLanguage { get; set; } = "en";

--- a/Pkmds.Tests/GlobalUsings.cs
+++ b/Pkmds.Tests/GlobalUsings.cs
@@ -5,5 +5,6 @@ global using Pkmds.Core.Utilities;
 global using Pkmds.Rcl;
 global using Pkmds.Rcl.Components;
 global using Pkmds.Rcl.Components.EditForms.Tabs;
+global using Pkmds.Rcl.Models;
 global using Pkmds.Rcl.Services;
 global using Xunit;


### PR DESCRIPTION
## Summary
- New **Wonder Cards** tab in \`SaveFileComponent\` lists the wonder card / mystery gift slots stored in the loaded save file. Tab is conditionally rendered via \`AppService.HasWonderCardSlots()\` so it stays hidden on unsupported saves (Gen 1/2, RS, SWSH, LA, SV).
- Service surface: \`HasWonderCardSlots()\` and \`GetWonderCardSlots()\` on \`IAppService\`. Returns \`IReadOnlyList<WonderCardSlotInfo>\` (a generation-agnostic record with \`Index\`, \`Title\`, \`CardType\`, \`CardId\`, \`Species\`, \`IsEmpty\`, \`Received\`, \`ExtraInfo\`).
- Generation coverage matches PKHeX WinForms' \`SAV_Wondercard\`:
  - **Gen 3** (E, FRLG): single \`WonderCard3\` slot via \`ISaveBlock3LargeExpansion.GetWonderCard(sav.Japanese)\`. \"Mystery Event script present\" appears in the Notes column when \`MysteryData\` is non-empty.
  - **Gen 4** (DP, Pt, HGSS): 11 slots via \`IMysteryGiftStorageProvider\` — 8× \`PGT\` + 3× \`PCD\`. SAV4HGSS gets a 12th row labelled \"Lock Capsule\".
  - **Gen 5** (BW, B2W2): 12× \`PGF\`.
  - **Gen 6** (XY, ORAS): 24× \`WC6\`.
  - **Gen 7** (SM, USUM): 48× \`WC7\`.
  - **Gen 7b** (LGPE): 10× \`WR7\`.
- Received status is read via optional \`IMysteryGiftFlags\` cast (Gen 4–7); shown as a checkmark, empty radio, or em-dash (Gen 3, no flag bitmap).

Closes #811. Follow-ups: #812 (per-slot actions: export, clear, edit, receive toggle) and #813 (BDSP \`MysteryBlock8b\` received-gift history viewer).

## Test plan
- [ ] **Gen 3** — load \`TestFiles/Pocket Monsters - Emerald (Japan).sav\` (already has the Old Sea Map WC3 imported via #423). Tab should show 1 row: title \"Old Sea Map\" (or its JP equivalent), type \`WonderCard3\`, Notes column says \"Mystery Event script present\".
- [ ] **Gen 3 RS** — load a Ruby/Sapphire save. Tab should NOT appear (no \`ISaveBlock3LargeExpansion\`).
- [ ] **Gen 4 HGSS** — load any HG/SS save. Tab shows 12 rows; the last row has Notes \"Lock Capsule\".
- [ ] **Gen 4/5/6/7** — load saves of each. Tab shows correct slot count (11/12/24/48). Empty slots render as \"(empty)\" with em-dashes.
- [ ] **Gen 7b** — load LGPE. Tab shows 10 \`WR7\` rows.
- [ ] **Gen 8/9** (SWSH, LA, BDSP, SV) — load any. Tab does NOT appear.
- [ ] On a save with received gifts (Gen 4–7), the Received column shows the checkmark for cards whose flag is set.
- [ ] After importing a new mystery gift via the existing \"Mystery Gifts\" tab, the Wonder Cards tab reflects the new slot on next render (the property recomputes per render).

🤖 Generated with [Claude Code](https://claude.com/claude-code)