### PR TITLE
fix: resolve held-item names with the source Pokémon's context (#827)

### DIFF
--- a/Pkmds.Rcl/Components/Dialogs/ShowdownImportDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/ShowdownImportDialog.razor.cs
@@ -167,9 +167,12 @@ public partial class ShowdownImportDialog
 
         parts.Add($"Lv.{set.Level}");
 
-        if (set.HeldItem > 0 && set.HeldItem < strings.Item.Count)
+        // ShowdownSet.HeldItem is in the set's Context-specific item ID space, which differs
+        // from the modern (Gen 4+) `strings.Item` table for Gen 1/2/3/4/8b/9/9a sets.
+        var setItems = strings.GetItemStrings(set.Context);
+        if (set.HeldItem > 0 && set.HeldItem < setItems.Length)
         {
-            parts.Add($"@ {strings.Item[set.HeldItem]}");
+            parts.Add($"@ {setItems[set.HeldItem]}");
         }
 
         return string.Join(" ", parts);

--- a/Pkmds.Rcl/Components/MainTabPages/AdvancedSearchTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/AdvancedSearchTab.razor
@@ -578,8 +578,9 @@
                                         </MudStack>
                                         @if (heldItemId is > 0 && AppState.SaveFile is { } heldItemSf)
                                         {
-                                            var heldItemName = heldItemId.Value < GameInfo.Strings.itemlist.Length
-                                                ? GameInfo.Strings.itemlist[heldItemId.Value]
+                                            var heldItemNames = GameInfo.Strings.GetItemStrings(heldItemSf.Context, heldItemSf.Version);
+                                            var heldItemName = heldItemId.Value < heldItemNames.Length
+                                                ? heldItemNames[heldItemId.Value]
                                                 : string.Empty;
                                             <object class="item-sprite"
                                                     type="image/png"
@@ -916,11 +917,16 @@
                             </MudTd>
 
                             <MudTd DataLabel="Held Item">
+                                @{
+                                    var rowItemNames = AppState.SaveFile is { } rowSf
+                                        ? GameInfo.Strings.GetItemStrings(context.Pokemon.Context, rowSf.Version)
+                                        : System.Array.Empty<string>();
+                                }
                                 @if (context.Pokemon.HeldItem > 0
                                      && AppState.SaveFile is { } sf
-                                     && context.Pokemon.HeldItem < GameInfo.Strings.itemlist.Length)
+                                     && context.Pokemon.HeldItem < rowItemNames.Length)
                                 {
-                                    var heldItemName = GameInfo.Strings.itemlist[context.Pokemon.HeldItem];
+                                    var heldItemName = rowItemNames[context.Pokemon.HeldItem];
                                     <span @onclick:stopPropagation="true"
                                           style="display:inline-flex;align-items:center;gap:4px;">
                                             <object class="item-sprite"

--- a/Pkmds.Rcl/Components/MainTabPages/AdvancedSearchTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/AdvancedSearchTab.razor.cs
@@ -148,13 +148,17 @@ public partial class AdvancedSearchTab : RefreshAwareComponent
         loadedHeldItems.Clear();
         loadedBalls.Clear();
 
-        var itemlist = GameInfo.Strings.itemlist;
         var version = saveFile.Version;
 
         var distinctAbilityIds = results.Select(r => r.Pokemon.Ability).Distinct().ToList();
-        var distinctHeldItemIds = results.Select(r => r.Pokemon.HeldItem)
-            .Where(id => id > 0 && id < itemlist.Length)
-            .Distinct()
+        // Item IDs are context-specific (Gen 1/2/3/4/8b/9/9a all differ from the modern table).
+        // Resolve the name with the source Pokémon's own context, then dedupe by ID — the
+        // cache is keyed by ID and any duplicates within a single save will share a context.
+        var distinctHeldItemEntries = results
+            .Where(r => r.Pokemon.HeldItem > 0)
+            .Select(r => (Id: r.Pokemon.HeldItem, Context: r.Pokemon.Context))
+            .GroupBy(t => t.Id)
+            .Select(g => g.First())
             .ToList();
         var distinctBallIds = results.Select(r => r.Pokemon.Ball)
             .Where(id => id > 0)
@@ -164,7 +168,11 @@ public partial class AdvancedSearchTab : RefreshAwareComponent
         var abilityResults = await Task.WhenAll(
             distinctAbilityIds.Select(async id => (id, info: await DescriptionService.GetAbilityInfoAsync(id, version))));
         var heldItemResults = await Task.WhenAll(
-            distinctHeldItemIds.Select(async id => (id, info: await DescriptionService.GetItemInfoAsync(SafeNameLookup.Item(itemlist, id), version))));
+            distinctHeldItemEntries.Select(async entry =>
+            {
+                var items = GameInfo.Strings.GetItemStrings(entry.Context, version);
+                return (id: entry.Id, info: await DescriptionService.GetItemInfoAsync(SafeNameLookup.Item(items, entry.Id), version));
+            }));
         var ballResults = await Task.WhenAll(
             distinctBallIds.Select(async id =>
             {
@@ -553,9 +561,11 @@ public partial class AdvancedSearchTab : RefreshAwareComponent
             : null;
         if (heldItemId.HasValue && AppState.SaveFile is { } sf)
         {
-            var itemlist = GameInfo.Strings.itemlist;
-            var name = heldItemId.Value < itemlist.Length
-                ? itemlist[heldItemId.Value]
+            // The filter dropdown sources from FilteredSources.Items, whose Value is in the
+            // save's context-specific item ID space — look the name up in the same space.
+            var items = GameInfo.Strings.GetItemStrings(sf.Context, sf.Version);
+            var name = heldItemId.Value < items.Length
+                ? items[heldItemId.Value]
                 : null;
             filterHeldItemInfo = name is not null
                 ? await DescriptionService.GetItemInfoAsync(name, sf.Version)

--- a/Pkmds.Rcl/Components/MainTabPages/TradePane.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TradePane.razor
@@ -108,8 +108,9 @@
                     var abilityName = selected.Ability >= 0 && selected.Ability < strings.Ability.Count
                         ? strings.Ability[selected.Ability]
                         : null;
-                    var heldItemName = selected.HeldItem > 0 && selected.HeldItem < strings.Item.Count
-                        ? strings.Item[selected.HeldItem]
+                    var selectedItemNames = strings.GetItemStrings(selected.Context, saveFile.Version);
+                    var heldItemName = selected.HeldItem > 0 && selected.HeldItem < selectedItemNames.Length
+                        ? selectedItemNames[selected.HeldItem]
                         : null;
                     var hasNature = natureName is not null;
                     var hasAbility = abilityName is not null;

--- a/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor.cs
@@ -783,8 +783,11 @@ public partial class TradeTab : RefreshAwareComponent
         var speciesName = pkm.Species < strings.specieslist.Length
             ? strings.specieslist[pkm.Species]
             : $"Species #{pkm.Species}";
-        var itemName = itemId < strings.Item.Count
-            ? strings.Item[itemId]
+        // Held-item IDs are context-specific (e.g. Gen 3 ID 199 = Metal Coat,
+        // but modern ID 199 = Babiri Berry). Look up using the Pokémon's own context.
+        var items = strings.GetItemStrings(pkm.Context, save.Version);
+        var itemName = itemId < items.Length
+            ? items[itemId]
             : $"Item #{itemId}";
         var bagLabel = ReferenceEquals(save, AppState.SaveFile) ? "Slot A" : "Slot B";
         return $"{speciesName}’s {itemName} (from {bagLabel}’s bag)";


### PR DESCRIPTION
## Summary

Fixes #827 — a Gen 3 Pokémon holding Metal Coat was being displayed as "Babiri Berry".

Several display sites indexed `GameInfo.Strings.itemlist` / `strings.Item` (the modern Gen 4+ unified item table) directly with `Pokemon.HeldItem`. Gen 1/2/3/4/8b/9/9a all have their own item ID spaces, so the same numeric ID resolves to a different item in each table. The reporter's Gen 3 Scyther held Metal Coat (Gen 3 ID 199); rendered against the modern table, ID 199 is Babiri Berry — which they wrote as "Rabiri Berri".

The Pokémon editor's Main tab was already correct because it goes through `AppService.GetItemComboItem()` → `GameInfo.FilteredSources.Items` (context-aware). The bag tab and `EvolvePickerDialog.GetItemName` were also already correct.

## Fix

Each affected site now resolves item names with `GameInfo.Strings.GetItemStrings(context, version)`:

- `AdvancedSearchTab.razor` — held-item column in the results table and the held-item filter preview
- `AdvancedSearchTab.razor.cs` — `LoadResultDescriptionsAsync` (description tooltips) and `OnHeldItemFilterChanged`
- `TradePane.razor` — selected-Pokémon details panel
- `TradeTab.razor.cs` — `DescribeHeldItem` (held-item-loss confirmation dialog)
- `ShowdownImportDialog.razor.cs` — set summary line; uses the parsed `ShowdownSet.Context`

## Audit for the same bug class in other tables

- **Locations**: already routed through `GameInfo.GetLocationName(...)` — safe.
- **Wallpapers**: `BoxLayoutDialog` already gen-handles them — safe.
- **Types / abilities / moves / species / natures**: IDs are stable across modern generations, so direct indexing isn't a defect.
- **`EvolvePickerDialog.GetItemName`**: already uses `Pokemon.Context` — safe.

## Test plan

- [ ] Load a Gen 3 FRLG save with a Pokémon holding Metal Coat (item ID 199 in Gen 3)
- [ ] Open Advanced Search, run a search that includes that Pokémon — held-item column reads "Metal Coat"
- [ ] Use the held-item filter to pick "Metal Coat" — preview text and description match
- [ ] Open the Trade tab with that save selected — selected-Pokémon panel shows "Metal Coat"
- [ ] Initiate a trade where the held item would be lost — confirmation dialog shows "Metal Coat" (not "Babiri Berry")
- [ ] Paste a Gen-3 Showdown set with `@ Metal Coat` into the import dialog — set summary shows "@ Metal Coat"
- [ ] Spot-check the same flows on a Gen 9 SV save — items still render correctly there
- [ ] Spot-check a Gen 1 / Gen 2 save's held-item display in the same flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)