### PR TITLE
HaX legalize retry, edit-form delete fix, dialog backdrop default

### DIFF
--- a/Pkmds.Rcl/Components/Dialogs/ShowdownImportDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/ShowdownImportDialog.razor.cs
@@ -214,6 +214,7 @@ public partial class ShowdownImportDialog
         var converted = new List<PKM>(parsedEntries.Count);
         var conversionFailed = 0;
         var skippedImpossible = 0;
+        var illegalAmongConverted = 0;
         foreach (var entry in parsedEntries)
         {
             // Reject blank PKMs (Species == 0). LegalizationService falls back to a
@@ -234,26 +235,34 @@ public partial class ShowdownImportDialog
             }
 
             converted.Add(pkm);
+            // The legality engine's BuildSetFallback / SuccessHaX paths produce populated
+            // but illegal PKMs (e.g. Garchomp@15 in BDSP). They survive the Species/IsPresent
+            // filters above, so without this tracking the snackbar would say "Imported 1
+            // Pokémon" with green Success severity even though the result is plainly illegal.
+            if (entry.Status == LegalityStatus.Illegal)
+            {
+                illegalAmongConverted++;
+            }
         }
 
         if (converted.Count == 0)
         {
-            ReportResult(0, conversionFailed, skippedImpossible);
+            ReportResult(0, conversionFailed, skippedImpossible, illegalAmongConverted);
             MudDialog?.Close();
             return;
         }
 
         if (importToParty)
         {
-            await ImportToPartyAsync(sav, converted, conversionFailed, skippedImpossible);
+            await ImportToPartyAsync(sav, converted, conversionFailed, skippedImpossible, illegalAmongConverted);
         }
         else
         {
-            ImportToBox(converted, conversionFailed, skippedImpossible);
+            ImportToBox(converted, conversionFailed, skippedImpossible, illegalAmongConverted);
         }
     }
 
-    private async Task ImportToPartyAsync(SaveFile sav, List<PKM> converted, int conversionFailed, int skippedImpossible)
+    private async Task ImportToPartyAsync(SaveFile sav, List<PKM> converted, int conversionFailed, int skippedImpossible, int illegalAmongConverted)
     {
         var emptySlots = 6 - sav.PartyCount;
 
@@ -269,7 +278,7 @@ public partial class ShowdownImportDialog
                 }
             }
 
-            ReportResult(placed, conversionFailed + (converted.Count - placed), skippedImpossible);
+            ReportResult(placed, conversionFailed + (converted.Count - placed), skippedImpossible, illegalAmongConverted);
             MudDialog?.Close();
             return;
         }
@@ -293,11 +302,11 @@ public partial class ShowdownImportDialog
 
         var written = AppService.OverwriteParty(converted);
         var skipped = Math.Max(0, converted.Count - written);
-        ReportResult(written, conversionFailed + skipped, skippedImpossible);
+        ReportResult(written, conversionFailed + skipped, skippedImpossible, illegalAmongConverted);
         MudDialog?.Close();
     }
 
-    private void ImportToBox(List<PKM> converted, int conversionFailed, int skippedImpossible)
+    private void ImportToBox(List<PKM> converted, int conversionFailed, int skippedImpossible, int illegalAmongConverted)
     {
         var placed = 0;
         foreach (var pkm in converted)
@@ -309,18 +318,23 @@ public partial class ShowdownImportDialog
         }
 
         RefreshService.RefreshBoxState();
-        ReportResult(placed, conversionFailed + (converted.Count - placed), skippedImpossible);
+        ReportResult(placed, conversionFailed + (converted.Count - placed), skippedImpossible, illegalAmongConverted);
         MudDialog?.Close();
     }
 
-    private void ReportResult(int imported, int failed, int skippedImpossible)
+    private void ReportResult(int imported, int failed, int skippedImpossible, int illegal)
     {
         if (imported == 0 && failed == 0 && skippedImpossible == 0)
         {
             return;
         }
 
-        var parts = new List<string>(2);
+        // Cap illegal at imported — placement failures might have dropped some illegal
+        // entries, and we can't tell which. Reporting more illegal than imported would
+        // read as nonsense to the user.
+        var illegalImported = Math.Min(illegal, imported);
+
+        var parts = new List<string>(3);
         if (failed > 0)
         {
             parts.Add($"{failed} could not be placed");
@@ -329,6 +343,11 @@ public partial class ShowdownImportDialog
         if (skippedImpossible > 0)
         {
             parts.Add($"{skippedImpossible} skipped (not in this game)");
+        }
+
+        if (illegalImported > 0)
+        {
+            parts.Add($"{illegalImported} illegal");
         }
 
         var message = parts.Count == 0

--- a/Pkmds.Rcl/Components/EditForms/Tabs/LegalityTab.razor.cs
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/LegalityTab.razor.cs
@@ -142,6 +142,16 @@ public partial class LegalityTab : IDisposable
                     ShowSuccessSnackbar(result.Pokemon, result.Changes);
                     break;
 
+                case LegalizationStatus.SuccessHaX:
+                    // HaX retry replaced the editor PKM with a populated-but-illegal result.
+                    // Still invoke OnPokemonLegalized so the editor reflects the change; the
+                    // legality alert will repaint as Invalid.
+                    await OnPokemonLegalized.InvokeAsync(result.Pokemon);
+                    Snackbar.Add(
+                        result.FailureReason ?? "Imported via HaX retry — illegal but populated.",
+                        Severity.Warning);
+                    break;
+
                 case LegalizationStatus.Timeout:
                     Snackbar.Add(result.FailureReason ?? "Legalization timed out.", Severity.Warning);
                     break;

--- a/Pkmds.Rcl/Models/LegalizationResult.cs
+++ b/Pkmds.Rcl/Models/LegalizationResult.cs
@@ -12,7 +12,16 @@ public enum LegalizationStatus
     Failed,
 
     /// <summary>The legalization attempt exceeded the time limit.</summary>
-    Timeout
+    Timeout,
+
+    /// <summary>
+    /// The normal pipeline produced no legal result, but a HaX retry (with
+    /// <see cref="PKHeX.Core.EntityConverter.AllowIncompatibleConversion" /> relaxed
+    /// and <c>IsEncounterValid</c>'s level pre-filter skipped) produced a populated
+    /// but illegal Pokémon. Surface this with a warning rather than the green
+    /// "successfully legalized" affordance — the result is intentionally illegal.
+    /// </summary>
+    SuccessHaX,
 }
 
 /// <summary>

--- a/Pkmds.Rcl/Services/AppService.cs
+++ b/Pkmds.Rcl/Services/AppService.cs
@@ -406,6 +406,10 @@ public class AppService(IAppState appState, IRefreshService refreshService, ILeg
         saveFile.DeletePartySlot(partySlotNumber);
 
         AppState.SelectedPartySlotNumber = null;
+        // Clear the edit-form PKM so the unsaved-changes guard doesn't prompt against a
+        // baseline that belongs to a Pokémon the user just deleted. The setter nulls
+        // editFormBaselineBytes for us.
+        EditFormPokemon = null;
 
         RefreshService.RefreshPartyState();
     }
@@ -421,6 +425,9 @@ public class AppService(IAppState appState, IRefreshService refreshService, ILeg
 
         AppState.SelectedBoxNumber = null;
         AppState.SelectedBoxSlotNumber = null;
+        // Clear the edit-form PKM so the unsaved-changes guard doesn't prompt against a
+        // baseline that belongs to a Pokémon the user just deleted.
+        EditFormPokemon = null;
 
         RefreshService.RefreshBoxState();
     }

--- a/Pkmds.Rcl/Services/DialogOptionsHelper.cs
+++ b/Pkmds.Rcl/Services/DialogOptionsHelper.cs
@@ -7,12 +7,16 @@ public sealed class DialogOptionsHelper : IDialogOptionsHelper
     // layout responsive to live window resizes, which setting FullScreen at
     // open-time could not — MudBlazor bakes FullScreen into the dialog once
     // and won't re-react to viewport changes without closing and reopening.
+    // Default backdropClick=false: in MudBlazor's default, clicking outside the dialog
+    // dismisses it. That's too easy to trigger accidentally — a stray page-background
+    // click in the middle of an import flow would discard a parsed-but-not-yet-imported
+    // PokePaste team. Opt-in to backdrop dismissal per-dialog by passing backdropClick:true.
     public Task<DialogOptions> BuildAsync(
         MaxWidth desktopMaxWidth,
         bool fullWidth = true,
         bool closeButton = true,
         bool closeOnEscapeKey = true,
-        bool backdropClick = true) =>
+        bool backdropClick = false) =>
         Task.FromResult(new DialogOptions
         {
             MaxWidth = desktopMaxWidth,

--- a/Pkmds.Rcl/Services/IDialogOptionsHelper.cs
+++ b/Pkmds.Rcl/Services/IDialogOptionsHelper.cs
@@ -30,5 +30,5 @@ public interface IDialogOptionsHelper
         bool fullWidth = true,
         bool closeButton = true,
         bool closeOnEscapeKey = true,
-        bool backdropClick = true);
+        bool backdropClick = false);
 }

