### PR TITLE
feat: warn before discarding unsaved Pokémon edits

### DIFF
--- a/Pkmds.Rcl/Components/BoxGrid.razor.cs
+++ b/Pkmds.Rcl/Components/BoxGrid.razor.cs
@@ -11,8 +11,18 @@ public partial class BoxGrid : RefreshAwareComponent
             ? "w-80 h-[400px] grid grid-cols-4 grid-rows-5 gap-1"
             : "grid grid-cols-6 gap-1 w-full aspect-[6/5] mx-auto";
 
-    private void SetSelectedPokemon(PKM? pokemon, int boxNumber, int slotNumber) =>
+    private async Task SetSelectedPokemon(PKM? pokemon, int boxNumber, int slotNumber)
+    {
+        if (!await UnsavedChangesGuard.ConfirmAsync(
+                AppService,
+                DialogService,
+                "This Pokémon has unsaved changes. Save them to the slot before switching to another?"))
+        {
+            return;
+        }
+
         AppService.SetSelectedBoxPokemon(pokemon, boxNumber, slotNumber);
+    }
 
     private string GetClass(int slotNumber) =>
         AppState.SelectedBoxNumber == BoxNumber && AppState.SelectedBoxSlotNumber == slotNumber

--- a/Pkmds.Rcl/Components/EditForms/PokemonEditForm.razor.cs
+++ b/Pkmds.Rcl/Components/EditForms/PokemonEditForm.razor.cs
@@ -76,7 +76,7 @@ public partial class PokemonEditForm : IDisposable
             return;
         }
 
-        if (HasUnsavedChanges(saveFile))
+        if (AppService.EditFormHasUnsavedChanges())
         {
             var save = await DialogService.ShowMessageBoxAsync(
                 "Unsaved Changes",
@@ -116,38 +116,6 @@ public partial class PokemonEditForm : IDisposable
         var speciesName = AppService.GetPokemonSpeciesName(Pokemon.Species)
                           ?? Pokemon.Species.ToString(CultureInfo.InvariantCulture);
         Snackbar.Add($"{speciesName} added to Bank.", Severity.Success);
-    }
-
-    private bool HasUnsavedChanges(SaveFile saveFile)
-    {
-        if (Pokemon is null)
-        {
-            return false;
-        }
-
-        var selectedPokemonType = AppService.GetSelectedPokemonSlot(out var partySlot, out var boxNumber, out var boxSlot);
-
-        PKM? slotPokemon = selectedPokemonType switch
-        {
-            SelectedPokemonType.Party => saveFile.GetPartySlotAtIndex(partySlot),
-            SelectedPokemonType.Box => saveFile.GetBoxSlotAtIndex(boxNumber, boxSlot),
-            SelectedPokemonType.None when saveFile is SAV7b && AppState.SelectedBoxSlotNumber is { } lgSlot =>
-                saveFile.GetBoxSlotAtIndex(lgSlot / saveFile.BoxSlotCount, lgSlot % saveFile.BoxSlotCount),
-            _ => null
-        };
-
-        if (slotPokemon is null || Pokemon.SIZE_STORED != slotPokemon.SIZE_STORED)
-        {
-            return false;
-        }
-
-        var editedBytes = new byte[Pokemon.SIZE_STORED];
-        Pokemon.WriteDecryptedDataStored(editedBytes);
-
-        var slotBytes = new byte[slotPokemon.SIZE_STORED];
-        slotPokemon.WriteDecryptedDataStored(slotBytes);
-
-        return !editedBytes.AsSpan().SequenceEqual(slotBytes);
     }
 
     private void SaveAndClose()

--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
@@ -586,6 +586,18 @@ public partial class MainLayout : IDisposable
             return;
         }
 
+        // Warn if the user has edits in the Pokémon editor that haven't been written
+        // back to a slot — exporting now would produce a save file without those edits.
+        if (!await UnsavedChangesGuard.ConfirmAsync(
+                AppService,
+                DialogService,
+                "You have unsaved changes to a Pokémon. Save them to the slot before exporting, or export without those changes?",
+                saveText: "Save & Export",
+                discardText: "Export Anyway"))
+        {
+            return;
+        }
+
         Logger.LogInformation("Exporting save file");
         AppState.ShowProgressIndicator = true;
 

