### PR TITLE
fix: convert pasted Pokémon to save format before write (#843)

### DIFF
--- a/Pkmds.Rcl/Components/BoxGrid.razor.cs
+++ b/Pkmds.Rcl/Components/BoxGrid.razor.cs
@@ -16,7 +16,8 @@ public partial class BoxGrid : RefreshAwareComponent
         if (!await UnsavedChangesGuard.ConfirmAsync(
                 AppService,
                 DialogService,
-                "This Pokémon has unsaved changes. Save them to the slot before switching to another?"))
+                "This Pokémon has unsaved changes. Save them to the slot before switching to another?",
+                snackbar: Snackbar))
         {
             return;
         }

--- a/Pkmds.Rcl/Components/BoxGrid.razor.cs
+++ b/Pkmds.Rcl/Components/BoxGrid.razor.cs
@@ -11,8 +11,18 @@ public partial class BoxGrid : RefreshAwareComponent
             ? "w-80 h-[400px] grid grid-cols-4 grid-rows-5 gap-1"
             : "grid grid-cols-6 gap-1 w-full aspect-[6/5] mx-auto";
 
-    private void SetSelectedPokemon(PKM? pokemon, int boxNumber, int slotNumber) =>
+    private async Task SetSelectedPokemon(PKM? pokemon, int boxNumber, int slotNumber)
+    {
+        if (!await UnsavedChangesGuard.ConfirmAsync(
+                AppService,
+                DialogService,
+                "This Pokémon has unsaved changes. Save them to the slot before switching to another?"))
+        {
+            return;
+        }
+
         AppService.SetSelectedBoxPokemon(pokemon, boxNumber, slotNumber);
+    }
 
     private string GetClass(int slotNumber) =>
         AppState.SelectedBoxNumber == BoxNumber && AppState.SelectedBoxSlotNumber == slotNumber

--- a/Pkmds.Rcl/Components/EditForms/PokemonEditForm.razor.cs
+++ b/Pkmds.Rcl/Components/EditForms/PokemonEditForm.razor.cs
@@ -226,7 +226,35 @@ public partial class PokemonEditForm : IDisposable
 
         void PastePokemon()
         {
-            Pokemon = AppState.CopiedPokemon.Clone();
+            if (AppState.SaveFile is not { } saveFile || AppState.CopiedPokemon is null)
+            {
+                return;
+            }
+
+            var pasted = AppState.CopiedPokemon.Clone();
+
+            // The copied Pokémon may originate from a different save loaded earlier in the
+            // session (e.g. copy from a Gen 6 save, then load a Gen 5 Black 2 save). PKHeX's
+            // SetPartySlot/SetBoxSlot throw ArgumentException when the runtime PKM type
+            // doesn't match the save's PKMType, so convert first and surface a friendly error
+            // when conversion isn't possible instead of crashing.
+            if (pasted.GetType() != saveFile.PKMType)
+            {
+                var converted = EntityConverter.ConvertToType(pasted, saveFile.PKMType, out var c);
+                if (!c.IsSuccess || converted is null)
+                {
+                    Snackbar.Add(
+                        $"Could not paste Pokémon: {c.GetDisplayString(pasted, saveFile.PKMType)}",
+                        Severity.Error);
+                    return;
+                }
+
+                pasted = converted;
+            }
+
+            saveFile.AdaptToSaveFile(pasted);
+
+            Pokemon = pasted;
             AppService.SavePokemon(Pokemon);
 
             var selectedPokemonType =

--- a/Pkmds.Rcl/Components/EditForms/PokemonEditForm.razor.cs
+++ b/Pkmds.Rcl/Components/EditForms/PokemonEditForm.razor.cs
@@ -76,7 +76,7 @@ public partial class PokemonEditForm : IDisposable
             return;
         }
 