--- a/Pkmds.Rcl/Services/LegalizationService.cs
+++ b/Pkmds.Rcl/Services/LegalizationService.cs
@@ -166,7 +166,7 @@ public sealed class LegalizationService : ILegalizationService
             if (ct.IsCancellationRequested)
             {
                 return new LegalizationOutcome(
-                    bestAttempt ?? BuildSetFallback(blank, set),
+                    bestAttempt ?? BuildSetFallback(blank, sav, set),
                     LegalizationStatus.Failed,
                     "Cancelled.");
             }
@@ -181,7 +181,7 @@ public sealed class LegalizationService : ILegalizationService
                 }
 
                 return new LegalizationOutcome(
-                    bestAttempt ?? BuildSetFallback(blank, set),
+                    bestAttempt ?? BuildSetFallback(blank, sav, set),
                     LegalizationStatus.Timeout,
                     $"Timed out after {timeoutSeconds}s ({attemptCount} encounters tried).");
             }
@@ -301,7 +301,7 @@ public sealed class LegalizationService : ILegalizationService
         }
 
         return new LegalizationOutcome(
-            bestAttempt ?? BuildSetFallback(blank, set),
+            bestAttempt ?? BuildSetFallback(blank, sav, set),
             LegalizationStatus.Failed,
             $"No legal result found after {attemptCount} encounters.");
     }
@@ -317,16 +317,22 @@ public sealed class LegalizationService : ILegalizationService
     /// BDSP) or when the moveset is unlearnable (so
     /// <see cref="EncounterMovesetGenerator.GenerateEncounters" /> yields zero
     /// candidates). The result is illegal but carries the user's requested
-    /// moves / item / nature / IVs, giving the caller a recognisable starting
+    /// moves / item / nature / IVs plus the save's trainer/language so it
+    /// renders correctly in the UI, giving the caller a recognisable starting
     /// point instead of a blank slot. Mirrors ALM's <c>last ?? template</c>
     /// fallback.
     /// </summary>
-    private static PKM BuildSetFallback(PKM blank, ShowdownSet set)
+    private static PKM BuildSetFallback(PKM blank, SaveFile sav, ShowdownSet set)
     {
         var pk = blank.Clone();
         pk.Species = set.Species;
         pk.Form = set.Form;
         pk.CurrentLevel = set.Level;
+        // Seed language + OT before ApplySetDetails so localized lookups (nickname,
+        // species name, etc.) resolve against the save's trainer instead of a zeroed
+        // blank. Matches the rebuild path's order at the top of the encounter loop.
+        pk.Language = sav.Language > 0 ? sav.Language : (int)LanguageID.English;
+        sav.ApplyTo(pk);
         pk.ApplySetDetails(set);
         return pk;
     }

--- a/Pkmds.Rcl/Services/LegalizationService.cs
+++ b/Pkmds.Rcl/Services/LegalizationService.cs
@@ -7,10 +7,12 @@ namespace Pkmds.Rcl.Services;
 /// In WASM, responsiveness comes from cooperative yielding (Task.Yield) inside the
 /// legalization loop rather than wrapping the work in Task.Run.
 /// </summary>
