### PR TITLE
fix(legalize): repair Showdown import when legalization fails

### DIFF
--- a/Pkmds.Rcl/Components/Dialogs/ShowdownImportDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/ShowdownImportDialog.razor.cs
@@ -216,7 +216,11 @@ public partial class ShowdownImportDialog
         var skippedImpossible = 0;
         foreach (var entry in parsedEntries)
         {
-            if (entry.Pokemon is not { } pkm)
+            // Reject blank PKMs (Species == 0). LegalizationService falls back to a
+            // blank when no encounter survives pre-filtering; placing one would silently
+            // succeed (writing a Species=0 entity to an empty slot is a no-op) and the
+            // user would see a green snackbar with no Pokémon imported.
+            if (entry.Pokemon is not { Species: > 0 } pkm)
             {
                 conversionFailed++;
                 continue;

--- a/Pkmds.Rcl/Services/AppService.cs
+++ b/Pkmds.Rcl/Services/AppService.cs
@@ -490,8 +490,11 @@ public class AppService(IAppState appState, IRefreshService refreshService, ILeg
         // fallback, and post-generation fixes. On Failed/Timeout, the outcome still
         // carries the best-effort attempt (with post-generation fixes already applied),
         // so we return it rather than a raw blank — the user can edit it further.
+        // A Species=0 result means even the best-effort fallback didn't catch — return
+        // null so callers (the Showdown import dialog's parse preview, etc.) can show
+        // a clear "conversion failed" state instead of an entry with a blank icon.
         var result = LegalizationService.GenerateFromSetSync(set, sav);
-        return result.Pokemon;
+        return result.Pokemon is { Species: > 0 } pkm ? pkm : null;
     }
 
     public bool TryPlacePokemonInPartySlot(PKM pkm)

--- a/Pkmds.Rcl/Services/LegalizationService.cs
+++ b/Pkmds.Rcl/Services/LegalizationService.cs
@@ -166,7 +166,7 @@ public sealed class LegalizationService : ILegalizationService
             if (ct.IsCancellationRequested)
             {
                 return new LegalizationOutcome(
-                    bestAttempt ?? blank,
+                    bestAttempt ?? BuildSetFallback(blank, set),
                     LegalizationStatus.Failed,
                     "Cancelled.");
             }
@@ -181,7 +181,7 @@ public sealed class LegalizationService : ILegalizationService
                 }
 
                 return new LegalizationOutcome(
-                    bestAttempt ?? blank,
+                    bestAttempt ?? BuildSetFallback(blank, set),
                     LegalizationStatus.Timeout,
                     $"Timed out after {timeoutSeconds}s ({attemptCount} encounters tried).");
             }
@@ -301,9 +301,34 @@ public sealed class LegalizationService : ILegalizationService
         }
 
         return new LegalizationOutcome(
-            bestAttempt ?? blank,
+            bestAttempt ?? BuildSetFallback(blank, set),
             LegalizationStatus.Failed,
             $"No legal result found after {attemptCount} encounters.");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  Best-effort fallback (no encounter found)
+    // ──────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Builds a populated PKM from <paramref name="set" /> when the encounter
+    /// loop produces nothing — for example when every encounter is filtered out
+    /// by <see cref="IsEncounterValid" /> (Garchomp specified at Level 15 in
+    /// BDSP) or when the moveset is unlearnable (so
+    /// <see cref="EncounterMovesetGenerator.GenerateEncounters" /> yields zero
+    /// candidates). The result is illegal but carries the user's requested
+    /// moves / item / nature / IVs, giving the caller a recognisable starting
+    /// point instead of a blank slot. Mirrors ALM's <c>last ?? template</c>
+    /// fallback.
+    /// </summary>
+    private static PKM BuildSetFallback(PKM blank, ShowdownSet set)
+    {
+        var pk = blank.Clone();
+        pk.Species = set.Species;
+        pk.Form = set.Form;
+        pk.CurrentLevel = set.Level;
+        pk.ApplySetDetails(set);
+        return pk;
     }
 
     // ──────────────────────────────────────────────────────────────────────

--- a/Pkmds.Rcl/Services/LegalizationService.cs
+++ b/Pkmds.Rcl/Services/LegalizationService.cs
@@ -882,6 +882,20 @@ public sealed class LegalizationService : ILegalizationService
             pk.SetDefaultNickname();
         }
 
+        // Seed expected nickname trash residue for Gen 7b / Gen 8+ formats.
+        // TrashByteVerifier.VerifyTrashNickname expects a nicknamed Pokémon's
+        // NicknameTrash to carry the species default name as "underlay" — the
+        // bytes that would naturally remain after a player renamed a freshly-
+        // caught Pokémon in-game. ApplySetDetails writes into a zero buffer,
+        // so the residue is missing → "Fishy: Expected Trash Bytes".
+        // ApplyTrashBytes writes the species-name bytes past the new terminator
+        // without disturbing the user's nickname.
+        if ((pk.Format >= 8 || pk.Context == EntityContext.Gen7b) && pk.IsNicknamed)
+        {
+            var speciesName = SpeciesName.GetSpeciesNameGeneration(pk.Species, pk.Language, pk.Format);
+            StringConverter8.ApplyTrashBytes(pk.NicknameTrash, speciesName);
+        }
+
         // Average height/weight if unset.
         if (pk is IScaledSize ss && ss.HeightScalar == 0 && ss.WeightScalar == 0)
         {


### PR DESCRIPTION
## Summary

- **#858** — `LegalizationService` no longer silently produces blank (Species = 0) PKMs when no encounter survives `IsEncounterValid`'s pre-filter (e.g. Garchomp at Level 15 in BDSP, or any set whose moveset is unlearnable). All three failure-path returns (cancellation / timeout / exhaustion) now build a populated best-effort PKM via `ApplySetDetails`, mirroring ALM's `last ?? template` pattern. `ShowdownImportDialog` rejects `Species == 0` at the import step, and `AppService.ConvertShowdownSetToPkm` returns `null` when the engine couldn't even produce a probe — so the parse preview shows a "conversion failed" state instead of a misleading icon, and the snackbar warns instead of falsely reporting success.
- **#860** — `LegalizationService.ApplyPostGenerationFixes` now seeds the species default name into `NicknameTrash` (via `StringConverter8.ApplyTrashBytes`) for nicknamed Gen 7b / Gen 8+ imports. `TrashByteVerifier.VerifyTrashNickname` expects that residue (it's what an in-game rename naturally leaves behind), and without it the legality report flagged imports as "Fishy: Expected Trash Bytes."

Follow-up: #859 tracks adding a HaX-aware retry path that bypasses `IsEncounterValid` when `IsHaXEnabled` is set — out of scope for this PR.

## Test plan

- [ ] Load a BDSP save. Import the Garchomp@Lv15 set from #858 — the success snackbar should turn into a yellow "1 could not be placed" warning, no Pokémon written to the slot.
- [ ] Same save, import a valid set with a custom nickname (e.g. `Ikura (Garchomp) (F) @ Yache Berry`, default level). Open the imported Pokémon → Legality tab. The "Fishy: Expected Trash Bytes" warning under Nickname should be gone.
- [ ] Import a set with default nickname (no rename) — Legality tab should remain clean (residue isn't seeded for non-nicknamed Pokémon).
- [ ] Spot-check imports against a Gen 5 (BW2) save and a Gen 9 (SV) save to confirm the trash-byte change doesn't regress non-Gen 8b formats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)