### PR TITLE
fix: guard Form picker against out-of-range Pokemon.Form (#829)

### DIFF
--- a/Pkmds.Rcl/Components/EditForms/Tabs/MainTab.razor
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/MainTab.razor
@@ -233,7 +233,7 @@
                                         @bind-Value="@Pokemon.Form"
                                         @bind-Value:after="@AfterFormChanged"
                                         Items="@Enumerable.Range(0, forms.Length).Select(i => (byte)i)"
-                                        ToStringFunc="@(i => forms[i])"
+                                        ToStringFunc="@(i => i < forms.Length ? forms[i] : string.Empty)"
                                         For="@(() => Pokemon.Form)"/>
                 </MudStack>
                 <MudImage Src="@GetFormPreviewSprite()"
@@ -261,7 +261,7 @@
                                                 RefreshService.Refresh();
                                             })"
                                     Items="@Enumerable.Range(0, formArgs.Length).Select(i => (uint?)i)"
-                                    ToStringFunc="@(i => i.HasValue ? formArgs[i.Value] : string.Empty)"/>
+                                    ToStringFunc="@(i => i is { } v && v < formArgs.Length ? formArgs[v] : string.Empty)"/>
             }
 
             @if (IsAlcremie)

--- a/Pkmds.Rcl/Components/EditForms/Tabs/MainTab.razor.cs
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/MainTab.razor.cs
@@ -702,6 +702,15 @@ public partial class MainTab : IDisposable
 
         Pokemon.Species = species;
 
+        // Reset Form when it is no longer valid for the new species' form list.
+        // Without this, switching from a many-form species (e.g. Vivillon Form 19)
+        // to one with fewer forms leaves Form pointing past the new form list,
+        // producing a blank Form picker and an invalid PKM state.
+        if (Pokemon.Form >= Pokemon.PersonalInfo.FormCount)
+        {
+            Pokemon.Form = 0;
+        }
+
         // AbilityNumber 0 is invalid for every encounter. SetAbilityIndex sets
         // both the Ability ID and AbilityNumber together, which is required —
         // setting AbilityNumber alone leaves Ability at 0 (AbilityUnexpected).


### PR DESCRIPTION
## Summary

Fixes #829 — `IndexOutOfRangeException` thrown by `MudAutocomplete<…>.ConvertSet` while editing a Pokémon, originating in `MainTab.razor`'s Form picker `ToStringFunc`.

**Root cause:** `ToStringFunc="@(i => forms[i])"` indexed `forms` unconditionally with `Pokemon.Form`. When `Pokemon.Form` exceeds `forms.Length - 1` — e.g. a Pokémon transferred into a generation that filters out its form, or a stale form left over after switching to a species with fewer forms — `MudAutocomplete.UpdateTextPropertyAsync` invokes the lambda to render the current value's display text and throws.

**Fix (two layers):**

- **`MainTab.razor`** — defensive `ToStringFunc` on the Form and Form Arg pickers, mirroring the existing `forms.ElementAtOrDefault(...)` pattern used a few lines below for the form-preview tooltip.
- **`MainTab.razor.cs` `SetSpecies`** — clamp `Pokemon.Form` to 0 when it exceeds the new species' `PersonalInfo.FormCount`, matching PKHeX WinForms' `SetForms` behavior. This keeps the underlying PKM state valid on species change so the picker shows a real form rather than a blank entry.

## Test plan

- [ ] Open a save and edit a Pokémon whose Form > new species' FormCount (e.g. a Vivillon at Form 19, then change Species to Pikachu) — Form picker no longer crashes and resets to 0.
- [ ] Open the reporter's Ultra Sun save (issue #829 attachment) and edit Pokémon — no `IndexOutOfRangeException`.
- [ ] Sanity check: editing species/forms on a normal Pokémon still works, including form-arg widgets (Vivillon, Furfrou, Alcremie).

🤖 Generated with [Claude Code](https://claude.com/claude-code)