-public sealed class LegalizationService : ILegalizationService
+public sealed class LegalizationService(IAppState appState) : ILegalizationService
 {
     /// <summary>Default maximum wall-clock time (seconds) for a single legalization attempt.</summary>
     private const int DefaultTimeoutSeconds = 15;
+
+    private IAppState AppState { get; } = appState;
 
     public async Task<LegalizationOutcome> LegalizeAsync(
         PKM pk,
@@ -300,10 +302,114 @@ public sealed class LegalizationService : ILegalizationService
             return new LegalizationOutcome(bestFishyAttempt, LegalizationStatus.Success);
         }
 
+        // HaX retry: nothing legal survived. With HaX on, do a relaxed pass that bypasses
+        // IsEncounterValid (level filter is the usual culprit — e.g. Garchomp@15 in BDSP
+        // where every encounter has LevelMin > 15) and AllowIncompatibleConversion, and
+        // returns the first non-null produced PKM as SuccessHaX. Mirrors the existing HaX
+        // bypass at PokemonSlotComponent.razor.cs:485.
+        if (AppState.IsHaXEnabled)
+        {
+            var haxResult = TryHaXRetry(
+                set, sav, blank, destType, criteria, encounters, timer, timeoutSeconds, ct);
+            if (haxResult is not null)
+            {
+                return haxResult;
+            }
+        }
+
         return new LegalizationOutcome(
             bestAttempt ?? BuildSetFallback(blank, sav, set),
             LegalizationStatus.Failed,
             $"No legal result found after {attemptCount} encounters.");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  HaX retry path
+    // ──────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Relaxed retry used only when <see cref="IAppState.IsHaXEnabled" /> is true and the
+    /// normal loop produced no legal (or fishy-but-valid) result. Re-iterates the same
+    /// encounter sequence with two relaxations: <c>IsEncounterValid</c> is skipped (so
+    /// level-min mismatches no longer reject every encounter) and
+    /// <see cref="EntityConverter.AllowIncompatibleConversion" /> is set to
+    /// <see cref="EntityCompatibilitySetting.AllowIncompatibleAll" /> for the duration of
+    /// the retry. Returns the first PKM the pipeline produces, marked
+    /// <see cref="LegalizationStatus.SuccessHaX" />. Returns <c>null</c> if no encounter
+    /// survives even the relaxed pipeline (caller falls through to BuildSetFallback).
+    /// </summary>
+    private LegalizationOutcome? TryHaXRetry(
+        ShowdownSet set,
+        SaveFile sav,
+        PKM blank,
+        Type destType,
+        EncounterCriteria criteria,
+        IEnumerable<IEncounterable> encounters,
+        Stopwatch timer,
+        int timeoutSeconds,
+        CancellationToken ct)
+    {
+        var previous = EntityConverter.AllowIncompatibleConversion;
+        EntityConverter.AllowIncompatibleConversion = EntityCompatibilitySetting.AllowIncompatibleAll;
+        try
+        {
+            foreach (var enc in encounters)
+            {
+                if (ct.IsCancellationRequested || timer.Elapsed.TotalSeconds >= timeoutSeconds)
+                {
+                    return null;
+                }
+
+                try
+                {
+                    var adjustedCriteria = AdjustCriteriaForEncounter(criteria, enc, set);
+                    var raw = enc.ConvertToPKM(sav, adjustedCriteria);
+
+                    if (raw.OriginalTrainerName.Length == 0)
+                    {
+                        raw.Language = sav.Language;
+                        sav.ApplyTo(raw);
+                    }
+
+                    if (raw.IsEgg)
+                    {
+                        HatchEgg(raw, sav);
+                    }
+
+                    var pk = EntityConverter.ConvertToType(raw, destType, out _);
+                    if (pk is null)
+                    {
+                        continue;
+                    }
+
+                    pk.ApplySetDetails(set);
+                    // honourLevel: false → the user asked for set.Level explicitly. Skip the
+                    // CurrentLevel-up clamp inside ApplyPostGenerationFixes so e.g.
+                    // Garchomp@15 stays at 15 instead of being pushed up to the encounter's
+                    // LevelMin. MetLevel and ObedienceLevel are still kept ≤ CurrentLevel.
+                    ApplyPostGenerationFixes(pk, sav, enc, set, honourEncounterLevelMin: false);
+
+                    return new LegalizationOutcome(
+                        pk,
+                        LegalizationStatus.SuccessHaX,
+                        "Imported via HaX retry — illegal but populated.");
+                }
+                catch (OperationCanceledException)
+                {
+                    return null;
+                }
+                catch
+                {
+                    // Encounter conversion can throw for incompatible formats; skip silently.
+                }
+            }
+
+            return null;
+        }
+        finally
+        {
+            EntityConverter.AllowIncompatibleConversion = previous;
+        }
     }
 
     // ──────────────────────────────────────────────────────────────────────
@@ -760,11 +866,18 @@ public sealed class LegalizationService : ILegalizationService
     /// Applies fixes after <see cref="CommonEdits.ApplySetDetails" /> to ensure legality.
     /// Mirrors AppService.ApplyPostImportFixes + ALM's ApplySetDetails final tweaks.
     /// </summary>
+    /// <param name="honourEncounterLevelMin">
+    /// When <c>true</c> (the default), <c>CurrentLevel</c> is bumped up to
+    /// <see cref="IEncounterTemplate.LevelMin" /> if it sits below — required for vanilla
+    /// legality. The HaX retry passes <c>false</c> so the user's requested level is
+    /// preserved (Garchomp@15 stays at 15, accepted as illegal).
+    /// </param>
     private static void ApplyPostGenerationFixes(
         PKM pk,
         SaveFile sav,
         IEncounterable enc,
-        ShowdownSet set)
+        ShowdownSet set,
+        bool honourEncounterLevelMin = true)
     {
         // Restore event-specific properties that ApplySetDetails (or intermediate
         // conversions) may have trampled. enc.ConvertToPKM already set these once,
@@ -811,8 +924,8 @@ public sealed class LegalizationService : ILegalizationService
             }
         }
 
-        // Clamp level to encounter minimum.
-        if (pk.CurrentLevel < enc.LevelMin)
+        // Clamp level to encounter minimum (skipped in HaX retry — see XML doc).
+        if (honourEncounterLevelMin && pk.CurrentLevel < enc.LevelMin)
         {
             pk.CurrentLevel = enc.LevelMin;
         }

