### PR TITLE
Bump PKHeX.Core to 26.5.5

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,7 +20,7 @@
         <PackageVersion Include="Microsoft.JSInterop" Version="10.0.3"/>
         <PackageVersion Include="Microsoft.JSInterop.WebAssembly" Version="10.0.3"/>
         <PackageVersion Include="MudBlazor" Version="9.4.0"/>
-        <PackageVersion Include="PKHeX.Core" Version="26.4.11"/>
+        <PackageVersion Include="PKHeX.Core" Version="26.5.5"/>
         <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0"/>
         <PackageVersion Include="Serilog.Sinks.BrowserConsole" Version="8.0.0"/>
         <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5"/>

--- a/Pkmds.Rcl/Components/MainTabPages/BadgesComponent.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/BadgesComponent.razor.cs
@@ -147,15 +147,15 @@ public partial class BadgesComponent : IDisposable
                 break;
 
             case EntityContext.Gen4 when saveFile is SAV4DP sav4dp:
-                sav4dp.Badges = ToggleBadge(sav4dp.Badges, badgeIndex);
+                sav4dp.Badges = (byte)ToggleBadge(sav4dp.Badges, badgeIndex);
                 break;
 
             case EntityContext.Gen4 when saveFile is SAV4Pt sav4pt:
-                sav4pt.Badges = ToggleBadge(sav4pt.Badges, badgeIndex);
+                sav4pt.Badges = (byte)ToggleBadge(sav4pt.Badges, badgeIndex);
                 break;
 
             case EntityContext.Gen4 when saveFile is SAV4HGSS sav4hgss:
-                sav4hgss.Badges = ToggleBadge(sav4hgss.Badges, badgeIndex);
+                sav4hgss.Badges = (byte)ToggleBadge(sav4hgss.Badges, badgeIndex);
                 break;
 
             case EntityContext.Gen5 when saveFile is SAV5BW sav5bw:


### PR DESCRIPTION
Update central package version in Directory.Packages.props to PKHeX.Core 26.5.5. This ensures projects use the newer PKHeX.Core release (replacing 26.4.11) to pick up fixes and improvements from the updated dependency.