### PR TITLE
feat: report what was changed when legalizing a Pokémon (#833)

### DIFF
--- a/Pkmds.Rcl/Components/Dialogs/LegalizationChangesDialog.razor
+++ b/Pkmds.Rcl/Components/Dialogs/LegalizationChangesDialog.razor
@@ -1,0 +1,72 @@
+<MudDialog>
+    <TitleContent>
+        <MudText Typo="@Typo.h6">
+            <MudIcon Icon="@Icons.Material.Filled.AutoFixHigh"
+                     Class="mr-2"
+                     Style="vertical-align: middle;"/>
+            Legalization Changes
+        </MudText>
+        @if (!string.IsNullOrEmpty(PokemonLabel))
+        {
+            <MudText Typo="@Typo.caption"
+                     Color="@Color.Secondary">
+                @PokemonLabel
+            </MudText>
+        }
+    </TitleContent>
+    <DialogContent>
+        @if (Changes.IsEmpty)
+        {
+            <MudText Color="@Color.Secondary">
+                No changes were made — the Pokémon was already legal in every checked field.
+            </MudText>
+        }
+        else
+        {
+            <MudStack Spacing="2"
+                      Style="min-width: 480px;">
+                <MudText Typo="@Typo.body2"
+                         Color="@Color.Secondary">
+                    @Changes.Count change@(Changes.Count == 1 ? string.Empty : "s") across @CategoryCount categor@(CategoryCount == 1 ? "y" : "ies").
+                </MudText>
+
+                <MudExpansionPanels MultiExpansion>
+                    @foreach (var group in Changes.ByCategory())
+                    {
+                        <MudExpansionPanel Text="@($"{GetCategoryLabel(group.Key)} ({group.Count()})")">
+                            <MudSimpleTable Dense
+                                            Hover
+                                            Striped
+                                            Bordered>
+                                <thead>
+                                <tr>
+                                    <th>Field</th>
+                                    <th>Before</th>
+                                    <th>After</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                @foreach (var change in group)
+                                {
+                                    <tr>
+                                        <td>@change.FieldLabel</td>
+                                        <td>@(change.OldValue ?? "—")</td>
+                                        <td>@(change.NewValue ?? "—")</td>
+                                    </tr>
+                                }
+                                </tbody>
+                            </MudSimpleTable>
+                        </MudExpansionPanel>
+                    }
+                </MudExpansionPanels>
+            </MudStack>
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@Close"
+                   Variant="@Variant.Filled"
+                   Color="@Color.Default">
+            Close
+        </MudButton>
+    </DialogActions>
+</MudDialog>

--- a/Pkmds.Rcl/Components/Dialogs/LegalizationChangesDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/LegalizationChangesDialog.razor.cs
@@ -1,0 +1,33 @@
+namespace Pkmds.Rcl.Components.Dialogs;
+
+public partial class LegalizationChangesDialog
+{
+    [CascadingParameter]
+    private IMudDialogInstance? MudDialog { get; set; }
+
+    [Parameter]
+    [EditorRequired]
+    public LegalizationChanges Changes { get; set; } = LegalizationChanges.Empty;
+
+    /// <summary>
+    /// Optional human-readable label identifying the Pokémon (e.g. "Pikachu (Box 3, Slot 7)").
+    /// Shown as a subtitle in the dialog header.
+    /// </summary>
+    [Parameter]
+    public string? PokemonLabel { get; set; }
+
+    private int CategoryCount => Changes.ByCategory().Count();
+
+    private static string GetCategoryLabel(LegalizationChangeCategory category) => category switch
+    {
+        LegalizationChangeCategory.Identity => "Identity",
+        LegalizationChangeCategory.Origin => "Origin",
+        LegalizationChangeCategory.Battle => "Battle",
+        LegalizationChangeCategory.Stats => "Stats",
+        LegalizationChangeCategory.Cosmetic => "Cosmetic",
+        LegalizationChangeCategory.Internal => "Internal",
+        _ => category.ToString()
+    };
+
+    private void Close() => MudDialog?.Close(DialogResult.Cancel());
+}

--- a/Pkmds.Rcl/Components/EditForms/Tabs/LegalityTab.razor.cs
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/LegalityTab.razor.cs
@@ -82,6 +82,38 @@ public partial class LegalityTab : IDisposable
     public void Dispose() =>
         RefreshService.OnAppStateChanged -= StateHasChanged;
 
+    private void ShowSuccessSnackbar(PKM legalizedPokemon, LegalizationChanges changes)
+    {
+        if (changes.IsEmpty)
+        {
+            Snackbar.Add("Legalized successfully. Click Save to apply changes.", Severity.Success);
+            return;
+        }
+
+        var plural = changes.Count == 1 ? string.Empty : "s";
+        var message = $"Legalized successfully — {changes.Count} change{plural}. Click Save to apply.";
+        Snackbar.Add(message, Severity.Success, config =>
+        {
+            config.Action = "View changes";
+            config.ActionColor = Color.Inherit;
+            config.OnClick = _ => ShowChangesDialog(legalizedPokemon, changes);
+        });
+    }
+
+    private async Task ShowChangesDialog(PKM pokemon, LegalizationChanges changes)
+    {
+        var label = AppService.GetPokemonSpeciesName(pokemon.Species) ?? string.Empty;
+        var parameters = new DialogParameters<LegalizationChangesDialog>
+        {
+            { x => x.Changes, changes },
+            { x => x.PokemonLabel, label }
+        };
+
+        var options = await DialogOptionsHelper.BuildAsync(MaxWidth.Medium);
+        await DialogService.ShowAsync<LegalizationChangesDialog>(
+            "Legalization Changes", parameters, options);
+    }
+
     private async Task LegalizeAsync()
     {
         if (Pokemon is null || AppState.SaveFile is not { } sav)
@@ -107,7 +139,7 @@ public partial class LegalityTab : IDisposable
             {
                 case LegalizationStatus.Success:
                     await OnPokemonLegalized.InvokeAsync(result.Pokemon);
-                    Snackbar.Add("Legalized successfully. Click Save to apply changes.", Severity.Success);
+                    ShowSuccessSnackbar(result.Pokemon, result.Changes);
                     break;
 
                 case LegalizationStatus.Timeout:

--- a/Pkmds.Rcl/Components/MainTabPages/LegalityReportTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/LegalityReportTab.razor
@@ -163,6 +163,8 @@
 
                     <MudTh>First Issue</MudTh>
 
+                    <MudTh Style="width: 1%;">Changes</MudTh>
+
                 </HeaderContent>
 
                 <RowTemplate>
@@ -182,6 +184,19 @@
                     </MudTd>
 
                     <MudTd DataLabel="First Issue">@context.FirstIssue</MudTd>
+
+                    <MudTd DataLabel="Changes">
+                        @if (HasChangesFor(context))
+                        {
+                            <MudTooltip Text="View what was changed during legalization">
+                                <MudIconButton Icon="@Icons.Material.Filled.ListAlt"
+                                               Size="@Size.Small"
+                                               Color="@Color.Primary"
+                                               OnClick="@(() => ShowChangesDialogAsync(context))"
+                                               aria-label="View legalization changes"/>
+                            </MudTooltip>
+                        }
+                    </MudTd>
 
                 </RowTemplate>
 

--- a/Pkmds.Rcl/Components/MainTabPages/LegalityReportTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/LegalityReportTab.razor.cs
@@ -170,7 +170,14 @@ public partial class LegalityReportTab : RefreshAwareComponent
             {
                 case LegalityStatus.Legal:
                     successCount++;
-                    if (!result.Changes.IsEmpty)
+                    // Recompute the diff against the bytes actually stored in the save
+                    // rather than reusing result.Changes (which was diffed against the
+                    // in-memory result.Pokemon before SetBoxSlot/SetPartySlot ran). The
+                    // EntityImportSettings.None write path can still serialize/deserialize
+                    // and trim trailing fields, so the row's "View changes" must reflect
+                    // what the user will see if they re-scan.
+                    var storedChanges = PkmDiffer.Diff(entry.Pokemon, storedPk);
+                    if (!storedChanges.IsEmpty)
                     {
                         // Index by the row's location, not the entry instance, because the
                         // entry was replaced above with a new record and any future re-scan
@@ -178,7 +185,7 @@ public partial class LegalityReportTab : RefreshAwareComponent
                         var key = entry.IsParty
                             ? (-1, entry.SlotNumber)
                             : (entry.BoxNumber, entry.SlotNumber);
-                        changesByLocation[key] = result.Changes;
+                        changesByLocation[key] = storedChanges;
                     }
 
                     break;

--- a/Pkmds.Rcl/Components/MainTabPages/LegalityReportTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/LegalityReportTab.razor.cs
@@ -11,6 +11,12 @@ public partial class LegalityReportTab : RefreshAwareComponent
     private CancellationTokenSource? legalizeCts;
     private LegalityStatus? statusFilter;
 
+    // Field-level diffs collected during the most recent batch legalize, keyed by
+    // (Box, Slot) for box entries and (-1, partySlot) for party entries. Only the
+    // rows that flipped to Legal get an entry — everything else stays absent so
+    // the row's "View changes" affordance can hide cleanly.
+    private readonly Dictionary<(int Box, int Slot), LegalizationChanges> changesByLocation = [];
+
     /// <summary>
     /// Callback invoked after a row is clicked to jump to the Party / Box tab.
     /// </summary>
@@ -48,6 +54,9 @@ public partial class LegalityReportTab : RefreshAwareComponent
         legalizeCts?.Dispose();
         legalizeCts = new CancellationTokenSource();
         var ct = legalizeCts.Token;
+
+        // Drop any diffs from a prior run — they don't apply once we re-legalize.
+        changesByLocation.Clear();
 
         isLegalizing = true;
         legalizationPercent = 0;
@@ -161,6 +170,17 @@ public partial class LegalityReportTab : RefreshAwareComponent
             {
                 case LegalityStatus.Legal:
                     successCount++;
+                    if (!result.Changes.IsEmpty)
+                    {
+                        // Index by the row's location, not the entry instance, because the
+                        // entry was replaced above with a new record and any future re-scan
+                        // will rebuild new instances entirely.
+                        var key = entry.IsParty
+                            ? (-1, entry.SlotNumber)
+                            : (entry.BoxNumber, entry.SlotNumber);
+                        changesByLocation[key] = result.Changes;
+                    }
+
                     break;
                 case LegalityStatus.Fishy:
                     // Valid PKHeX-wise but still flagged Fishy — count separately so the
@@ -270,6 +290,9 @@ public partial class LegalityReportTab : RefreshAwareComponent
         isScanning = true;
         hasRun = false;
         legalityReportEntries = [];
+        // A re-scan invalidates whatever the old diffs claimed; the entries they keyed
+        // were re-fetched from the save and may not match anymore.
+        changesByLocation.Clear();
         statusFilter = null;
         StateHasChanged();
 
@@ -367,4 +390,29 @@ public partial class LegalityReportTab : RefreshAwareComponent
 
     private bool TableFilterFunction(LegalityReportEntry legalityReportEntry) =>
         statusFilter is null || legalityReportEntry.Status == statusFilter;
+
+    private bool HasChangesFor(LegalityReportEntry entry) =>
+        changesByLocation.ContainsKey(GetLocationKey(entry));
+
+    private async Task ShowChangesDialogAsync(LegalityReportEntry entry)
+    {
+        if (!changesByLocation.TryGetValue(GetLocationKey(entry), out var changes) || changes.IsEmpty)
+        {
+            return;
+        }
+
+        var label = $"{entry.SpeciesName} ({entry.Location})";
+        var parameters = new DialogParameters<LegalizationChangesDialog>
+        {
+            { x => x.Changes, changes },
+            { x => x.PokemonLabel, label }
+        };
+
+        var options = await DialogOptionsHelper.BuildAsync(MaxWidth.Medium);
+        await DialogService.ShowAsync<LegalizationChangesDialog>(
+            "Legalization Changes", parameters, options);
+    }
+
+    private static (int Box, int Slot) GetLocationKey(LegalityReportEntry entry) =>
+        entry.IsParty ? (-1, entry.SlotNumber) : (entry.BoxNumber, entry.SlotNumber);
 }

--- a/Pkmds.Rcl/Models/LegalizationChanges.cs
+++ b/Pkmds.Rcl/Models/LegalizationChanges.cs
@@ -1,0 +1,61 @@
+namespace Pkmds.Rcl.Models;
+
+/// <summary>
+/// Buckets a single field-level change reported by <see cref="LegalizationOutcome.Changes" />.
+/// Used to group rows in the change-summary dialog.
+/// </summary>
+public enum LegalizationChangeCategory
+{
+    /// <summary>Species, Form, Nickname, Gender, Language.</summary>
+    Identity,
+
+    /// <summary>Ball, met / egg location, met level / date, OT, TID/SID, version.</summary>
+    Origin,
+
+    /// <summary>Moves, relearn moves, held item, ability, Tera type.</summary>
+    Battle,
+
+    /// <summary>IVs, EVs, AVs/GVs, nature, stat nature, Hyper Training flags.</summary>
+    Stats,
+
+    /// <summary>Shininess, friendship, markings, ribbon delta.</summary>
+    Cosmetic,
+
+    /// <summary>PID, encryption constant.</summary>
+    Internal
+}
+
+/// <summary>
+/// A single field-level diff between the original Pokémon and its legalized
+/// counterpart.
+/// </summary>
+/// <param name="Category">Which group this change belongs to in the UI.</param>
+/// <param name="FieldLabel">Human-readable field name (e.g. "Move 1", "HP IV").</param>
+/// <param name="OldValue">Pre-legalization value, formatted for display.</param>
+/// <param name="NewValue">Post-legalization value, formatted for display.</param>
+public readonly record struct LegalizationChange(
+    LegalizationChangeCategory Category,
+    string FieldLabel,
+    string? OldValue,
+    string? NewValue);
+
+/// <summary>
+/// The set of field-level differences between the input and output of a successful
+/// legalization. Empty for failures, timeouts, and Showdown-set generation (no
+/// "before" exists).
+/// </summary>
+public sealed record LegalizationChanges(IReadOnlyList<LegalizationChange> Changes)
+{
+    /// <summary>Convenience instance returned when nothing changed.</summary>
+    public static LegalizationChanges Empty { get; } = new([]);
+
+    /// <summary>Total number of field changes across all categories.</summary>
+    public int Count => Changes.Count;
+
+    /// <summary>Whether there are any changes to report.</summary>
+    public bool IsEmpty => Changes.Count == 0;
+
+    /// <summary>Groups the changes by category, preserving insertion order within each group.</summary>
+    public IEnumerable<IGrouping<LegalizationChangeCategory, LegalizationChange>> ByCategory() =>
+        Changes.GroupBy(c => c.Category);
+}

--- a/Pkmds.Rcl/Models/LegalizationResult.cs
+++ b/Pkmds.Rcl/Models/LegalizationResult.cs
@@ -27,4 +27,14 @@ public enum LegalizationStatus
 public record LegalizationOutcome(
     PKM Pokemon,
     LegalizationStatus Status,
-    string? FailureReason = null);
+    string? FailureReason = null)
+{
+    /// <summary>
+    /// Field-level differences between the input PKM and <see cref="Pokemon" />. Populated
+    /// only when <see cref="Status" /> is <see cref="LegalizationStatus.Success" /> and the
+    /// caller supplied a starting PKM (i.e. legalize-existing, not generate-from-set).
+    /// Defaults to <see cref="LegalizationChanges.Empty" /> so non-diffing call sites
+    /// stay source-compatible.
+    /// </summary>
+    public LegalizationChanges Changes { get; init; } = LegalizationChanges.Empty;
+}

--- a/Pkmds.Rcl/Services/LegalizationService.cs
+++ b/Pkmds.Rcl/Services/LegalizationService.cs
@@ -19,6 +19,12 @@ public sealed class LegalizationService : ILegalizationService
         CancellationToken ct = default,
         int? timeoutSeconds = null)
     {
+        // Snapshot the original now so the success diff sees pre-mutation state.
+        // Both passes mutate clones of pk internally, but pinning a clone here keeps
+        // the differ insulated from any future caller that hands us a pk reference
+        // they continue to mutate.
+        var original = pk.Clone();
+
         // Build a ShowdownSet from the existing PKM so the core loop can treat both
         // "legalize existing" and "generate from set" uniformly.
         var set = new ShowdownSet(ShowdownParsing.GetShowdownText(pk));
@@ -33,7 +39,7 @@ public sealed class LegalizationService : ILegalizationService
 
         if (preserveOutcome.Status == LegalizationStatus.Success)
         {
-            return preserveOutcome;
+            return preserveOutcome with { Changes = PkmDiffer.Diff(original, preserveOutcome.Pokemon) };
         }
 
         if (ct.IsCancellationRequested)
@@ -44,8 +50,12 @@ public sealed class LegalizationService : ILegalizationService
         // Fallback: rebuild via enc.ConvertToPKM + ApplySetDetails. Lossy, but gets
         // the user a legal result when preserve-mode cannot.
         var rebuildBudget = Math.Max(1, budget - preserveBudget);
-        return await CoreLegalizeAsync(
+        var rebuildOutcome = await CoreLegalizeAsync(
             set, pk, sav, progress, ct, rebuildBudget, preserveDetails: false);
+
+        return rebuildOutcome.Status == LegalizationStatus.Success
+            ? rebuildOutcome with { Changes = PkmDiffer.Diff(original, rebuildOutcome.Pokemon) }
+            : rebuildOutcome;
     }
 
     public async Task<LegalizationOutcome> GenerateFromSetAsync(

--- a/Pkmds.Rcl/Services/PkmDiffer.cs
+++ b/Pkmds.Rcl/Services/PkmDiffer.cs
@@ -355,17 +355,59 @@ public static class PkmDiffer
                 a.OriginalTrainerFriendship.ToString(CultureInfo.InvariantCulture)));
         }
 
-        var beforeMarkings = GetPackedMarkings(b);
-        var afterMarkings = GetPackedMarkings(a);
-        if (beforeMarkings != afterMarkings)
-        {
-            changes.Add(new LegalizationChange(
-                LegalizationChangeCategory.Cosmetic, "Markings",
-                beforeMarkings.ToString("X", CultureInfo.InvariantCulture),
-                afterMarkings.ToString("X", CultureInfo.InvariantCulture)));
-        }
-
+        AddMarkingDiff(b, a, changes);
         AddRibbonDelta(b, a, changes);
+    }
+
+    /// <summary>
+    /// Names for marking slots 0–5 (Circle, Triangle, Square, Heart, Star, Diamond).
+    /// Slot order is the same in every generation that uses <see cref="IAppliedMarkings3" />,
+    /// <see cref="IAppliedMarkings4" />, or <see cref="IAppliedMarkings7" />.
+    /// </summary>
+    private static readonly string[] MarkingSlotNames =
+        ["Circle", "Triangle", "Square", "Heart", "Star", "Diamond"];
+
+    private static void AddMarkingDiff(PKM b, PKM a, List<LegalizationChange> changes)
+    {
+        // Two flavours: Gen 7+ uses MarkingColor (None/Blue/Pink) per slot via
+        // IAppliedMarkings<MarkingColor>; Gen 3-6 uses bool per slot via
+        // IAppliedMarkings<bool>. Diff each slot individually so the dialog reads
+        // "Marking (Triangle): None → Blue" instead of opaque packed-byte hex.
+        if (b is IAppliedMarkings<MarkingColor> bColors && a is IAppliedMarkings<MarkingColor> aColors)
+        {
+            DiffMarkingSlots(bColors, aColors, changes,
+                v => v == MarkingColor.None ? "None" : v.ToString());
+        }
+        else if (b is IAppliedMarkings<bool> bBools && a is IAppliedMarkings<bool> aBools)
+        {
+            DiffMarkingSlots(bBools, aBools, changes,
+                v => v ? "Set" : "Unset");
+        }
+    }
+
+    private static void DiffMarkingSlots<T>(
+        IAppliedMarkings<T> before,
+        IAppliedMarkings<T> after,
+        List<LegalizationChange> changes,
+        Func<T, string> format)
+        where T : unmanaged
+    {
+        var slots = Math.Min(before.MarkingCount, MarkingSlotNames.Length);
+        for (var i = 0; i < slots; i++)
+        {
+            var bv = before.GetMarking(i);
+            var av = after.GetMarking(i);
+            if (EqualityComparer<T>.Default.Equals(bv, av))
+            {
+                continue;
+            }
+
+            changes.Add(new LegalizationChange(
+                LegalizationChangeCategory.Cosmetic,
+                $"Marking ({MarkingSlotNames[i]})",
+                format(bv),
+                format(av)));
+        }
     }
 
     private static void AddRibbonDelta(PKM b, PKM a, List<LegalizationChange> changes)
@@ -526,12 +568,5 @@ public static class PkmDiffer
         2 => "2 (secondary)",
         4 => "Hidden",
         _ => abilityNumber.ToString(CultureInfo.InvariantCulture)
-    };
-
-    private static int GetPackedMarkings(PKM pk) => pk switch
-    {
-        IAppliedMarkings7 m7 => m7.MarkingValue,
-        IAppliedMarkings3 m3 => m3.MarkingValue,
-        _ => 0
     };
 }

