### PR TITLE
fix: clamp PartyCount when counting battle-ready Pokemon (#844)

### DIFF
--- a/Pkmds.Rcl/Components/PokemonSlotComponent.razor.cs
+++ b/Pkmds.Rcl/Components/PokemonSlotComponent.razor.cs
@@ -315,9 +315,14 @@ public partial class PokemonSlotComponent : IDisposable
 
     private static int GetBattleReadyCount(SaveFile saveFile)
     {
-        // Count battle-ready Pokémon in party (non-Eggs with Species > 0)
+        // Clamp PartyCount to the canonical 6-slot maximum. SAV3.PartyCount reads a single
+        // raw byte from the save block, and a corrupt or unusual GBA save can report > 6,
+        // which would slice past the party buffer in GetPartySlotAtIndex and throw
+        // ArgumentOutOfRangeException during render. Mirrors PKHeX's own SaveFile.PartyData
+        // getter (issue #844).
+        var partyCount = Math.Min(saveFile.PartyCount, 6);
         var count = 0;
-        for (var i = 0; i < saveFile.PartyCount; i++)
+        for (var i = 0; i < partyCount; i++)
         {
             var partyMon = saveFile.GetPartySlotAtIndex(i);
             if (partyMon is { Species: > 0, IsEgg: false })

--- a/Pkmds.Rcl/Components/PokemonSlotComponent.razor.cs
+++ b/Pkmds.Rcl/Components/PokemonSlotComponent.razor.cs
@@ -2,6 +2,9 @@ namespace Pkmds.Rcl.Components;
 
 public partial class PokemonSlotComponent : IDisposable
 {
+    // Mirrors PKHeX's internal SaveFile.MaxPartyCount (private there, so we can't reuse it).
+    private const int MaxPartyCount = 6;
+
     // Tracks (species, form, formArg, isShiny, isFemale, spriteStyle) tuples whose high-res sprites have loaded
     // at least once this session. Shared across all instances so switching boxes doesn't re-flash.
     // SpriteStyle is included so switching the setting mid-session never shows stale cached state.
@@ -320,7 +323,7 @@ public partial class PokemonSlotComponent : IDisposable
         // which would slice past the party buffer in GetPartySlotAtIndex and throw
         // ArgumentOutOfRangeException during render. Mirrors PKHeX's own SaveFile.PartyData
         // getter (issue #844).
-        var partyCount = Math.Min(saveFile.PartyCount, 6);
+        var partyCount = Math.Min(saveFile.PartyCount, MaxPartyCount);
         var count = 0;
         for (var i = 0; i < partyCount; i++)
         {

--- a/Pkmds.Tests/PokemonSlotPartyCountTests.cs
+++ b/Pkmds.Tests/PokemonSlotPartyCountTests.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Components;
+
+namespace Pkmds.Tests;
+
+/// <summary>
+/// Regression tests covering the PartyCount clamp in <see cref="PokemonSlotComponent" />.
+/// SAV3.PartyCount reads a single raw byte from the save block; a corrupt or unusual GBA save
+/// can report &gt; 6, which without clamping would slice past the party buffer in
+/// <c>GetPartySlotAtIndex</c> and throw <see cref="ArgumentOutOfRangeException" /> during render.
+/// See issue #844.
+/// </summary>
+public class PokemonSlotPartyCountTests
+{
+    [Fact]
+    public void PokemonSlotComponent_PartySlot_CorruptGen3PartyCount_RendersWithoutThrowing()
+    {
+        var (saveFile, appState, refreshService, appService) =
+            BunitTestHelpers.LoadSave("POKEMON EMER_BPEE-0.sav");
+
+        var sav3 = saveFile.Should().BeAssignableTo<SAV3>().Subject;
+        sav3.LargeBlock.PartyCount = 99; // force a corrupt count > the canonical 6-slot maximum
+
+        var pkm = saveFile.BlankPKM;
+        pkm.Species = (ushort)Species.Bulbasaur;
+
+        using var ctx = BunitTestHelpers.CreateBunitContext(appState, refreshService, appService);
+
+        var render = () => ctx.Render<PokemonSlotComponent>(p => p
+            .Add(c => c.SlotNumber, 0)
+            .Add(c => c.Pokemon, pkm)
+            .Add(c => c.IsPartySlot, true)
+            .Add(c => c.OnSlotClick, EventCallback.Empty)
+            .Add(c => c.GetClassFunction, () => string.Empty));
+
+        render.Should().NotThrow(
+            "GetBattleReadyCount must clamp PartyCount to MaxPartyCount so corrupt Gen3 saves don't slice past the party buffer");
+    }
+}


### PR DESCRIPTION
## Summary
- Crash report #844: `ArgumentOutOfRangeException` thrown from `GetPartySlot` while rendering any party slot, completely breaking the UI for the affected user (an Emerald `SAV3E` save).
- Root cause: `PokemonSlotComponent.GetBattleReadyCount` looped on `saveFile.PartyCount` directly. On `SAV3`, `PartyCount` is a raw byte read from `LargeBlock.PartyCount` — a corrupt or unusual GBA save can report > 6, and `GetPartySlotAtIndex(6+)` slices past the party buffer and throws.
- Fix: clamp the loop bound to `Math.Min(saveFile.PartyCount, 6)`, matching PKHeX's own defensive clamp in `SaveFile.PartyData` (`MaxPartyCount = 6`).
- Because `IsDraggable()` runs every render of every party slot, this crash was on the hot path — clamping here unblocks the UI.

The same `for (i = 0; i < PartyCount; i++)` pattern exists elsewhere in the codebase (e.g. `AppService`, `LegalityReportTab`, `BulkExportDialog`) but those only fire on user actions, not every render. Holding off on a broader sweep — happy to follow up in a separate PR if you'd like.

## Test plan
- [x] `dotnet build Pkmds.Rcl/Pkmds.Rcl.csproj -c Debug` succeeds with no warnings/errors.
- [ ] CI passes (`buildandtest.yml`).
- [ ] Manual: load a normal GBA save and confirm party drag/drop still works (last battle-ready guard still triggers when only 1 non-egg party member remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)