### PR TITLE
fix(layout): push iOS PWA status bar off the app bar contents

### DIFF
--- a/Pkmds.Rcl/wwwroot/css/app.css
+++ b/Pkmds.Rcl/wwwroot/css/app.css
@@ -1,6 +1,16 @@
 body, html {
-    padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom, 16px) env(safe-area-inset-left, 8px);
+    /* Top inset is handled by .mud-appbar below so the iOS status bar overlays the
+       app bar (not a blank gap above it) when running as an installed PWA with
+       apple-mobile-web-app-status-bar-style=black-translucent. Adding it here too
+       would double-count and leave a 44px gap of background colour above the bar. */
+    padding: 0 env(safe-area-inset-right) env(safe-area-inset-bottom, 16px) env(safe-area-inset-left, 8px);
     box-sizing: border-box;
+}
+
+/* Push the app bar's contents below the iOS status bar in standalone PWA mode.
+   In a regular browser tab env(safe-area-inset-top) is 0, so this is a no-op. */
+.mud-appbar {
+    padding-top: env(safe-area-inset-top, 0px);
 }
 
 .menu-container {


### PR DESCRIPTION
When PKMDS is added to an iPad/iPhone home screen and launched as a standalone PWA, apple-mobile-web-app-status-bar-style=black-translucent makes iOS draw the system status bar over the page rather than reserving a slot for it. body's padding-top: env(safe-area-inset-top) wasn't enough on its own — MudAppBar sits at the top of MudLayout, so its contents (title, menu icon, theme toggle, GitHub button) rendered beneath the time / signal / battery glyphs.

Move the top inset off body and onto .mud-appbar so the system status bar visually overlays the app bar's background instead of clipping its text. body still handles left / right / bottom insets for landscape notches and the home-indicator gap. In a regular browser tab, env(safe-area-inset-top) resolves to 0, so this is a no-op there.