-        if (HasUnsavedChanges(saveFile))
+        if (AppService.EditFormHasUnsavedChanges())
         {
             var save = await DialogService.ShowMessageBoxAsync(
                 "Unsaved Changes",
@@ -116,38 +116,6 @@ public partial class PokemonEditForm : IDisposable
         var speciesName = AppService.GetPokemonSpeciesName(Pokemon.Species)
                           ?? Pokemon.Species.ToString(CultureInfo.InvariantCulture);
         Snackbar.Add($"{speciesName} added to Bank.", Severity.Success);
-    }
-
-    private bool HasUnsavedChanges(SaveFile saveFile)
-    {
-        if (Pokemon is null)
-        {
-            return false;
-        }
-
-        var selectedPokemonType = AppService.GetSelectedPokemonSlot(out var partySlot, out var boxNumber, out var boxSlot);
-
-        PKM? slotPokemon = selectedPokemonType switch
-        {
-            SelectedPokemonType.Party => saveFile.GetPartySlotAtIndex(partySlot),
-            SelectedPokemonType.Box => saveFile.GetBoxSlotAtIndex(boxNumber, boxSlot),
-            SelectedPokemonType.None when saveFile is SAV7b && AppState.SelectedBoxSlotNumber is { } lgSlot =>
-                saveFile.GetBoxSlotAtIndex(lgSlot / saveFile.BoxSlotCount, lgSlot % saveFile.BoxSlotCount),
-            _ => null
-        };
-
-        if (slotPokemon is null || Pokemon.SIZE_STORED != slotPokemon.SIZE_STORED)
-        {
-            return false;
-        }
-
-        var editedBytes = new byte[Pokemon.SIZE_STORED];
-        Pokemon.WriteDecryptedDataStored(editedBytes);
-
-        var slotBytes = new byte[slotPokemon.SIZE_STORED];
-        slotPokemon.WriteDecryptedDataStored(slotBytes);
-
-        return !editedBytes.AsSpan().SequenceEqual(slotBytes);
     }
 
     private void SaveAndClose()

--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
@@ -586,6 +586,18 @@ public partial class MainLayout : IDisposable
             return;
         }
 
+        // Warn if the user has edits in the Pokémon editor that haven't been written
+        // back to a slot — exporting now would produce a save file without those edits.
+        if (!await UnsavedChangesGuard.ConfirmAsync(
+                AppService,
+                DialogService,
+                "You have unsaved changes to a Pokémon. Save them to the slot before exporting, or export without those changes?",
+                saveText: "Save & Export",
+                discardText: "Export Anyway"))
+        {
+            return;
+        }
+
         Logger.LogInformation("Exporting save file");
         AppState.ShowProgressIndicator = true;
 

--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
@@ -593,7 +593,8 @@ public partial class MainLayout : IDisposable
                 DialogService,
                 "You have unsaved changes to a Pokémon. Save them to the slot before exporting, or export without those changes?",
                 saveText: "Save & Export",
-                discardText: "Export Anyway"))
+                discardText: "Export Anyway",
+                snackbar: Snackbar))
         {
             return;
         }

--- a/Pkmds.Rcl/Components/LetsGoBoxGrid.razor.cs
+++ b/Pkmds.Rcl/Components/LetsGoBoxGrid.razor.cs
@@ -2,8 +2,18 @@ namespace Pkmds.Rcl.Components;
 
 public partial class LetsGoBoxGrid
 {
-    private void SetSelectedPokemon(PKM? pokemon, int slotNumber) =>
+    private async Task SetSelectedPokemon(PKM? pokemon, int slotNumber)
+    {
+        if (!await UnsavedChangesGuard.ConfirmAsync(
+                AppService,
+                DialogService,
+                "This Pokémon has unsaved changes. Save them to the slot before switching to another?"))
+        {
+            return;
+        }
+
         AppService.SetSelectedLetsGoPokemon(pokemon, slotNumber);
+    }
 
     private string GetClass(int slotNumber) => AppState.SelectedBoxSlotNumber == slotNumber
         ? Constants.SelectedSlotClass

--- a/Pkmds.Rcl/Components/LetsGoBoxGrid.razor.cs
+++ b/Pkmds.Rcl/Components/LetsGoBoxGrid.razor.cs
@@ -7,7 +7,8 @@ public partial class LetsGoBoxGrid
         if (!await UnsavedChangesGuard.ConfirmAsync(
                 AppService,
                 DialogService,
-                "This Pokémon has unsaved changes. Save them to the slot before switching to another?"))
+                "This Pokémon has unsaved changes. Save them to the slot before switching to another?",
+                snackbar: Snackbar))
         {
             return;
         }

