### PR TITLE
fix(pokedex): guard LA fill/clear against non-settable research tasks

### DIFF
--- a/Pkmds.Rcl/Components/MainTabPages/PokedexTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/PokedexTab.razor.cs
@@ -305,7 +305,11 @@ public partial class PokedexTab
 
             foreach (var task in PokedexConstants8a.ResearchTasks[dexIndex - 1])
             {
-                if (task.TaskThresholds.Length == 0)
+                // ObtainForms / PartOfArceus / SpeciesQuest tasks have no settable
+                // counter — calling SetResearchTaskProgressByForce on them throws
+                // ArgumentOutOfRangeException from PokedexSaveResearchEntry.SetCurrentResearchLevel.
+                // PKHeX WinForms (SAV_PokedexLA.cs) gates each call on this check.
+                if (!task.Task.CanSetCurrentValue() || task.TaskThresholds.Length == 0)
                 {
                     continue;
                 }
@@ -335,7 +339,7 @@ public partial class PokedexTab
 
             foreach (var task in PokedexConstants8a.ResearchTasks[dexIndex - 1])
             {
-                if (task.TaskThresholds.Length == 0)
+                if (!task.Task.CanSetCurrentValue() || task.TaskThresholds.Length == 0)
                 {
                     continue;
                 }


### PR DESCRIPTION
## Summary
- Fixes #826 — Fill Pokédex on a Legends: Arceus save crashed with `ArgumentOutOfRangeException` from `PokedexSaveResearchEntry.SetCurrentResearchLevel`.
- Some species' research lists include `ObtainForms` / `PartOfArceus` / `SpeciesQuest` tasks, which are valid `PokedexResearchTaskType8a` enum values but have no settable counter — `SetCurrentResearchLevel`'s switch falls through to a throw.
- Now skip those tasks via `PokedexResearchTaskType8a.CanSetCurrentValue()`, matching what PKHeX WinForms does at `SAV_PokedexLA.cs:391`. Applied to both `FillGen8LaPokedex` and `ClearAllLaResearch` since they share the same iteration pattern.

## Test plan
- [ ] Load a Legends: Arceus save and click Fill Pokédex — no crash, dex completion proceeds.
- [ ] Click Clear on the same save — research entries reset cleanly.
- [ ] Verify other-game Fill / Clear paths still work (Gen 1–9, BDSP, ZA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)