### PR TITLE
fix(layout): grow MudMainContent padding-top with iOS status-bar inset

### DIFF
--- a/Pkmds.Rcl/wwwroot/css/app.css
+++ b/Pkmds.Rcl/wwwroot/css/app.css
@@ -13,6 +13,18 @@ body, html {
     padding-top: env(safe-area-inset-top, 0px);
 }
 
+/* The padding above grows .mud-appbar's effective height by the iOS status-bar
+   inset, but MudBlazor's .mud-main-content padding-top is fixed to the bar's
+   nominal height — so page content (e.g. the save-file title row in
+   SaveFileComponent) renders behind the now-taller bar in standalone PWA mode.
+   Match the inset here so MudMainContent's reserved space tracks the bar.
+   Selector specificity (0,2,0) matches MudBlazor's .mud-appbar-dense rule and
+   our stylesheet loads after, so this wins. We always use MudAppBar Dense, so
+   the dense variant is the only one that needs covering. */
+.mud-appbar-dense ~ .mud-main-content {
+    padding-top: calc(var(--mud-appbar-height) - var(--mud-appbar-height) / 4 + env(safe-area-inset-top, 0px));
+}
+
 .menu-container {
     padding-bottom: env(safe-area-inset-bottom, 16px); /* Fallback to 16px */
     padding-left: env(safe-area-inset-left, 8px); /* Fallback to 8px */


### PR DESCRIPTION
## Summary
- Follow-up to #856. The previous commit grew `.mud-appbar` by `env(safe-area-inset-top)` so the iOS PWA status bar overlays the bar's background. But MudBlazor's `.mud-main-content` reserves space below the bar with a fixed calc (~48px dense), so the now-taller bar (~92px on iPad PWA) covered the first row of page content — the save-file title row in `SaveFileComponent`.
- Add the same inset to `.mud-appbar-dense ~ .mud-main-content`'s `padding-top` so reserved space tracks the bar's actual height. Selector specificity (0,2,0) matches MudBlazor's dense rule and our stylesheet loads after, so this wins. No-op in a regular browser tab since `env(safe-area-inset-top)` is 0.

## Test plan
- [ ] iPad PWA (Add to Home Screen, standalone): save-file title row sits visibly below the iOS status bar, not behind the app bar.
- [ ] iPad PWA in compact / Stage Manager window: save-file title row not clipped by the PWA chrome.
- [ ] Regular Safari tab on iPad: layout unchanged from before (no extra gap above content).
- [ ] Desktop browser (≥1280px): layout unchanged; tabs and content positioned exactly as on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)