--- a/Pkmds.Rcl/Services/PkmDiffer.cs
+++ b/Pkmds.Rcl/Services/PkmDiffer.cs
@@ -1,0 +1,537 @@
+namespace Pkmds.Rcl.Services;
+
+/// <summary>
+/// Computes the field-level differences between two <see cref="PKM" /> instances. Used
+/// after a successful legalization to surface "what was changed" to the user.
+/// </summary>
+/// <remarks>
+/// PKHeX.Core does not expose a diff/changelog from <see cref="LegalityAnalysis" /> or
+/// any of the legalize entry points — the only product is the final PKM. This service
+/// reconstructs the diff by inspecting matching properties on the before/after PKMs.
+/// Format-gated fields (Hyper Training, AVs, GVs, Tera type, etc.) are checked via
+/// interface tests so the differ doesn't blow up on cross-format comparisons.
+/// </remarks>
+public static class PkmDiffer
+{
+    /// <summary>
+    /// Returns the set of human-meaningful differences between <paramref name="before" />
+    /// and <paramref name="after" />. Returns <see cref="LegalizationChanges.Empty" /> if
+    /// either argument is null or no fields differ.
+    /// </summary>
+    public static LegalizationChanges Diff(PKM? before, PKM? after)
+    {
+        if (before is null || after is null)
+        {
+            return LegalizationChanges.Empty;
+        }
+
+        var changes = new List<LegalizationChange>();
+
+        AddIdentity(before, after, changes);
+        AddOrigin(before, after, changes);
+        AddBattle(before, after, changes);
+        AddStats(before, after, changes);
+        AddCosmetic(before, after, changes);
+        AddInternal(before, after, changes);
+
+        return changes.Count == 0
+            ? LegalizationChanges.Empty
+            : new LegalizationChanges(changes);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  Identity
+    // ──────────────────────────────────────────────────────────────────────
+
+    private static void AddIdentity(PKM b, PKM a, List<LegalizationChange> changes)
+    {
+        if (b.Species != a.Species)
+        {
+            changes.Add(new LegalizationChange(
+                LegalizationChangeCategory.Identity, "Species",
+                SafeNameLookup.Species(b.Species), SafeNameLookup.Species(a.Species)));
+        }
+
+        if (b.Form != a.Form)
+        {
+            changes.Add(new LegalizationChange(
+                LegalizationChangeCategory.Identity, "Form",
+                b.Form.ToString(CultureInfo.InvariantCulture),
+                a.Form.ToString(CultureInfo.InvariantCulture)));
+        }
+
+        if (!string.Equals(b.Nickname, a.Nickname, StringComparison.Ordinal))
+        {
+            changes.Add(new LegalizationChange(
+                LegalizationChangeCategory.Identity, "Nickname", b.Nickname, a.Nickname));
+        }
+
+        if (b.IsNicknamed != a.IsNicknamed)
+        {
+            changes.Add(new LegalizationChange(
+                LegalizationChangeCategory.Identity, "Is Nicknamed",
+                b.IsNicknamed.ToString(), a.IsNicknamed.ToString()));
+        }
+
+        if (b.Gender != a.Gender)
+        {
+            changes.Add(new LegalizationChange(
+                LegalizationChangeCategory.Identity, "Gender",
+                FormatGender(b.Gender), FormatGender(a.Gender)));
+        }
+
+        if (b.Language != a.Language)
+        {
+            changes.Add(new LegalizationChange(
+                LegalizationChangeCategory.Identity, "Language",
+                FormatLanguage(b.Language), FormatLanguage(a.Language)));
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  Origin
+    // ──────────────────────────────────────────────────────────────────────
+
+    private static void AddOrigin(PKM b, PKM a, List<LegalizationChange> changes)
+    {
+        if (b.Ball != a.Ball)
+        {
+            changes.Add(new LegalizationChange(
+                LegalizationChangeCategory.Origin, "Ball",
+                FormatBall(b.Ball), FormatBall(a.Ball)));
+        }
+
+        if (b.MetLocation != a.MetLocation)
+        {
+            changes.Add(new LegalizationChange(
+                LegalizationChangeCategory.Origin, "Met Location",
+                FormatLocation(b, isEgg: false), FormatLocation(a, isEgg: false)));
+        }
+
+        if (b.MetLevel != a.MetLevel)
+        {
+            changes.Add(new LegalizationChange(
+                LegalizationChangeCategory.Origin, "Met Level",
+                b.MetLevel.ToString(CultureInfo.InvariantCulture),
+                a.MetLevel.ToString(CultureInfo.InvariantCulture)));
+        }
+
+        if (b.MetDate != a.MetDate)
+        {
+            changes.Add(new LegalizationChange(
+                LegalizationChangeCategory.Origin, "Met Date",
+                FormatDate(b.MetDate), FormatDate(a.MetDate)));
+        }
+
+        if (b.EggLocation != a.EggLocation)
+        {
+            changes.Add(new LegalizationChange(
+                LegalizationChangeCategory.Origin, "Egg Location",
+                FormatLocation(b, isEgg: true), FormatLocation(a, isEgg: true)));
+        }
+
+        if (b.EggMetDate != a.EggMetDate)
+        {
+            changes.Add(new LegalizationChange(
+                LegalizationChangeCategory.Origin, "Egg Date",
+                FormatDate(b.EggMetDate), FormatDate(a.EggMetDate)));
+        }
+
+        if (!string.Equals(b.OriginalTrainerName, a.OriginalTrainerName, StringComparison.Ordinal))
+        {
+            changes.Add(new LegalizationChange(
+                LegalizationChangeCategory.Origin, "OT Name",
+                b.OriginalTrainerName, a.OriginalTrainerName));
+        }
+
+        if (b.OriginalTrainerGender != a.OriginalTrainerGender)
+        {
+            changes.Add(new LegalizationChange(
+                LegalizationChangeCategory.Origin, "OT Gender",
+                FormatGender(b.OriginalTrainerGender), FormatGender(a.OriginalTrainerGender)));
+        }
+
+        if (b.TID16 != a.TID16)
+        {
+            changes.Add(new LegalizationChange(
+                LegalizationChangeCategory.Origin, "TID",
+                b.TID16.ToString(CultureInfo.InvariantCulture),
+                a.TID16.ToString(CultureInfo.InvariantCulture)));
+        }
+
+        if (b.SID16 != a.SID16)
+        {
+            changes.Add(new LegalizationChange(
+                LegalizationChangeCategory.Origin, "SID",
+                b.SID16.ToString(CultureInfo.InvariantCulture),
+                a.SID16.ToString(CultureInfo.InvariantCulture)));
+        }
+
+        if (b.Version != a.Version)
+        {
+            changes.Add(new LegalizationChange(
+                LegalizationChangeCategory.Origin, "Origin Game",
+                b.Version.ToString(), a.Version.ToString()));
+        }
+
+        if (b.FatefulEncounter != a.FatefulEncounter)
+        {
+            changes.Add(new LegalizationChange(
+                LegalizationChangeCategory.Origin, "Fateful Encounter",
+                b.FatefulEncounter.ToString(), a.FatefulEncounter.ToString()));
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  Battle
+    // ──────────────────────────────────────────────────────────────────────
+
+    private static void AddBattle(PKM b, PKM a, List<LegalizationChange> changes)
+    {
+        AddMoveDiff(changes, "Move 1", b.Move1, a.Move1, b.Move1_PPUps, a.Move1_PPUps);
+        AddMoveDiff(changes, "Move 2", b.Move2, a.Move2, b.Move2_PPUps, a.Move2_PPUps);
+        AddMoveDiff(changes, "Move 3", b.Move3, a.Move3, b.Move3_PPUps, a.Move3_PPUps);
+        AddMoveDiff(changes, "Move 4", b.Move4, a.Move4, b.Move4_PPUps, a.Move4_PPUps);
+
+        AddRelearnDiff(changes, "Relearn 1", b.RelearnMove1, a.RelearnMove1);
+        AddRelearnDiff(changes, "Relearn 2", b.RelearnMove2, a.RelearnMove2);
+        AddRelearnDiff(changes, "Relearn 3", b.RelearnMove3, a.RelearnMove3);
+        AddRelearnDiff(changes, "Relearn 4", b.RelearnMove4, a.RelearnMove4);
+
+        if (b.HeldItem != a.HeldItem)
+        {
+            changes.Add(new LegalizationChange(
+                LegalizationChangeCategory.Battle, "Held Item",
+                SafeNameLookup.Item(b.HeldItem), SafeNameLookup.Item(a.HeldItem)));
+        }
+
+        if (b.Ability != a.Ability)
+        {
+            changes.Add(new LegalizationChange(
+                LegalizationChangeCategory.Battle, "Ability",
+                SafeNameLookup.Ability(b.Ability), SafeNameLookup.Ability(a.Ability)));
+        }
+
+        if (b.AbilityNumber != a.AbilityNumber)
+        {
+            changes.Add(new LegalizationChange(
+                LegalizationChangeCategory.Battle, "Ability Slot",
+                FormatAbilitySlot(b.AbilityNumber), FormatAbilitySlot(a.AbilityNumber)));
+        }
+
+        if (b is ITeraType bt && a is ITeraType at)
+        {
+            if (bt.TeraTypeOriginal != at.TeraTypeOriginal)
+            {
+                changes.Add(new LegalizationChange(
+                    LegalizationChangeCategory.Battle, "Tera Type (Original)",
+                    bt.TeraTypeOriginal.ToString(), at.TeraTypeOriginal.ToString()));
+            }
+
+            if (bt.TeraTypeOverride != at.TeraTypeOverride)
+            {
+                changes.Add(new LegalizationChange(
+                    LegalizationChangeCategory.Battle, "Tera Type (Override)",
+                    bt.TeraTypeOverride.ToString(), at.TeraTypeOverride.ToString()));
+            }
+        }
+    }
+
+    private static void AddMoveDiff(
+        List<LegalizationChange> changes, string label,
+        ushort beforeMove, ushort afterMove, int beforePpUps, int afterPpUps)
+    {
+        if (beforeMove != afterMove)
+        {
+            changes.Add(new LegalizationChange(
+                LegalizationChangeCategory.Battle, label,
+                SafeNameLookup.Move(beforeMove), SafeNameLookup.Move(afterMove)));
+        }
+        else if (beforePpUps != afterPpUps)
+        {
+            changes.Add(new LegalizationChange(
+                LegalizationChangeCategory.Battle, $"{label} PP Ups",
+                beforePpUps.ToString(CultureInfo.InvariantCulture),
+                afterPpUps.ToString(CultureInfo.InvariantCulture)));
+        }
+    }
+
+    private static void AddRelearnDiff(
+        List<LegalizationChange> changes, string label, ushort beforeMove, ushort afterMove)
+    {
+        if (beforeMove == afterMove)
+        {
+            return;
+        }
+
+        changes.Add(new LegalizationChange(
+            LegalizationChangeCategory.Battle, label,
+            SafeNameLookup.Move(beforeMove), SafeNameLookup.Move(afterMove)));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  Stats
+    // ──────────────────────────────────────────────────────────────────────
+
+    private static void AddStats(PKM b, PKM a, List<LegalizationChange> changes)
+    {
+        AddIntDiff(changes, LegalizationChangeCategory.Stats, "HP IV", b.IV_HP, a.IV_HP);
+        AddIntDiff(changes, LegalizationChangeCategory.Stats, "Atk IV", b.IV_ATK, a.IV_ATK);
+        AddIntDiff(changes, LegalizationChangeCategory.Stats, "Def IV", b.IV_DEF, a.IV_DEF);
+        AddIntDiff(changes, LegalizationChangeCategory.Stats, "SpA IV", b.IV_SPA, a.IV_SPA);
+        AddIntDiff(changes, LegalizationChangeCategory.Stats, "SpD IV", b.IV_SPD, a.IV_SPD);
+        AddIntDiff(changes, LegalizationChangeCategory.Stats, "Spe IV", b.IV_SPE, a.IV_SPE);
+
+        AddIntDiff(changes, LegalizationChangeCategory.Stats, "HP EV", b.EV_HP, a.EV_HP);
+        AddIntDiff(changes, LegalizationChangeCategory.Stats, "Atk EV", b.EV_ATK, a.EV_ATK);
+        AddIntDiff(changes, LegalizationChangeCategory.Stats, "Def EV", b.EV_DEF, a.EV_DEF);
+        AddIntDiff(changes, LegalizationChangeCategory.Stats, "SpA EV", b.EV_SPA, a.EV_SPA);
+        AddIntDiff(changes, LegalizationChangeCategory.Stats, "SpD EV", b.EV_SPD, a.EV_SPD);
+        AddIntDiff(changes, LegalizationChangeCategory.Stats, "Spe EV", b.EV_SPE, a.EV_SPE);
+
+        if (b.Nature != a.Nature)
+        {
+            changes.Add(new LegalizationChange(
+                LegalizationChangeCategory.Stats, "Nature",
+                SafeNameLookup.Nature((int)b.Nature), SafeNameLookup.Nature((int)a.Nature)));
+        }
+
+        if (b.StatNature != a.StatNature)
+        {
+            changes.Add(new LegalizationChange(
+                LegalizationChangeCategory.Stats, "Stat Nature",
+                SafeNameLookup.Nature((int)b.StatNature), SafeNameLookup.Nature((int)a.StatNature)));
+        }
+
+        if (b is IHyperTrain bh && a is IHyperTrain ah)
+        {
+            AddBoolDiff(changes, LegalizationChangeCategory.Stats, "Hyper Train HP", bh.HT_HP, ah.HT_HP);
+            AddBoolDiff(changes, LegalizationChangeCategory.Stats, "Hyper Train Atk", bh.HT_ATK, ah.HT_ATK);
+            AddBoolDiff(changes, LegalizationChangeCategory.Stats, "Hyper Train Def", bh.HT_DEF, ah.HT_DEF);
+            AddBoolDiff(changes, LegalizationChangeCategory.Stats, "Hyper Train SpA", bh.HT_SPA, ah.HT_SPA);
+            AddBoolDiff(changes, LegalizationChangeCategory.Stats, "Hyper Train SpD", bh.HT_SPD, ah.HT_SPD);
+            AddBoolDiff(changes, LegalizationChangeCategory.Stats, "Hyper Train Spe", bh.HT_SPE, ah.HT_SPE);
+        }
+
+        if (b is IAwakened bav && a is IAwakened aav)
+        {
+            AddIntDiff(changes, LegalizationChangeCategory.Stats, "HP AV", bav.AV_HP, aav.AV_HP);
+            AddIntDiff(changes, LegalizationChangeCategory.Stats, "Atk AV", bav.AV_ATK, aav.AV_ATK);
+            AddIntDiff(changes, LegalizationChangeCategory.Stats, "Def AV", bav.AV_DEF, aav.AV_DEF);
+            AddIntDiff(changes, LegalizationChangeCategory.Stats, "SpA AV", bav.AV_SPA, aav.AV_SPA);
+            AddIntDiff(changes, LegalizationChangeCategory.Stats, "SpD AV", bav.AV_SPD, aav.AV_SPD);
+            AddIntDiff(changes, LegalizationChangeCategory.Stats, "Spe AV", bav.AV_SPE, aav.AV_SPE);
+        }
+
+        if (b is IGanbaru bgv && a is IGanbaru agv)
+        {
+            AddIntDiff(changes, LegalizationChangeCategory.Stats, "HP GV", bgv.GV_HP, agv.GV_HP);
+            AddIntDiff(changes, LegalizationChangeCategory.Stats, "Atk GV", bgv.GV_ATK, agv.GV_ATK);
+            AddIntDiff(changes, LegalizationChangeCategory.Stats, "Def GV", bgv.GV_DEF, agv.GV_DEF);
+            AddIntDiff(changes, LegalizationChangeCategory.Stats, "SpA GV", bgv.GV_SPA, agv.GV_SPA);
+            AddIntDiff(changes, LegalizationChangeCategory.Stats, "SpD GV", bgv.GV_SPD, agv.GV_SPD);
+            AddIntDiff(changes, LegalizationChangeCategory.Stats, "Spe GV", bgv.GV_SPE, agv.GV_SPE);
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  Cosmetic
+    // ──────────────────────────────────────────────────────────────────────
+
+    private static void AddCosmetic(PKM b, PKM a, List<LegalizationChange> changes)
+    {
+        if (b.IsShiny != a.IsShiny)
+        {
+            changes.Add(new LegalizationChange(
+                LegalizationChangeCategory.Cosmetic, "Shiny",
+                b.IsShiny.ToString(), a.IsShiny.ToString()));
+        }
+
+        if (b.OriginalTrainerFriendship != a.OriginalTrainerFriendship)
+        {
+            changes.Add(new LegalizationChange(
+                LegalizationChangeCategory.Cosmetic, "OT Friendship",
+                b.OriginalTrainerFriendship.ToString(CultureInfo.InvariantCulture),
+                a.OriginalTrainerFriendship.ToString(CultureInfo.InvariantCulture)));
+        }
+
+        var beforeMarkings = GetPackedMarkings(b);
+        var afterMarkings = GetPackedMarkings(a);
+        if (beforeMarkings != afterMarkings)
+        {
+            changes.Add(new LegalizationChange(
+                LegalizationChangeCategory.Cosmetic, "Markings",
+                beforeMarkings.ToString("X", CultureInfo.InvariantCulture),
+                afterMarkings.ToString("X", CultureInfo.InvariantCulture)));
+        }
+
+        AddRibbonDelta(b, a, changes);
+    }
+
+    private static void AddRibbonDelta(PKM b, PKM a, List<LegalizationChange> changes)
+    {
+        // Collapse to a single "added / removed" entry. Listing each ribbon would
+        // dominate the dialog because legalize re-derives the full ribbon set.
+        // Use RibbonInfo.GetRibbonInfo (reflection-based) for format-aware coverage —
+        // it walks every property starting with "Ribbon" on the actual PKM subtype.
+        var beforeRibbons = RibbonInfo.GetRibbonInfo(b);
+        var afterRibbons = RibbonInfo.GetRibbonInfo(a);
+        var afterByName = new Dictionary<string, RibbonInfo>(afterRibbons.Count, StringComparer.Ordinal);
+        foreach (var ribbon in afterRibbons)
+        {
+            afterByName[ribbon.Name] = ribbon;
+        }
+
+        var added = 0;
+        var removed = 0;
+        foreach (var beforeRibbon in beforeRibbons)
+        {
+            if (!afterByName.TryGetValue(beforeRibbon.Name, out var afterRibbon))
+            {
+                continue;
+            }
+
+            switch (beforeRibbon.Type)
+            {
+                case RibbonValueType.Boolean
+                    when beforeRibbon.HasRibbon != afterRibbon.HasRibbon:
+                    if (afterRibbon.HasRibbon)
+                    {
+                        added++;
+                    }
+                    else
+                    {
+                        removed++;
+                    }
+
+                    break;
+                case RibbonValueType.Byte
+                    when beforeRibbon.RibbonCount != afterRibbon.RibbonCount:
+                    var delta = afterRibbon.RibbonCount - beforeRibbon.RibbonCount;
+                    if (delta > 0)
+                    {
+                        added += delta;
+                    }
+                    else
+                    {
+                        removed += -delta;
+                    }
+
+                    break;
+            }
+        }
+
+        if (added > 0 || removed > 0)
+        {
+            changes.Add(new LegalizationChange(
+                LegalizationChangeCategory.Cosmetic, "Ribbons",
+                null,
+                $"+{added} / -{removed}"));
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  Internal
+    // ──────────────────────────────────────────────────────────────────────
+
+    private static void AddInternal(PKM b, PKM a, List<LegalizationChange> changes)
+    {
+        if (b.PID != a.PID)
+        {
+            changes.Add(new LegalizationChange(
+                LegalizationChangeCategory.Internal, "PID",
+                b.PID.ToString("X8", CultureInfo.InvariantCulture),
+                a.PID.ToString("X8", CultureInfo.InvariantCulture)));
+        }
+
+        if (b.EncryptionConstant != a.EncryptionConstant)
+        {
+            changes.Add(new LegalizationChange(
+                LegalizationChangeCategory.Internal, "Encryption Constant",
+                b.EncryptionConstant.ToString("X8", CultureInfo.InvariantCulture),
+                a.EncryptionConstant.ToString("X8", CultureInfo.InvariantCulture)));
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  Helpers
+    // ──────────────────────────────────────────────────────────────────────
+
+    private static void AddIntDiff(
+        List<LegalizationChange> changes, LegalizationChangeCategory category,
+        string label, int before, int after)
+    {
+        if (before == after)
+        {
+            return;
+        }
+
+        changes.Add(new LegalizationChange(
+            category, label,
+            before.ToString(CultureInfo.InvariantCulture),
+            after.ToString(CultureInfo.InvariantCulture)));
+    }
+
+    private static void AddBoolDiff(
+        List<LegalizationChange> changes, LegalizationChangeCategory category,
+        string label, bool before, bool after)
+    {
+        if (before == after)
+        {
+            return;
+        }
+
+        changes.Add(new LegalizationChange(
+            category, label, before.ToString(), after.ToString()));
+    }
+
+    private static string FormatGender(byte gender) => gender switch
+    {
+        0 => "Male",
+        1 => "Female",
+        2 => "Genderless",
+        _ => gender.ToString(CultureInfo.InvariantCulture)
+    };
+
+    private static string FormatLanguage(int language)
+    {
+        if (Enum.IsDefined(typeof(LanguageID), (byte)language))
+        {
+            return ((LanguageID)language).ToString();
+        }
+
+        return language.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static string FormatBall(byte ball)
+    {
+        var balls = GameInfo.Strings.balllist;
+        return ball < balls.Length && !string.IsNullOrEmpty(balls[ball])
+            ? balls[ball]
+            : $"(Ball #{ball:000})";
+    }
+
+    private static string FormatLocation(PKM pkm, bool isEgg)
+    {
+        var locId = isEgg ? pkm.EggLocation : pkm.MetLocation;
+        return GameInfo.GetLocationName(isEgg, locId, pkm.Format, pkm.Generation, pkm.Version);
+    }
+
+    private static string FormatDate(DateOnly? date) =>
+        date?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) ?? "—";
+
+    private static string FormatAbilitySlot(int abilityNumber) => abilityNumber switch
+    {
+        1 => "1 (primary)",
+        2 => "2 (secondary)",
+        4 => "Hidden",
+        _ => abilityNumber.ToString(CultureInfo.InvariantCulture)
+    };
+
+    private static int GetPackedMarkings(PKM pk) => pk switch
+    {
+        IAppliedMarkings7 m7 => m7.MarkingValue,
+        IAppliedMarkings3 m3 => m3.MarkingValue,
+        _ => 0
+    };
+}

--- a/Pkmds.Tests/PkmDifferTests.cs
+++ b/Pkmds.Tests/PkmDifferTests.cs
@@ -2,6 +2,15 @@ namespace Pkmds.Tests;
 
 public class PkmDifferTests
 {
+    static PkmDifferTests()
+    {
+        // PkmDiffer pulls move / ball / species / nature names from GameInfo.Strings.
+        // Although these tests don't assert on language-dependent text, run the full
+        // localization init once so the suite is deterministic regardless of which
+        // other test class runs first under parallel xUnit execution.
+        LocalizeUtil.InitializeStrings(GameLanguage.DefaultLanguage);
+    }
+
     [Fact]
     public void Diff_IdenticalPkms_ReturnsEmpty()
     {

--- a/Pkmds.Tests/PkmDifferTests.cs
+++ b/Pkmds.Tests/PkmDifferTests.cs
@@ -1,0 +1,152 @@
+namespace Pkmds.Tests;
+
+public class PkmDifferTests
+{
+    [Fact]
+    public void Diff_IdenticalPkms_ReturnsEmpty()
+    {
+        var before = new PK9 { Species = (ushort)Species.Pikachu };
+        var after = before.Clone();
+
+        var result = PkmDiffer.Diff(before, after);
+
+        result.IsEmpty.Should().BeTrue();
+        result.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void Diff_NullArguments_ReturnsEmpty()
+    {
+        PkmDiffer.Diff(null, null).IsEmpty.Should().BeTrue();
+        PkmDiffer.Diff(new PK9(), null).IsEmpty.Should().BeTrue();
+        PkmDiffer.Diff(null, new PK9()).IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Diff_DifferentMoves_ReportsBattleCategory()
+    {
+        var before = new PK9 { Species = (ushort)Species.Pikachu, Move1 = (ushort)Move.Tackle };
+        var after = before.Clone();
+        after.Move1 = (ushort)Move.Thunderbolt;
+
+        var result = PkmDiffer.Diff(before, after);
+
+        result.Count.Should().Be(1);
+        var change = result.Changes[0];
+        change.Category.Should().Be(LegalizationChangeCategory.Battle);
+        change.FieldLabel.Should().Be("Move 1");
+        change.OldValue.Should().NotBeNullOrEmpty();
+        change.NewValue.Should().NotBeNullOrEmpty();
+        change.OldValue.Should().NotBe(change.NewValue);
+    }
+
+    [Fact]
+    public void Diff_DifferentIVs_ReportsStatsCategory()
+    {
+        var before = new PK9 { Species = (ushort)Species.Pikachu, IV_HP = 0, IV_ATK = 31 };
+        var after = before.Clone();
+        after.IV_HP = 31;
+
+        var result = PkmDiffer.Diff(before, after);
+
+        result.Count.Should().Be(1);
+        var change = result.Changes[0];
+        change.Category.Should().Be(LegalizationChangeCategory.Stats);
+        change.FieldLabel.Should().Be("HP IV");
+        change.OldValue.Should().Be("0");
+        change.NewValue.Should().Be("31");
+    }
+
+    [Fact]
+    public void Diff_HyperTrainingFlag_ReportedOnly_WhenInterfaceMatches()
+    {
+        // PK9 implements IHyperTrain — flag flip should surface.
+        var before = new PK9();
+        var after = before.Clone();
+        after.HT_HP = true;
+
+        var result = PkmDiffer.Diff(before, after);
+
+        result.Changes.Should().ContainSingle(c => c.FieldLabel == "Hyper Train HP");
+
+        // PK3 does not implement IHyperTrain — comparing two PK3s must not throw or
+        // attempt to read HT_* properties off a non-IHyperTrain entity.
+        var pk3Before = new PK3 { Species = (ushort)Species.Pikachu };
+        var pk3After = pk3Before.Clone();
+        var pk3Result = PkmDiffer.Diff(pk3Before, pk3After);
+        pk3Result.IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Diff_DifferentBall_ReportsOriginCategory_WithBallNames()
+    {
+        var before = new PK9 { Species = (ushort)Species.Pikachu, Ball = (byte)Ball.Poke };
+        var after = before.Clone();
+        after.Ball = (byte)Ball.Master;
+
+        var result = PkmDiffer.Diff(before, after);
+
+        var ballChange = result.Changes.Should().ContainSingle(c => c.FieldLabel == "Ball").Subject;
+        ballChange.Category.Should().Be(LegalizationChangeCategory.Origin);
+        ballChange.OldValue.Should().NotBe(ballChange.NewValue);
+    }
+
+    [Fact]
+    public void Diff_RibbonCountDelta_CollapsesToSingleEntry()
+    {
+        // Flip many ribbons in both directions — the differ should still emit just one
+        // "Ribbons" line so the dialog isn't dominated by ribbon noise.
+        var before = new PK9 { RibbonChampionKalos = true, RibbonChampionG3 = true };
+        var after = before.Clone();
+        after.RibbonChampionKalos = false; // removed
+        after.RibbonChampionG3 = false; // removed
+        after.RibbonChampionAlola = true; // added
+        after.RibbonChampionGalar = true; // added
+        after.RibbonChampionPaldea = true; // added
+
+        var result = PkmDiffer.Diff(before, after);
+
+        var ribbonRows = result.Changes.Where(c => c.FieldLabel == "Ribbons").ToList();
+        ribbonRows.Should().ContainSingle();
+        ribbonRows[0].Category.Should().Be(LegalizationChangeCategory.Cosmetic);
+        ribbonRows[0].NewValue.Should().Contain("+3");
+        ribbonRows[0].NewValue.Should().Contain("-2");
+    }
+
+    [Fact]
+    public void Diff_PidAndEncryptionConstant_ReportedAsInternal()
+    {
+        var before = new PK9 { PID = 0x11111111, EncryptionConstant = 0x22222222 };
+        var after = before.Clone();
+        after.PID = 0xAAAAAAAA;
+        after.EncryptionConstant = 0xBBBBBBBB;
+
+        var result = PkmDiffer.Diff(before, after);
+
+        result.Changes.Should().Contain(c => c.FieldLabel == "PID" && c.Category == LegalizationChangeCategory.Internal);
+        result.Changes.Should().Contain(c => c.FieldLabel == "Encryption Constant" && c.Category == LegalizationChangeCategory.Internal);
+    }
+
+    [Fact]
+    public void ByCategory_GroupsChangesAcrossMultipleCategories()
+    {
+        var before = new PK9
+        {
+            Species = (ushort)Species.Pikachu,
+            Move1 = (ushort)Move.Tackle,
+            IV_HP = 0,
+            Ball = (byte)Ball.Poke
+        };
+        var after = before.Clone();
+        after.Move1 = (ushort)Move.Thunderbolt;
+        after.IV_HP = 31;
+        after.Ball = (byte)Ball.Master;
+
+        var result = PkmDiffer.Diff(before, after);
+
+        var grouped = result.ByCategory().ToDictionary(g => g.Key, g => g.Count());
+        grouped.Should().ContainKey(LegalizationChangeCategory.Battle);
+        grouped.Should().ContainKey(LegalizationChangeCategory.Stats);
+        grouped.Should().ContainKey(LegalizationChangeCategory.Origin);
+    }
+}

--- a/Pkmds.Tests/PkmDifferTests.cs
+++ b/Pkmds.Tests/PkmDifferTests.cs
@@ -114,6 +114,40 @@ public class PkmDifferTests
     }
 
     [Fact]
+    public void Diff_Markings_DecodedPerSlot_ForGen7Plus()
+    {
+        // Gen 7+ stores 2-bit MarkingColor per slot. The diff should report each slot
+        // by name (Circle, Triangle, …) with human-readable colour, not packed hex.
+        var before = new PK9 { MarkingTriangle = MarkingColor.Blue };
+        var after = before.Clone();
+        after.MarkingCircle = MarkingColor.Pink;
+        after.MarkingDiamond = MarkingColor.Blue;
+
+        var result = PkmDiffer.Diff(before, after);
+
+        var markingChanges = result.Changes
+            .Where(c => c.FieldLabel.StartsWith("Marking ", StringComparison.Ordinal))
+            .ToList();
+        markingChanges.Should().HaveCount(2);
+        markingChanges.Should().Contain(c => c.FieldLabel == "Marking (Circle)" && c.OldValue == "None" && c.NewValue == "Pink");
+        markingChanges.Should().Contain(c => c.FieldLabel == "Marking (Diamond)" && c.OldValue == "None" && c.NewValue == "Blue");
+    }
+
+    [Fact]
+    public void Diff_Markings_DecodedPerSlot_ForGen3Through6()
+    {
+        // Gen 3-6 stores a bool per slot. Format should be Set/Unset, not raw bools.
+        var before = new PK4();
+        var after = before.Clone();
+        after.MarkingHeart = true;
+
+        var result = PkmDiffer.Diff(before, after);
+
+        result.Changes.Should().ContainSingle(c => c.FieldLabel == "Marking (Heart)")
+            .Which.Should().Match<LegalizationChange>(c => c.OldValue == "Unset" && c.NewValue == "Set");
+    }
+
+    [Fact]
     public void Diff_PidAndEncryptionConstant_ReportedAsInternal()
     {
         var before = new PK9 { PID = 0x11111111, EncryptionConstant = 0x22222222 };


### PR DESCRIPTION
Closes #833.

## Summary
- Adds a categorized diff between the original and legalized PKM. PKHeX.Core does not expose any change metadata from `LegalizationOutcome`, so the differ reconstructs the diff field-by-field, gating format-specific properties (`IHyperTrain`, `IAwakened`, `IGanbaru`, `ITeraType`, `IAppliedMarkings*`) so cross-format checks don't blow up.
- Single-edit flow: success snackbar in **Legality** tab now shows `Legalized successfully — N changes. Click Save to apply.` with a **View changes** action button that opens the new dialog.
- Batch flow: **Legality Report** tab tracks per-row changes during the sweep and adds a "Changes" column with a `MudIconButton` for rows that flipped to Legal. Aggregate count snackbar is unchanged.
- Box-level batch (`PokemonStorageComponent.LegalizeBoxAsync`) is intentionally untouched — kept aggregate-only per discussion.
- Ribbons collapse to a single `+N / -M` line so legalize re-deriving the full ribbon set doesn't dominate the dialog.

## Implementation notes
- New `LegalizationChanges` model in `Pkmds.Rcl/Models` (category enum, `LegalizationChange` record struct, `LegalizationChanges` record).
- `LegalizationOutcome.Changes` added as a non-breaking init-property defaulting to `LegalizationChanges.Empty`.
- New `PkmDiffer` static service in `Pkmds.Rcl/Services` (lives there rather than `Pkmds.Core` because it depends on the `LegalizationChanges` model).
- New `LegalizationChangesDialog` modeled on `SaveFileRepairDialog`: `MudExpansionPanels` per category, each with a `Field | Before | After` table.
- 9 unit tests in `PkmDifferTests` covering identical PKMs, null inputs, moves, IVs, format-gated fields, ball name lookup, ribbon collapse, PID/EC, multi-category grouping.

## Test plan
- [ ] CI green (build + tests)
- [ ] Manually load a save, edit a Pokémon, legalize from the **Legality** tab, click **View changes** in the snackbar — verify the dialog shows categorized field diffs
- [ ] Legalize a Pokémon that's already legal — verify snackbar falls back to the original "no changes" message and no action button appears
- [ ] Run **Legality Report** scan, click **Legalize All Illegal**, verify rows that flipped to Legal show the list-icon button; click one, confirm dialog opens with the right per-row diff
- [ ] Re-run the legality report — confirm the prior diffs are cleared (no stale icons appear)

🤖 Generated with [Claude Code](https://claude.com/claude-code)