--- a/Pkmds.Rcl/Components/MainTabPages/AdvancedSearchTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/AdvancedSearchTab.razor.cs
@@ -318,6 +318,14 @@ public partial class AdvancedSearchTab : RefreshAwareComponent
 
     private async Task JumpToResultAsync(AdvancedSearchResult row)
     {
+        if (!await UnsavedChangesGuard.ConfirmAsync(
+                AppService,
+                DialogService,
+                "This Pokémon has unsaved changes. Save them to the slot before jumping to the search result?"))
+        {
+            return;
+        }
+
         if (row.IsParty)
         {
             AppService.SetSelectedPartyPokemon(row.Pokemon, row.SlotNumber);

--- a/Pkmds.Rcl/Components/MainTabPages/AdvancedSearchTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/AdvancedSearchTab.razor.cs
@@ -321,7 +321,8 @@ public partial class AdvancedSearchTab : RefreshAwareComponent
         if (!await UnsavedChangesGuard.ConfirmAsync(
                 AppService,
                 DialogService,
-                "This Pokémon has unsaved changes. Save them to the slot before jumping to the search result?"))
+                "This Pokémon has unsaved changes. Save them to the slot before jumping to the search result?",
+                snackbar: Snackbar))
         {
             return;
         }

--- a/Pkmds.Rcl/Components/MainTabPages/LegalityReportTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/LegalityReportTab.razor.cs
@@ -379,7 +379,8 @@ public partial class LegalityReportTab : RefreshAwareComponent
         if (!await UnsavedChangesGuard.ConfirmAsync(
                 AppService,
                 DialogService,
-                "This Pokémon has unsaved changes. Save them to the slot before jumping to the report entry?"))
+                "This Pokémon has unsaved changes. Save them to the slot before jumping to the report entry?",
+                snackbar: Snackbar))
         {
             return;
         }

--- a/Pkmds.Rcl/Components/MainTabPages/LegalityReportTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/LegalityReportTab.razor.cs
@@ -376,6 +376,14 @@ public partial class LegalityReportTab : RefreshAwareComponent
             return;
         }
 
+        if (!await UnsavedChangesGuard.ConfirmAsync(
+                AppService,
+                DialogService,
+                "This Pokémon has unsaved changes. Save them to the slot before jumping to the report entry?"))
+        {
+            return;
+        }
+
         if (entry.IsParty)
         {
             AppService.SetSelectedPartyPokemon(entry.Pokemon, entry.SlotNumber);

--- a/Pkmds.Rcl/Components/PartyGrid.razor.cs
+++ b/Pkmds.Rcl/Components/PartyGrid.razor.cs
@@ -9,7 +9,8 @@ public partial class PartyGrid : RefreshAwareComponent
         if (!await UnsavedChangesGuard.ConfirmAsync(
                 AppService,
                 DialogService,
-                "This Pokémon has unsaved changes. Save them to the slot before switching to another?"))
+                "This Pokémon has unsaved changes. Save them to the slot before switching to another?",
+                snackbar: Snackbar))
         {
             return;
         }

