### PR TITLE
Pokedex: remove SAV9SV/Gen 7 SeenAll workarounds fixed in PKHeX 26.5.5

### DIFF
--- a/Pkmds.Rcl/Components/MainTabPages/Pokedex/PokedexSpeciesGrid.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/Pokedex/PokedexSpeciesGrid.razor.cs
@@ -181,25 +181,10 @@ public partial class PokedexSpeciesGrid
             // Must write through the Zukan API directly for both dex block modes.
             if (sv.Zukan.GetRevision() == 0)
             {
-                // Paldea block (pre-DLC saves).
-                // PKHeX bug: PokeDexEntry9Paldea.SetSeen(true) is a no-op when state == 0
-                // because it uses Math.Min(state, 2) instead of Math.Max.  SetSeen(false)
-                // calls SetState(2) ("seen") instead of 0 ("unknown").
-                // Workaround: call SetState() directly.
+                // Paldea block (pre-DLC saves). SetSeen(false) lands on state 1
+                // ("known but not seen") to match PKHeX semantics — not state 0.
                 var entry = sv.Zukan.DexPaldea.Get(row.SpeciesId);
-                if (value)
-                {
-                    // Raise to "seen" (state 2) only if not already seen or caught.
-                    if (entry.GetState() < 2)
-                    {
-                        entry.SetState(2u);
-                    }
-                }
-                else
-                {
-                    // Clear everything — "unknown" (state 0).
-                    entry.SetState(0u);
-                }
+                entry.SetSeen(value);
             }
             else
             {
@@ -241,14 +226,8 @@ public partial class PokedexSpeciesGrid
             if (sv.Zukan.GetRevision() == 0)
             {
                 // Paldea block (pre-DLC saves).
-                // PKHeX bug: PokeDexEntry9Paldea.SetCaught(false) calls SetState(2) ("seen")
-                // instead of leaving caught unset.
-                // Workaround: call SetState() directly.
                 var entry = sv.Zukan.DexPaldea.Get(row.SpeciesId);
-                entry.SetState(value
-                        ? 3u // caught
-                        : 2u // seen but not caught
-                );
+                entry.SetCaught(value);
             }
             else
             {

--- a/Pkmds.Rcl/Components/MainTabPages/PokedexTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/PokedexTab.razor.cs
@@ -425,18 +425,11 @@ public partial class PokedexTab
             case SAV6AO ao:
                 ao.Zukan.SeenAll(false);
                 break;
-            // PKHeX bug: Zukan<T>.SeenAll(bool shinyToo = false) forwards shinyToo as
-            // the *value* parameter of SetAllSeen(bool value = true, bool shinyToo),
-            // so SeenAll(false) → SetAllSeen(false) which CLEARS instead of setting.
-            // Workaround: call SetAllSeen(true, false) directly.
-            // Affects all classes that inherit the base Zukan<T>.SeenAll — in practice
-            // Zukan7 (Gen 7 SM/USUM) and Zukan7b (Gen 7b LGPE).
-            // Zukan8 (SWSH) and Zukan8b (BDSP) both override SeenAll correctly.
             case SAV7 s7:
-                s7.Zukan.SetAllSeen();
+                s7.Zukan.SeenAll();
                 break;
             case SAV7b b7:
-                b7.Zukan.SetAllSeen();
+                b7.Zukan.SeenAll();
                 break;
             case SAV8SWSH swsh:
                 swsh.Zukan.SeenAll();
@@ -445,36 +438,6 @@ public partial class PokedexTab
                 bs.Zukan.SeenAll();
                 break;
             // SAV8LA: no Zukan.SeenAll(); button is disabled for LA
-
-            // SAV9SV (Paldea/T0 mode): PokeDexEntry9Paldea.SetSeen(true) has a
-            // PKHeX bug — it uses Math.Min(state, 2) instead of Math.Max, so it
-            // never *raises* state from 0 ("unknown") to 2 ("seen").
-            // Workaround: iterate dex-indexed species and call SetState(2) directly
-            // for any entry below the "seen" threshold.  Species already at state 3
-            // (caught) are left untouched.
-            // For Kitakami/DLC mode (GetRevision != 0) Zukan9Kitakami.SeenAll works
-            // correctly via FlagsFormSeen, so the standard path is used there.
-            case SAV9SV sv when sv.Zukan.GetRevision() == 0:
-                for (ushort i = 1; i <= sv.MaxSpeciesID; i++)
-                {
-                    if (!PokedexHelpers.IsSpeciesInSvDex(sv, i))
-                    {
-                        continue;
-                    }
-
-                    var entry = sv.Zukan.DexPaldea.Get(i);
-                    if (entry.GetState() < 2)
-                    {
-                        entry.SetState(2);
-                    }
-
-                    if (i % 50 == 0)
-                    {
-                        await Task.Yield();
-                    }
-                }
-
-                break;
             case SAV9SV sv:
                 sv.Zukan.SeenAll();
                 break;


### PR DESCRIPTION
## Summary

PR #850 bumped PKHeX.Core to 26.5.5, which fixes three workaround sites in our pokédex code. This PR unwinds them.

- `PokeDexEntry9Paldea.SetSeen` now uses `Math.Max`, so the per-species `SetState` workaround in `OnSeenChanged` collapses to `entry.SetSeen(value)`.
- `PokeDexEntry9Paldea.SetCaught(false)` no longer over-clears, so the manual `SetState` in `OnCaughtChanged` collapses to `entry.SetCaught(value)`.
- `Zukan<T>.SeenAll(bool)` now forwards `shinyToo` via a named arg, so the `SetAllSeen()` workaround for `SAV7` / `SAV7b` reverts to `SeenAll()`.
- The `SAV9SV` Paldea-mode "Seen All" loop merges into the general `SAV9SV` case now that the upstream `SetSeen(true)` fix is in place.

## Decision: `SetSeen(false)` semantics (state 0 vs state 1)

Per acceptance criterion #2 in #851: unchecking Seen on a Gen 9 SV save now lands on **state 1** ("known but not seen") rather than state 0 ("unknown"). This matches PKHeX.Core's `SetSeen(false)` semantics. Although PKHeX WinForms doesn't expose a Seen checkbox (it uses a 4-value state combo box instead), state 1 is the upstream API's chosen behavior and we maintain parity.

If a hard "forget species" affordance is wanted later, it can be added as a separate Clear action without re-introducing the workaround.

## Test plan

- [ ] Toggle Seen on/off for a Gen 9 SV save (Rev 0 / Paldea); confirm round-trip matches PKHeX WinForms (state 0 → 2 on check, 2 → 1 on uncheck)
- [ ] Toggle Caught on/off for a Gen 9 SV save (Rev 0); confirm caught → seen on uncheck
- [ ] Click "Seen All" on a Gen 7 SM/USUM save; confirm all dex entries marked seen
- [ ] Click "Seen All" on a Gen 7b LGPE save; confirm all dex entries marked seen
- [ ] Click "Seen All" on a Gen 9 SV save (Rev 0 and Rev 1+); confirm all dex entries marked seen

Closes #851