--- a/Pkmds.Rcl/Services/LegalizationService.cs
+++ b/Pkmds.Rcl/Services/LegalizationService.cs
@@ -352,91 +352,97 @@ public sealed class LegalizationService(IAppState appState) : ILegalizationServi
         CancellationToken ct)
     {
         var blank = sav.BlankPKM;
-        var previous = EntityConverter.AllowIncompatibleConversion;
-        EntityConverter.AllowIncompatibleConversion = EntityCompatibilitySetting.AllowIncompatibleAll;
-        try
+        foreach (var enc in encounters)
         {
-            foreach (var enc in encounters)
+            if (ct.IsCancellationRequested)
             {
-                if (ct.IsCancellationRequested)
-                {
-                    return new LegalizationOutcome(
-                        BuildSetFallback(blank, sav, set),
-                        LegalizationStatus.Failed,
-                        "Cancelled.");
-                }
-
-                if (timer.Elapsed.TotalSeconds >= timeoutSeconds)
-                {
-                    return new LegalizationOutcome(
-                        BuildSetFallback(blank, sav, set),
-                        LegalizationStatus.Timeout,
-                        $"Timed out after {timeoutSeconds}s during HaX retry.");
-                }
-
-                // Yield to the browser event loop per encounter (each is expensive). Match
-                // the main loop's pattern — Task.Delay(1), not Task.Yield, so the JS
-                // setTimeout actually releases the main thread.
-                if (async)
-                {
-                    await Task.Delay(1, ct);
-                }
-
-                try
-                {
-                    var adjustedCriteria = AdjustCriteriaForEncounter(criteria, enc, set);
-                    var raw = enc.ConvertToPKM(sav, adjustedCriteria);
-
-                    if (raw.OriginalTrainerName.Length == 0)
-                    {
-                        raw.Language = sav.Language > 0 ? sav.Language : (int)LanguageID.English;
-                        sav.ApplyTo(raw);
-                    }
-
-                    if (raw.IsEgg)
-                    {
-                        HatchEgg(raw, sav);
-                    }
-
-                    var pk = EntityConverter.ConvertToType(raw, destType, out _);
-                    if (pk is null)
-                    {
-                        continue;
-                    }
-
-                    pk.ApplySetDetails(set);
-                    // honourEncounterLevelMin: false → the user asked for set.Level
-                    // explicitly. Skip the CurrentLevel-up clamp inside
-                    // ApplyPostGenerationFixes so e.g. Garchomp@15 stays at 15 instead of
-                    // being pushed up to the encounter's LevelMin. MetLevel and
-                    // ObedienceLevel are still kept ≤ CurrentLevel.
-                    ApplyPostGenerationFixes(pk, sav, enc, set, honourEncounterLevelMin: false);
-                    pk.RefreshChecksum();
-
-                    return new LegalizationOutcome(
-                        pk,
-                        LegalizationStatus.SuccessHaX,
-                        "Imported via HaX retry — illegal but populated.");
-                }
-                catch (OperationCanceledException)
-                {
-                    return new LegalizationOutcome(
-                        BuildSetFallback(blank, sav, set),
-                        LegalizationStatus.Failed,
-                        "Cancelled.");
-                }
-                catch
-                {
-                    // Encounter conversion can throw for incompatible formats; skip silently.
-                }
+                return new LegalizationOutcome(
+                    BuildSetFallback(blank, sav, set),
+                    LegalizationStatus.Failed,
+                    "Cancelled.");
             }
 
-            return null;
+            if (timer.Elapsed.TotalSeconds >= timeoutSeconds)
+            {
+                return new LegalizationOutcome(
+                    BuildSetFallback(blank, sav, set),
+                    LegalizationStatus.Timeout,
+                    $"Timed out after {timeoutSeconds}s during HaX retry.");
+            }
+
+            // Yield to the browser event loop per encounter (each is expensive). Match
+            // the main loop's pattern — Task.Delay(1), not Task.Yield, so the JS
+            // setTimeout actually releases the main thread.
+            if (async)
+            {
+                await Task.Delay(1, ct);
+            }
+
+            try
+            {
+                var adjustedCriteria = AdjustCriteriaForEncounter(criteria, enc, set);
+                var raw = enc.ConvertToPKM(sav, adjustedCriteria);
+
+                if (raw.OriginalTrainerName.Length == 0)
+                {
+                    raw.Language = sav.Language > 0 ? sav.Language : (int)LanguageID.English;
+                    sav.ApplyTo(raw);
+                }
+
+                if (raw.IsEgg)
+                {
+                    HatchEgg(raw, sav);
+                }
+
+                // EntityConverter.AllowIncompatibleConversion is a global static. Scope
+                // the relaxed setting to *only* the ConvertToType call so the cooperative
+                // await above (and any other concurrent async work on the WASM thread)
+                // never observes HaX conversion mode unintentionally.
+                PKM? pk;
+                var previous = EntityConverter.AllowIncompatibleConversion;
+                EntityConverter.AllowIncompatibleConversion = EntityCompatibilitySetting.AllowIncompatibleAll;
+                try
+                {
+                    pk = EntityConverter.ConvertToType(raw, destType, out _);
+                }
+                finally
+                {
+                    EntityConverter.AllowIncompatibleConversion = previous;
+                }
+
+                if (pk is null)
+                {
+                    continue;
+                }
+
+                pk.ApplySetDetails(set);
+                // honourEncounterLevelMin: false → the user asked for set.Level
+                // explicitly. Skip the CurrentLevel-up clamp inside
+                // ApplyPostGenerationFixes so e.g. Garchomp@15 stays at 15 instead of
+                // being pushed up to the encounter's LevelMin. MetLevel and
+                // ObedienceLevel are still kept ≤ CurrentLevel.
+                ApplyPostGenerationFixes(pk, sav, enc, set, honourEncounterLevelMin: false);
+                pk.RefreshChecksum();
+
+                return new LegalizationOutcome(
+                    pk,
+                    LegalizationStatus.SuccessHaX,
+                    "Imported via HaX retry — illegal but populated.");
+            }
+            catch (OperationCanceledException)
+            {
+                return new LegalizationOutcome(
+                    BuildSetFallback(blank, sav, set),
+                    LegalizationStatus.Failed,
+                    "Cancelled.");
+            }
+            catch
+            {
+                // Encounter conversion can throw for incompatible formats; skip silently.
+            }
         }
-        finally
-        {
-            EntityConverter.AllowIncompatibleConversion = previous;
-        }
+
+        return null;
     }
 
     // ──────────────────────────────────────────────────────────────────────