--- a/Pkmds.Rcl/Components/LetsGoBoxGrid.razor.cs
+++ b/Pkmds.Rcl/Components/LetsGoBoxGrid.razor.cs
@@ -2,8 +2,18 @@ namespace Pkmds.Rcl.Components;
 
 public partial class LetsGoBoxGrid
 {
-    private void SetSelectedPokemon(PKM? pokemon, int slotNumber) =>
+    private async Task SetSelectedPokemon(PKM? pokemon, int slotNumber)
+    {
+        if (!await UnsavedChangesGuard.ConfirmAsync(
+                AppService,
+                DialogService,
+                "This Pokémon has unsaved changes. Save them to the slot before switching to another?"))
+        {
+            return;
+        }
+
         AppService.SetSelectedLetsGoPokemon(pokemon, slotNumber);
+    }
 
     private string GetClass(int slotNumber) => AppState.SelectedBoxSlotNumber == slotNumber
         ? Constants.SelectedSlotClass

--- a/Pkmds.Rcl/Components/MainTabPages/AdvancedSearchTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/AdvancedSearchTab.razor.cs
@@ -318,6 +318,14 @@ public partial class AdvancedSearchTab : RefreshAwareComponent
 
     private async Task JumpToResultAsync(AdvancedSearchResult row)
     {
+        if (!await UnsavedChangesGuard.ConfirmAsync(
+                AppService,
+                DialogService,
+                "This Pokémon has unsaved changes. Save them to the slot before jumping to the search result?"))
+        {
+            return;
+        }
+
         if (row.IsParty)
         {
             AppService.SetSelectedPartyPokemon(row.Pokemon, row.SlotNumber);

--- a/Pkmds.Rcl/Components/MainTabPages/LegalityReportTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/LegalityReportTab.razor.cs
@@ -376,6 +376,14 @@ public partial class LegalityReportTab : RefreshAwareComponent
             return;
         }
 
+        if (!await UnsavedChangesGuard.ConfirmAsync(
+                AppService,
+                DialogService,
+                "This Pokémon has unsaved changes. Save them to the slot before jumping to the report entry?"))
+        {
+            return;
+        }
+
         if (entry.IsParty)
         {
             AppService.SetSelectedPartyPokemon(entry.Pokemon, entry.SlotNumber);

--- a/Pkmds.Rcl/Components/PartyGrid.razor.cs
+++ b/Pkmds.Rcl/Components/PartyGrid.razor.cs
@@ -4,8 +4,18 @@ public partial class PartyGrid : RefreshAwareComponent
 {
     protected override RefreshEvents SubscribeTo => RefreshEvents.AppState | RefreshEvents.PartyState;
 
-    private void SetSelectedPokemon(PKM? pokemon, int slotNumber) =>
+    private async Task SetSelectedPokemon(PKM? pokemon, int slotNumber)
+    {
+        if (!await UnsavedChangesGuard.ConfirmAsync(
+                AppService,
+                DialogService,
+                "This Pokémon has unsaved changes. Save them to the slot before switching to another?"))
+        {
+            return;
+        }
+
         AppService.SetSelectedPartyPokemon(pokemon, slotNumber);
+    }
 
     private string GetClass(int slotNumber) => AppState.SelectedPartySlotNumber == slotNumber
         ? Constants.SelectedSlotClass

--- a/Pkmds.Rcl/Services/AppService.cs
+++ b/Pkmds.Rcl/Services/AppService.cs
@@ -287,6 +287,38 @@ public class AppService(IAppState appState, IRefreshService refreshService, ILeg
         }
     }
 
+    public bool EditFormHasUnsavedChanges()
+    {
+        if (AppState.SaveFile is not { } saveFile || EditFormPokemon is not { } pokemon)
+        {
+            return false;
+        }
+
+        var selectedPokemonType = GetSelectedPokemonSlot(out var partySlot, out var boxNumber, out var boxSlot);
+
+        PKM? slotPokemon = selectedPokemonType switch
+        {
+            SelectedPokemonType.Party => saveFile.GetPartySlotAtIndex(partySlot),
+            SelectedPokemonType.Box => saveFile.GetBoxSlotAtIndex(boxNumber, boxSlot),
+            SelectedPokemonType.None when saveFile is SAV7b && AppState.SelectedBoxSlotNumber is { } lgSlot =>
+                saveFile.GetBoxSlotAtIndex(lgSlot / saveFile.BoxSlotCount, lgSlot % saveFile.BoxSlotCount),
+            _ => null
+        };
+
+        if (slotPokemon is null || pokemon.SIZE_STORED != slotPokemon.SIZE_STORED)
+        {
+            return false;
+        }
+
+        var editedBytes = new byte[pokemon.SIZE_STORED];
+        pokemon.WriteDecryptedDataStored(editedBytes);
+
+        var slotBytes = new byte[slotPokemon.SIZE_STORED];
+        slotPokemon.WriteDecryptedDataStored(slotBytes);
+
+        return !editedBytes.AsSpan().SequenceEqual(slotBytes);
+    }
+
     public string GetCleanFileName(PKM pkm) => pkm.Context switch
     {
         EntityContext.SplitInvalid or EntityContext.MaxInvalid => DefaultPkmFileName,

--- a/Pkmds.Rcl/Services/IAppService.cs
+++ b/Pkmds.Rcl/Services/IAppService.cs
@@ -150,6 +150,13 @@ public interface IAppService
     void SavePokemon(PKM? selectedPokemon);
 
     /// <summary>
+    /// Returns true if <see cref="EditFormPokemon"/> differs byte-for-byte from the
+    /// data currently stored in its source slot — i.e. the user has edits that have
+    /// not been committed via <see cref="SavePokemon"/>.
+    /// </summary>
+    bool EditFormHasUnsavedChanges();
+
+    /// <summary>
     /// Generates a clean, standardized filename for exporting a Pokémon.
     /// Format varies by generation: Gen 1/2 use DV values, Gen 3+ use PID.
     /// </summary>

--- a/Pkmds.Rcl/Services/UnsavedChangesGuard.cs
+++ b/Pkmds.Rcl/Services/UnsavedChangesGuard.cs
@@ -1,0 +1,47 @@
+namespace Pkmds.Rcl.Services;
+
+/// <summary>
+/// Centralized prompt for actions that would discard or bypass unsaved Pokémon
+/// edits — slot navigation, save-file export, etc. Mirrors the existing
+/// "Add to Bank" pattern in <see cref="Components.EditForms.PokemonEditForm"/>.
+/// </summary>
+public static class UnsavedChangesGuard
+{
+    /// <summary>
+    /// If the edit form has unsaved Pokémon changes, prompts the user to Save,
+    /// Discard, or Cancel. Returns true when it is safe to proceed (no edits, or
+    /// the user chose Save/Discard); false when the user chose Cancel.
+    /// </summary>
+    public static async Task<bool> ConfirmAsync(
+        IAppService appService,
+        IDialogService dialogService,
+        string message,
+        string saveText = "Save",
+        string discardText = "Discard",
+        string cancelText = "Cancel")
+    {
+        if (!appService.EditFormHasUnsavedChanges())
+        {
+            return true;
+        }
+
+        var result = await dialogService.ShowMessageBoxAsync(
+            "Unsaved Changes",
+            message,
+            yesText: saveText,
+            noText: discardText,
+            cancelText: cancelText);
+
+        if (result is null)
+        {
+            return false;
+        }
+
+        if (result is true)
+        {
+            appService.SavePokemon(appService.EditFormPokemon);
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- Prompt the user with **Save / Discard / Cancel** when navigating away from a Pokémon (box slot, party slot, Let's Go slot, search-result jump, legality-report jump) while the editor has uncommitted changes.
- Same prompt (with **Save & Export / Export Anyway / Cancel**) before exporting the save file — exporting otherwise silently produces a file that omits the in-memory edits.
- Centralize the byte-compare check as `IAppService.EditFormHasUnsavedChanges()` (lifted from the private one inside `PokemonEditForm`) and the prompt flow as `UnsavedChangesGuard.ConfirmAsync(...)`, so all six call sites share one path.
- Also bundles the `anthropics/claude-code-action` 1.0.110 → 1.0.111 dependabot bump that was already merged into `dev`.

## Test plan
- [ ] Edit a box Pokémon, click a different box slot → prompt fires; Save commits, Discard reverts, Cancel keeps editing.
- [ ] Edit a party Pokémon, click another party slot → same three-way prompt behaves correctly.
- [ ] Edit a Let's Go slot, click another Let's Go slot → prompt fires.
- [ ] With unsaved edits, jump to a row in **Advanced Search** → prompt fires.
- [ ] With unsaved edits, click a row in **Legality Report** → prompt fires.
- [ ] With unsaved edits, click **Export Save File** → prompt offers Save & Export / Export Anyway / Cancel; "Export Anyway" produces a file without the edits as expected.
- [ ] Click the **same** slot you're currently editing without making changes → no prompt (silent re-select).
- [ ] First click after loading a save (no `EditFormPokemon` yet) → no prompt.
- [ ] "Add to Bank" still prompts only when there are unsaved changes (regression of existing flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)