--- a/Pkmds.Rcl/Components/PartyGrid.razor.cs
+++ b/Pkmds.Rcl/Components/PartyGrid.razor.cs
@@ -4,8 +4,18 @@ public partial class PartyGrid : RefreshAwareComponent
 {
     protected override RefreshEvents SubscribeTo => RefreshEvents.AppState | RefreshEvents.PartyState;
 
-    private void SetSelectedPokemon(PKM? pokemon, int slotNumber) =>
+    private async Task SetSelectedPokemon(PKM? pokemon, int slotNumber)
+    {
+        if (!await UnsavedChangesGuard.ConfirmAsync(
+                AppService,
+                DialogService,
+                "This Pokémon has unsaved changes. Save them to the slot before switching to another?"))
+        {
+            return;
+        }
+
         AppService.SetSelectedPartyPokemon(pokemon, slotNumber);
+    }
 
     private string GetClass(int slotNumber) => AppState.SelectedPartySlotNumber == slotNumber
         ? Constants.SelectedSlotClass

--- a/Pkmds.Rcl/Services/AppService.cs
+++ b/Pkmds.Rcl/Services/AppService.cs
@@ -287,6 +287,38 @@ public class AppService(IAppState appState, IRefreshService refreshService, ILeg
         }
     }
 
+    public bool EditFormHasUnsavedChanges()
+    {
+        if (AppState.SaveFile is not { } saveFile || EditFormPokemon is not { } pokemon)
+        {
+            return false;
+        }
+
+        var selectedPokemonType = GetSelectedPokemonSlot(out var partySlot, out var boxNumber, out var boxSlot);
+
+        PKM? slotPokemon = selectedPokemonType switch
+        {
+            SelectedPokemonType.Party => saveFile.GetPartySlotAtIndex(partySlot),
+            SelectedPokemonType.Box => saveFile.GetBoxSlotAtIndex(boxNumber, boxSlot),
+            SelectedPokemonType.None when saveFile is SAV7b && AppState.SelectedBoxSlotNumber is { } lgSlot =>
+                saveFile.GetBoxSlotAtIndex(lgSlot / saveFile.BoxSlotCount, lgSlot % saveFile.BoxSlotCount),
+            _ => null
+        };
+
+        if (slotPokemon is null || pokemon.SIZE_STORED != slotPokemon.SIZE_STORED)
+        {
+            return false;
+        }
+
+        var editedBytes = new byte[pokemon.SIZE_STORED];
+        pokemon.WriteDecryptedDataStored(editedBytes);
+
+        var slotBytes = new byte[slotPokemon.SIZE_STORED];
+        slotPokemon.WriteDecryptedDataStored(slotBytes);
+
+        return !editedBytes.AsSpan().SequenceEqual(slotBytes);
+    }
+
     public string GetCleanFileName(PKM pkm) => pkm.Context switch
     {
         EntityContext.SplitInvalid or EntityContext.MaxInvalid => DefaultPkmFileName,

--- a/Pkmds.Rcl/Services/IAppService.cs
+++ b/Pkmds.Rcl/Services/IAppService.cs
@@ -150,6 +150,13 @@ public interface IAppService
     void SavePokemon(PKM? selectedPokemon);
 
     /// <summary>
+    /// Returns true if <see cref="EditFormPokemon"/> differs byte-for-byte from the
+    /// data currently stored in its source slot — i.e. the user has edits that have
+    /// not been committed via <see cref="SavePokemon"/>.
+    /// </summary>
+    bool EditFormHasUnsavedChanges();
+
+    /// <summary>
     /// Generates a clean, standardized filename for exporting a Pokémon.
     /// Format varies by generation: Gen 1/2 use DV values, Gen 3+ use PID.
     /// </summary>

--- a/Pkmds.Rcl/Services/UnsavedChangesGuard.cs
+++ b/Pkmds.Rcl/Services/UnsavedChangesGuard.cs
@@ -10,7 +10,9 @@ public static class UnsavedChangesGuard
     /// <summary>
     /// If the edit form has unsaved Pokémon changes, prompts the user to Save,
     /// Discard, or Cancel. Returns true when it is safe to proceed (no edits, or
-    /// the user chose Save/Discard); false when the user chose Cancel.
+    /// the user chose Save/Discard); false when the user chose Cancel or the save
+    /// itself failed (so the caller does not silently abandon the user's edits by
+    /// continuing on to discard them).
     /// </summary>
     public static async Task<bool> ConfirmAsync(
         IAppService appService,
@@ -18,7 +20,8 @@ public static class UnsavedChangesGuard
         string message,
         string saveText = "Save",
         string discardText = "Discard",
-        string cancelText = "Cancel")
+        string cancelText = "Cancel",
+        ISnackbar? snackbar = null)
     {
         if (!appService.EditFormHasUnsavedChanges())
         {
@@ -39,7 +42,22 @@ public static class UnsavedChangesGuard
 
         if (result is true)
         {
-            appService.SavePokemon(appService.EditFormPokemon);
+            // SavePokemon ultimately calls PKHeX's SetPartySlotAtIndex / SetBoxSlotAtIndex,
+            // which throw ArgumentException when the runtime PKM type doesn't match the
+            // save's PKMType (see #843). Surface a friendly error and cancel the action
+            // so the user's edits aren't discarded by the navigation/export that would
+            // have followed a successful save.
+            try
+            {
+                appService.SavePokemon(appService.EditFormPokemon);
+            }
+            catch (ArgumentException ex)
+            {
+                snackbar?.Add(
+                    $"Could not save Pokémon to slot: {ex.Message}",
+                    Severity.Error);
+                return false;
+            }
         }
 
         return true;

--- a/Pkmds.Rcl/Services/UnsavedChangesGuard.cs
+++ b/Pkmds.Rcl/Services/UnsavedChangesGuard.cs
@@ -1,0 +1,47 @@
+namespace Pkmds.Rcl.Services;
+
+/// <summary>
+/// Centralized prompt for actions that would discard or bypass unsaved Pokémon
+/// edits — slot navigation, save-file export, etc. Mirrors the existing
+/// "Add to Bank" pattern in <see cref="Components.EditForms.PokemonEditForm"/>.
+/// </summary>
+public static class UnsavedChangesGuard
+{
+    /// <summary>
+    /// If the edit form has unsaved Pokémon changes, prompts the user to Save,
+    /// Discard, or Cancel. Returns true when it is safe to proceed (no edits, or
+    /// the user chose Save/Discard); false when the user chose Cancel.
+    /// </summary>
+    public static async Task<bool> ConfirmAsync(
+        IAppService appService,
+        IDialogService dialogService,
+        string message,
+        string saveText = "Save",
+        string discardText = "Discard",
+        string cancelText = "Cancel")
+    {
+        if (!appService.EditFormHasUnsavedChanges())
+        {
+            return true;
+        }
+
+        var result = await dialogService.ShowMessageBoxAsync(
+            "Unsaved Changes",
+            message,
+            yesText: saveText,
+            noText: discardText,
+            cancelText: cancelText);
+
+        if (result is null)
+        {
+            return false;
+        }
+
+        if (result is true)
+        {
+            appService.SavePokemon(appService.EditFormPokemon);
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes #843 — pasting a Pokémon copied from a different-generation save crashed with `ArgumentException: PKM Format needs to be PKHeX.Core.PK5...` when the active save's `PKMType` didn't match the cloned PKM's runtime type.
- `OnClickPaste` → `PastePokemon` in `PokemonEditForm.razor.cs` now runs the clone through `EntityConverter.ConvertToType` when types differ, calls `AdaptToSaveFile`, and surfaces a snackbar error instead of crashing when conversion isn't possible — matching the pattern already used by `MainLayout.LoadPokemonFile` and the file-drop path in `PokemonSlotComponent`.

## Test plan
- [ ] Load a Gen 6+ save, copy a Pokémon, then load a Gen 5 save (e.g. Black 2 `.dsv`) and paste into a party/box slot — verify it converts cleanly or shows a friendly error instead of crashing.
- [ ] Copy + paste within the same save (no format change) still works as before.
- [ ] Paste from a copied PKM into an empty slot (no confirmation dialog path) still works.
- [ ] Paste over an existing Pokémon (confirmation dialog path) still works.