--- a/Pkmds.Rcl/Services/LegalizationService.cs
+++ b/Pkmds.Rcl/Services/LegalizationService.cs
@@ -309,8 +309,8 @@ public sealed class LegalizationService(IAppState appState) : ILegalizationServi
         // bypass at PokemonSlotComponent.razor.cs:485.
         if (AppState.IsHaXEnabled)
         {
-            var haxResult = TryHaXRetry(
-                set, sav, blank, destType, criteria, encounters, timer, timeoutSeconds, ct);
+            var haxResult = await TryHaXRetry(
+                set, sav, destType, criteria, encounters, timer, timeoutSeconds, async, ct);
             if (haxResult is not null)
             {
                 return haxResult;
@@ -335,29 +335,51 @@ public sealed class LegalizationService(IAppState appState) : ILegalizationServi
     /// <see cref="EntityConverter.AllowIncompatibleConversion" /> is set to
     /// <see cref="EntityCompatibilitySetting.AllowIncompatibleAll" /> for the duration of
     /// the retry. Returns the first PKM the pipeline produces, marked
-    /// <see cref="LegalizationStatus.SuccessHaX" />. Returns <c>null</c> if no encounter
-    /// survives even the relaxed pipeline (caller falls through to BuildSetFallback).
+    /// <see cref="LegalizationStatus.SuccessHaX" />. Yields cooperatively per encounter in
+    /// async mode so the WASM main thread stays responsive. Returns a Timeout / Failed-Cancelled
+    /// outcome on timer elapse / cancellation, or <c>null</c> when the encounter pool is
+    /// exhausted without a survivor (caller falls through to BuildSetFallback).
     /// </summary>
-    private LegalizationOutcome? TryHaXRetry(
+    private async Task<LegalizationOutcome?> TryHaXRetry(
         ShowdownSet set,
         SaveFile sav,
-        PKM blank,
         Type destType,
         EncounterCriteria criteria,
         IEnumerable<IEncounterable> encounters,
         Stopwatch timer,
         int timeoutSeconds,
+        bool async,
         CancellationToken ct)
     {
+        var blank = sav.BlankPKM;
         var previous = EntityConverter.AllowIncompatibleConversion;
         EntityConverter.AllowIncompatibleConversion = EntityCompatibilitySetting.AllowIncompatibleAll;
         try
         {
             foreach (var enc in encounters)
             {
-                if (ct.IsCancellationRequested || timer.Elapsed.TotalSeconds >= timeoutSeconds)
+                if (ct.IsCancellationRequested)
                 {
-                    return null;
+                    return new LegalizationOutcome(
+                        BuildSetFallback(blank, sav, set),
+                        LegalizationStatus.Failed,
+                        "Cancelled.");
+                }
+
+                if (timer.Elapsed.TotalSeconds >= timeoutSeconds)
+                {
+                    return new LegalizationOutcome(
+                        BuildSetFallback(blank, sav, set),
+                        LegalizationStatus.Timeout,
+                        $"Timed out after {timeoutSeconds}s during HaX retry.");
+                }
+
+                // Yield to the browser event loop per encounter (each is expensive). Match
+                // the main loop's pattern — Task.Delay(1), not Task.Yield, so the JS
+                // setTimeout actually releases the main thread.
+                if (async)
+                {
+                    await Task.Delay(1, ct);
                 }
 
                 try
@@ -367,7 +389,7 @@ public sealed class LegalizationService(IAppState appState) : ILegalizationServi
 
                     if (raw.OriginalTrainerName.Length == 0)
                     {
-                        raw.Language = sav.Language;
+                        raw.Language = sav.Language > 0 ? sav.Language : (int)LanguageID.English;
                         sav.ApplyTo(raw);
                     }
 
@@ -383,11 +405,13 @@ public sealed class LegalizationService(IAppState appState) : ILegalizationServi
                     }
 
                     pk.ApplySetDetails(set);
-                    // honourLevel: false → the user asked for set.Level explicitly. Skip the
-                    // CurrentLevel-up clamp inside ApplyPostGenerationFixes so e.g.
-                    // Garchomp@15 stays at 15 instead of being pushed up to the encounter's
-                    // LevelMin. MetLevel and ObedienceLevel are still kept ≤ CurrentLevel.
+                    // honourEncounterLevelMin: false → the user asked for set.Level
+                    // explicitly. Skip the CurrentLevel-up clamp inside
+                    // ApplyPostGenerationFixes so e.g. Garchomp@15 stays at 15 instead of
+                    // being pushed up to the encounter's LevelMin. MetLevel and
+                    // ObedienceLevel are still kept ≤ CurrentLevel.
                     ApplyPostGenerationFixes(pk, sav, enc, set, honourEncounterLevelMin: false);
+                    pk.RefreshChecksum();
 
                     return new LegalizationOutcome(
                         pk,
@@ -396,7 +420,10 @@ public sealed class LegalizationService(IAppState appState) : ILegalizationServi
                 }
                 catch (OperationCanceledException)
                 {
-                    return null;
+                    return new LegalizationOutcome(
+                        BuildSetFallback(blank, sav, set),
+                        LegalizationStatus.Failed,
+                        "Cancelled.");
                 }
                 catch
                 {
@@ -440,6 +467,25 @@ public sealed class LegalizationService(IAppState appState) : ILegalizationServi
         pk.Language = sav.Language > 0 ? sav.Language : (int)LanguageID.English;
         sav.ApplyTo(pk);
         pk.ApplySetDetails(set);
+
+        // ApplyPostGenerationFixes is intentionally NOT run on the fallback path (no
+        // encounter ⇒ no encounter-aware fixes to apply), but the nickname/trash-byte
+        // seeding still matters here. Without these two lines, a Gen 7b / Gen 8+
+        // nicknamed import like "Garchy (Garchomp)" against a BDSP save (where every
+        // encounter is rejected by IsEncounterValid) lands with a zeroed NicknameTrash
+        // buffer and the legality report flags it "Fishy: Expected Trash Bytes."
+        if (string.IsNullOrEmpty(pk.Nickname))
+        {
+            pk.SetDefaultNickname();
+        }
+
+        if ((pk.Format >= 8 || pk.Context == EntityContext.Gen7b) && pk.IsNicknamed)
+        {
+            var speciesName = SpeciesName.GetSpeciesNameGeneration(pk.Species, pk.Language, pk.Format);
+            StringConverter8.ApplyTrashBytes(pk.NicknameTrash, speciesName);
+        }
+
+        pk.RefreshChecksum();
         return pk;
     }
 

--- a/Pkmds.Tests/AdvancedSearchTests.cs
+++ b/Pkmds.Tests/AdvancedSearchTests.cs
@@ -17,7 +17,7 @@ public class AdvancedSearchTests
         var data = File.ReadAllBytes(filePath);
         SaveUtil.TryGetSaveFile(data, out var saveFile, fileName).Should().BeTrue();
         var appState = new TestAppState { SaveFile = saveFile };
-        var service = new AppService(appState, new TestRefreshService(), new LegalizationService());
+        var service = new AppService(appState, new TestRefreshService(), new LegalizationService(appState));
         return (service, saveFile!);
     }
 

--- a/Pkmds.Tests/AppServiceTests.cs
+++ b/Pkmds.Tests/AppServiceTests.cs
@@ -17,7 +17,7 @@ public class AppServiceTests
 
         var appState = new TestAppState();
         var refreshService = new TestRefreshService();
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         // Act
         var fileName = appService.GetCleanFileName(pokemon!);
@@ -32,7 +32,7 @@ public class AppServiceTests
         // Arrange
         var appState = new TestAppState();
         var refreshService = new TestRefreshService();
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         // Act
         var result = appService.GetStatModifierString(Nature.Hardy);
@@ -47,7 +47,7 @@ public class AppServiceTests
         // Arrange
         var appState = new TestAppState();
         var refreshService = new TestRefreshService();
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         // Act - Bold: +Def, -Atk
         var result = appService.GetStatModifierString(Nature.Bold);
@@ -70,7 +70,7 @@ public class AppServiceTests
         var data = File.ReadAllBytes(filePath);
         FileUtil.TryGetPKM(data, out var pokemon, ".pk5").Should().BeTrue();
 
-        var appService = new AppService(appState, refreshService, new LegalizationService()) { EditFormPokemon = pokemon };
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState)) { EditFormPokemon = pokemon };
 
         // Act
         appService.ClearSelection();
@@ -89,7 +89,7 @@ public class AppServiceTests
         // Arrange
         var appState = new TestAppState { SelectedPartySlotNumber = 0 };
         var refreshService = new TestRefreshService();
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         // Act
         var result = appService.GetSelectedPokemonSlot(out var partySlot, out var boxNumber, out var boxSlot);
@@ -111,7 +111,7 @@ public class AppServiceTests
 
         var appState = new TestAppState();
         var refreshService = new TestRefreshService();
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         // Act
         var showdown = appService.ExportPokemonAsShowdown(pokemon);
@@ -127,7 +127,7 @@ public class AppServiceTests
         // Arrange
         var appState = new TestAppState();
         var refreshService = new TestRefreshService();
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         // Act
         var showdown = appService.ExportPokemonAsShowdown(null);
@@ -146,7 +146,7 @@ public class AppServiceTests
 
         var appState = new TestAppState { SaveFile = saveFile };
         var refreshService = new TestRefreshService();
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         // Act
         var showdown = appService.ExportPartyAsShowdown();
@@ -161,7 +161,7 @@ public class AppServiceTests
         // Arrange
         var appState = new TestAppState { SaveFile = null };
         var refreshService = new TestRefreshService();
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         // Act
         var showdown = appService.ExportPartyAsShowdown();
@@ -181,7 +181,7 @@ public class AppServiceTests
 
         var appState = new TestAppState { SaveFile = saveFile };
         var refreshService = new TestRefreshService();
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         // Act
         appService.SetSelectedBoxPokemon(null, 0, 0);
@@ -202,7 +202,7 @@ public class AppServiceTests
 
         var appState = new TestAppState { SaveFile = saveFile };
         var refreshService = new TestRefreshService();
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         // A PKM with Species=0 represents an empty slot; the template should be applied.
         var emptySlot = saveFile!.BlankPKM;
@@ -222,7 +222,7 @@ public class AppServiceTests
         // Arrange
         var appState = new TestAppState();
         var refreshService = new TestRefreshService();
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         // Act
         var result = appService.GetConsoleRegionComboItems();
@@ -244,7 +244,7 @@ public class AppServiceTests
         // Arrange
         var appState = new TestAppState { SaveFile = null };
         var refreshService = new TestRefreshService();
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         // Act
         var result = appService.TrySelectFirstEmptyBoxSlot();
@@ -275,7 +275,7 @@ public class AppServiceTests
 
         var appState = new TestAppState { SaveFile = saveFile };
         var refreshService = new TestRefreshService();
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         // Act
         var result = appService.TrySelectFirstEmptyBoxSlot();
@@ -308,7 +308,7 @@ public class AppServiceTests
 
         var appState = new TestAppState { SaveFile = saveFile };
         var refreshService = new TestRefreshService();
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         // Act
         var result = appService.TrySelectFirstEmptyBoxSlot();
@@ -343,7 +343,7 @@ public class AppServiceTests
 
         var appState = new TestAppState { SaveFile = saveFile };
         var refreshService = new TestRefreshService();
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         // Act
         var result = appService.TrySelectFirstEmptyBoxSlot();
@@ -359,7 +359,7 @@ public class AppServiceTests
     public void HasWonderCardSlots_NoSaveLoaded_ReturnsFalse()
     {
         var appState = new TestAppState { SaveFile = null };
-        var appService = new AppService(appState, new TestRefreshService(), new LegalizationService());
+        var appService = new AppService(appState, new TestRefreshService(), new LegalizationService(appState));
 
         appService.HasWonderCardSlots().Should().BeFalse();
         appService.GetWonderCardSlots().Should().BeEmpty();
@@ -374,7 +374,7 @@ public class AppServiceTests
         SaveUtil.TryGetSaveFile(data, out var saveFile, "POKEMON RUBY_AXVE-0.sav").Should().BeTrue();
 
         var appState = new TestAppState { SaveFile = saveFile };
-        var appService = new AppService(appState, new TestRefreshService(), new LegalizationService());
+        var appService = new AppService(appState, new TestRefreshService(), new LegalizationService(appState));
 
         appService.HasWonderCardSlots().Should().BeFalse();
         appService.GetWonderCardSlots().Should().BeEmpty();
@@ -389,7 +389,7 @@ public class AppServiceTests
         saveFile.Should().BeOfType<SAV3E>();
 
         var appState = new TestAppState { SaveFile = saveFile };
-        var appService = new AppService(appState, new TestRefreshService(), new LegalizationService());
+        var appService = new AppService(appState, new TestRefreshService(), new LegalizationService(appState));
 
         appService.HasWonderCardSlots().Should().BeTrue();
 
@@ -414,7 +414,7 @@ public class AppServiceTests
         SaveUtil.TryGetSaveFile(data, out var saveFile, "Black - Full Completion.sav").Should().BeTrue();
 
         var appState = new TestAppState { SaveFile = saveFile };
-        var appService = new AppService(appState, new TestRefreshService(), new LegalizationService());
+        var appService = new AppService(appState, new TestRefreshService(), new LegalizationService(appState));
 
         appService.HasWonderCardSlots().Should().BeTrue();
 
@@ -437,7 +437,7 @@ public class AppServiceTests
         saveFile.Should().BeOfType<SAV7b>();
 
         var appState = new TestAppState { SaveFile = saveFile };
-        var appService = new AppService(appState, new TestRefreshService(), new LegalizationService());
+        var appService = new AppService(appState, new TestRefreshService(), new LegalizationService(appState));
 
         appService.HasWonderCardSlots().Should().BeTrue();
 

--- a/Pkmds.Tests/BattleTeamTests.cs
+++ b/Pkmds.Tests/BattleTeamTests.cs
@@ -13,7 +13,7 @@ public class BattleTeamTests
     public void HasBattleTeams_Gen7Save_ReturnsTrue()
     {
         var (_, appState, refreshService, _) = BunitTestHelpers.LoadSave("moon.sav");
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         appService.HasBattleTeams().Should().BeTrue();
     }
@@ -22,7 +22,7 @@ public class BattleTeamTests
     public void HasBattleTeams_Gen5Save_ReturnsFalse()
     {
         var (_, appState, refreshService, _) = BunitTestHelpers.LoadSave("Black - Full Completion.sav");
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         appService.HasBattleTeams().Should().BeFalse();
     }
@@ -31,7 +31,7 @@ public class BattleTeamTests
     public void HasBattleBox_Gen5Save_ReturnsTrue()
     {
         var (_, appState, refreshService, _) = BunitTestHelpers.LoadSave("Black - Full Completion.sav");
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         appService.HasBattleBox().Should().BeTrue();
     }
@@ -40,7 +40,7 @@ public class BattleTeamTests
     public void HasBattleBox_Gen7Save_ReturnsFalse()
     {
         var (_, appState, refreshService, _) = BunitTestHelpers.LoadSave("moon.sav");
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         appService.HasBattleBox().Should().BeFalse();
     }
@@ -51,7 +51,7 @@ public class BattleTeamTests
         // Arrange — load a Gen 7 save and place Pokémon in box slots
         var (saveFile, appState, refreshService, _) = BunitTestHelpers.LoadSave("moon.sav");
         var sav7 = (SAV7)saveFile;
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         // Place 3 Pokémon in box 0, slots 0–2
         var species = new ushort[] { 25, 133, 150 }; // Pikachu, Eevee, Mewtwo
@@ -87,7 +87,7 @@ public class BattleTeamTests
     {
         var (saveFile, appState, refreshService, _) = BunitTestHelpers.LoadSave("moon.sav");
         var sav7 = (SAV7)saveFile;
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         // Clear team 1 (all slots = -1)
         for (var i = 6; i < 12; i++)
@@ -105,7 +105,7 @@ public class BattleTeamTests
     public void IsBattleTeamLocked_Gen7_DefaultUnlocked()
     {
         var (_, appState, refreshService, _) = BunitTestHelpers.LoadSave("moon.sav");
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         for (var i = 0; i < 6; i++)
         {
@@ -117,7 +117,7 @@ public class BattleTeamTests
     public void SetBattleTeamLocked_Gen7_TogglesLockState()
     {
         var (_, appState, refreshService, _) = BunitTestHelpers.LoadSave("moon.sav");
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         // Lock team 2
         appService.SetBattleTeamLocked(2, true);
@@ -134,7 +134,7 @@ public class BattleTeamTests
         // Arrange
         var (saveFile, appState, refreshService, _) = BunitTestHelpers.LoadSave("moon.sav");
         var sav7 = (SAV7)saveFile;
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         // Place a Pikachu in box 0 slot 0
         var pkm = sav7.BlankPKM;
@@ -165,7 +165,7 @@ public class BattleTeamTests
         // Arrange
         var (saveFile, appState, refreshService, _) = BunitTestHelpers.LoadSave("moon.sav");
         var sav7 = (SAV7)saveFile;
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         // Place Pokémon in box 0
         var pkm1 = sav7.BlankPKM;
@@ -208,7 +208,7 @@ public class BattleTeamTests
     public void HasBattleTeams_Gen8Shield_ReturnsTrue()
     {
         var (_, appState, refreshService, _) = BunitTestHelpers.LoadSave("Test-Save-Shield.sav");
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         appService.HasBattleTeams().Should().BeTrue();
     }
@@ -218,7 +218,7 @@ public class BattleTeamTests
     {
         var appState = new TestAppState { SaveFile = null };
         var refreshService = new TestRefreshService();
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         var team = appService.GetBattleTeamPokemon(0);
         team.Should().BeEmpty();
@@ -229,7 +229,7 @@ public class BattleTeamTests
     {
         var appState = new TestAppState { SaveFile = null };
         var refreshService = new TestRefreshService();
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         var result = appService.GetBattleBoxPokemon();
         result.Should().BeEmpty();
@@ -239,7 +239,7 @@ public class BattleTeamTests
     public void HasRentalTeams_Gen7Save_ReturnsFalse()
     {
         var (_, appState, refreshService, _) = BunitTestHelpers.LoadSave("moon.sav");
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         appService.HasRentalTeams().Should().BeFalse();
     }
@@ -248,7 +248,7 @@ public class BattleTeamTests
     public void HasRentalTeams_Gen8Shield_ReturnsTrue()
     {
         var (_, appState, refreshService, _) = BunitTestHelpers.LoadSave("Test-Save-Shield.sav");
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         appService.HasRentalTeams().Should().BeTrue();
     }
@@ -257,7 +257,7 @@ public class BattleTeamTests
     public void GetBattleTeamName_Gen7_ReturnsDefaultName()
     {
         var (_, appState, refreshService, _) = BunitTestHelpers.LoadSave("moon.sav");
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         // Gen 7 doesn't have custom team names — falls through to default
         var name = appService.GetBattleTeamName(0);
@@ -269,7 +269,7 @@ public class BattleTeamTests
     {
         var appState = new TestAppState();
         var refreshService = new TestRefreshService();
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         var showdown = appService.ExportTeamAsShowdown([]);
         showdown.Should().BeEmpty();
@@ -280,7 +280,7 @@ public class BattleTeamTests
     {
         var (saveFile, appState, refreshService, _) = BunitTestHelpers.LoadSave("moon.sav");
         var sav7 = (SAV7)saveFile;
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         var pkm = sav7.BlankPKM;
         pkm.Species = 25;
@@ -304,7 +304,7 @@ public class BattleTeamTests
     {
         var (saveFile, appState, refreshService, _) = BunitTestHelpers.LoadSave("moon.sav");
         var sav7 = (SAV7)saveFile;
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         var pkm1 = sav7.BlankPKM;
         pkm1.Species = 6;
@@ -340,7 +340,7 @@ public class BattleTeamTests
     {
         var (saveFile, appState, refreshService, _) = BunitTestHelpers.LoadSave("moon.sav");
         var sav7 = (SAV7)saveFile;
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         var pkm = sav7.BlankPKM;
         pkm.Species = 25;
@@ -367,7 +367,7 @@ public class BattleTeamTests
     public void UnlockAllBattleTeams_Gen7_UnlocksAllTeams()
     {
         var (_, appState, refreshService, _) = BunitTestHelpers.LoadSave("moon.sav");
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         appService.SetBattleTeamLocked(0, true);
         appService.SetBattleTeamLocked(2, true);
@@ -385,7 +385,7 @@ public class BattleTeamTests
     public void HasBattleBox_Gen6XY_ReturnsTrue()
     {
         var (_, appState, refreshService, _) = BunitTestHelpers.LoadSave("x.sav");
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         appService.HasBattleBox().Should().BeTrue();
     }
@@ -394,7 +394,7 @@ public class BattleTeamTests
     public void SetBattleBoxLocked_Gen5_TogglesLockState()
     {
         var (_, appState, refreshService, _) = BunitTestHelpers.LoadSave("Black - Full Completion.sav");
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         appService.SetBattleBoxLocked(true);
         appService.IsBattleBoxLocked().Should().BeTrue();

--- a/Pkmds.Tests/BoxManagementTests.cs
+++ b/Pkmds.Tests/BoxManagementTests.cs
@@ -13,7 +13,7 @@ public class BoxManagementTests
         // Arrange
         var appState = new TestAppState { SaveFile = null };
         var refreshService = new TestRefreshService();
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         // Act
         var result = appService.SwapBoxes(0, 1);
@@ -32,7 +32,7 @@ public class BoxManagementTests
 
         var appState = new TestAppState { SaveFile = saveFile };
         var refreshService = new TestRefreshService();
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         // Snapshot all slots in box 0 and box 1 before the swap
         var slotCount = saveFile!.BoxSlotCount;
@@ -68,7 +68,7 @@ public class BoxManagementTests
 
         var appState = new TestAppState { SaveFile = saveFile };
         var refreshService = new TestRefreshService();
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
 
         var slotCount = saveFile!.BoxSlotCount;
         var box0Before = Enumerable.Range(0, slotCount)

--- a/Pkmds.Tests/BunitTestHelpers.cs
+++ b/Pkmds.Tests/BunitTestHelpers.cs
@@ -28,7 +28,7 @@ internal static class BunitTestHelpers
         ParseSettings.InitFromSaveFileData(saveFile!);
         var appState = new TestAppState { SaveFile = saveFile };
         var refreshService = new TestRefreshService();
-        var appService = new AppService(appState, refreshService, new LegalizationService());
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
         return (saveFile!, appState, refreshService, appService);
     }
 

--- a/Pkmds.Tests/EncounterDatabaseTests.cs
+++ b/Pkmds.Tests/EncounterDatabaseTests.cs
@@ -18,7 +18,7 @@ public class EncounterDatabaseTests
         SaveUtil.TryGetSaveFile(data, out var saveFile, fileName).Should().BeTrue();
         LocalizeUtil.InitializeStrings(GameLanguage.DefaultLanguage, saveFile);
         var appState = new TestAppState { SaveFile = saveFile };
-        var service = new AppService(appState, new TestRefreshService(), new LegalizationService());
+        var service = new AppService(appState, new TestRefreshService(), new LegalizationService(appState));
         return service;
     }
 

--- a/Pkmds.Tests/EvolveTests.cs
+++ b/Pkmds.Tests/EvolveTests.cs
@@ -11,7 +11,7 @@ public class EvolveTests
     private static AppService CreateService(SaveFile? saveFile = null)
     {
         var appState = new TestAppState { SaveFile = saveFile };
-        return new AppService(appState, new TestRefreshService(), new LegalizationService());
+        return new AppService(appState, new TestRefreshService(), new LegalizationService(appState));
     }
 
     /// <summary>Creates a Gen 6 PK6 with the given species.</summary>

--- a/Pkmds.Tests/LegalityCheckerTests.cs
+++ b/Pkmds.Tests/LegalityCheckerTests.cs
@@ -16,7 +16,7 @@ public class LegalityCheckerTests
         var data = File.ReadAllBytes(Path.Combine(TestFilesPath, fileName));
         SaveUtil.TryGetSaveFile(data, out var saveFile, fileName).Should().BeTrue();
         var appState = new TestAppState { SaveFile = saveFile };
-        return (new AppService(appState, new TestRefreshService(), new LegalizationService()), saveFile!);
+        return (new AppService(appState, new TestRefreshService(), new LegalizationService(appState)), saveFile!);
     }
 
     private static PKM LoadPkm(string fileName)
@@ -67,7 +67,8 @@ public class LegalityCheckerTests
         pkm.AbilityNumber = 4; // Hidden Ability — illegal for this specific event Lucario
         pkm.RefreshChecksum();
 
-        var service = new AppService(new TestAppState(), new TestRefreshService(), new LegalizationService());
+        var localAppState = new TestAppState();
+        var service = new AppService(localAppState, new TestRefreshService(), new LegalizationService(localAppState));
         var la = service.GetLegalityAnalysis(pkm);
 
         la.Results.Any(r => !r.Valid && r.Identifier == CheckIdentifier.Ability)
@@ -182,7 +183,7 @@ public class LegalityCheckerTests
         ParseSettings.InitFromSaveFileData(saveFile!);
 
         var appState = new TestAppState { SaveFile = saveFile };
-        var service = new AppService(appState, new TestRefreshService(), new LegalizationService());
+        var service = new AppService(appState, new TestRefreshService(), new LegalizationService(appState));
 
         // Pick any non-empty party slot
         PKM? pkm = null;


### PR DESCRIPTION
## Summary

Four commits since #861 merged. Mix of issue work and review-driven follow-ups.

- **#859 — HaX retry path for failed Showdown imports.** When the normal legalization loop exhausts every encounter without producing a legal (or fishy-but-valid) result, `LegalizationService` now consults `AppState.IsHaXEnabled` and runs a relaxed retry: `IsEncounterValid` is bypassed (so level-min mismatches don't reject the whole pool — Garchomp@15 in BDSP can finally find a candidate), `EntityConverter.AllowIncompatibleConversion` is set to `AllowIncompatibleAll` for the duration of the retry, and `ApplyPostGenerationFixes` runs with `honourEncounterLevelMin: false` so the user's requested level survives. First produced PKM returns as new `LegalizationStatus.SuccessHaX`. `LegalityTab` invokes `OnPokemonLegalized` for the new state and shows a Warning snackbar; batch callers (`LegalityReportTab`, `PokemonStorageComponent`) keep their `!= Success` skip — batch "make legal" shouldn't write illegal results to slots. Mirrors the existing HaX bypass at `PokemonSlotComponent.razor.cs:485`.
- **PR-review follow-up to #861.** `BuildSetFallback` now also seeds `Language` (English fallback when `sav.Language` is 0) and calls `sav.ApplyTo(pk)` for OT name / TID-SID / OT gender / Version / region origin before `ApplySetDetails`. Without this the "best-effort" fallback rendered with a blank trainer and broken localized name lookups.
- **Delete + click-another-slot no longer prompts about unsaved changes.** `DeletePokemon` cleared the slot and the selection but left `EditFormPokemon` and `editFormBaselineBytes` pointing at the now-deleted PKM, so `EditFormHasUnsavedChanges` still saw the form's pre-delete edits as "unsaved." Both delete paths now clear `EditFormPokemon` (the setter nulls the baseline).
- **Dialog backdrop dismissal off by default.** `DialogOptionsHelper.BuildAsync` defaulted `backdropClick=true` (matching MudBlazor's own default), so a stray page-background click would dismiss any dialog opened through the helper — easy to do accidentally on the PokePaste import flow and lose a parsed-but-not-yet-imported team. Flipped to `backdropClick=false`; opt-in per-dialog.

## Test plan

- [ ] Load a BDSP save with HaX **on**. Import the Garchomp@Lv15 set from #858 — should land a Garchomp at Level 15 (illegal but with the requested moves/item), Warning snackbar saying "Imported via HaX retry — illegal but populated." Same set with HaX **off** should still surface the yellow "1 could not be placed" warning.
- [ ] Same save, HaX on, legalize an existing illegal Pokémon via the Legality tab where no legal encounter exists — verify it lands the populated SuccessHaX result and shows the Warning snackbar.
- [x] Edit a Pokémon in the slot editor, click Delete, confirm in the dialog, then click another slot. Should switch slots cleanly with **no** "unsaved changes" prompt.
- [x] Open the PokePaste import dialog, paste a team, then click outside the dialog onto the page background. Dialog should **stay open** (Escape key and the X still close it).
- [x] Spot-check a couple of other dialogs (Settings, About, Save File Info) — backdrop click should also no longer dismiss them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)