### PR TITLE
feat(gen3): add RTC editor for Ruby/Sapphire/Emerald

### DIFF
--- a/Pkmds.Rcl/Components/MainTabPages/RtcTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/RtcTab.razor
@@ -1,0 +1,143 @@
+@inherits RefreshAwareComponent
+
+@if (saveBlock is null)
+{
+    <MudAlert Severity="@Severity.Info"
+              Variant="@Variant.Outlined">
+        The RTC editor is only available for Ruby/Sapphire and Emerald saves.
+    </MudAlert>
+}
+else
+{
+    <MudStack Spacing="3">
+        <MudText Typo="@Typo.h5">
+            Real Time Clock
+        </MudText>
+
+        <MudAlert Severity="@Severity.Warning"
+                  Variant="@Variant.Outlined"
+                  Icon="@Icons.Material.Filled.Warning">
+            Editing the RTC changes time-based events in-game (berry growth, Shoal Cave tides, Mirage Island).
+            Save a backup from the <strong>Backups</strong> menu before applying changes.
+        </MudAlert>
+
+        <MudPaper Class="pa-4"
+                  Outlined>
+            <MudStack Spacing="2">
+                <MudText Typo="@Typo.h6">Initial Clock</MudText>
+                <MudText Typo="@Typo.body2"
+                         Color="@Color.Tertiary">
+                    The clock value when the in-game time was first set.
+                </MudText>
+                <div class="form-grid">
+                    <div class="form-field">
+                        <MudNumericField Label="Days"
+                                         T="@int"
+                                         Variant="@Variant.Outlined"
+                                         Min="0"
+                                         Max="@MaxDays"
+                                         @bind-Value="@initialDay"/>
+                    </div>
+                    <div class="form-field">
+                        <MudNumericField Label="Hours"
+                                         T="@int"
+                                         Variant="@Variant.Outlined"
+                                         Min="0"
+                                         Max="@MaxHours"
+                                         @bind-Value="@initialHour"/>
+                    </div>
+                    <div class="form-field">
+                        <MudNumericField Label="Minutes"
+                                         T="@int"
+                                         Variant="@Variant.Outlined"
+                                         Min="@Constants.MinMinutes"
+                                         Max="@Constants.MaxMinutes"
+                                         @bind-Value="@initialMinute"/>
+                    </div>
+                    <div class="form-field">
+                        <MudNumericField Label="Seconds"
+                                         T="@int"
+                                         Variant="@Variant.Outlined"
+                                         Min="@Constants.MinSeconds"
+                                         Max="@Constants.MaxSeconds"
+                                         @bind-Value="@initialSecond"/>
+                    </div>
+                </div>
+            </MudStack>
+        </MudPaper>
+
+        <MudPaper Class="pa-4"
+                  Outlined>
+            <MudStack Spacing="2">
+                <MudText Typo="@Typo.h6">Elapsed Clock</MudText>
+                <MudText Typo="@Typo.body2"
+                         Color="@Color.Tertiary">
+                    Time elapsed since the initial clock was set. Advance this past 734 days
+                    (≈ 2 years) to clear the Emerald berry-program glitch after a battery replacement.
+                </MudText>
+                <div class="form-grid">
+                    <div class="form-field">
+                        <MudNumericField Label="Days"
+                                         T="@int"
+                                         Variant="@Variant.Outlined"
+                                         Min="0"
+                                         Max="@MaxDays"
+                                         @bind-Value="@elapsedDay"/>
+                    </div>
+                    <div class="form-field">
+                        <MudNumericField Label="Hours"
+                                         T="@int"
+                                         Variant="@Variant.Outlined"
+                                         Min="0"
+                                         Max="@MaxHours"
+                                         @bind-Value="@elapsedHour"/>
+                    </div>
+                    <div class="form-field">
+                        <MudNumericField Label="Minutes"
+                                         T="@int"
+                                         Variant="@Variant.Outlined"
+                                         Min="@Constants.MinMinutes"
+                                         Max="@Constants.MaxMinutes"
+                                         @bind-Value="@elapsedMinute"/>
+                    </div>
+                    <div class="form-field">
+                        <MudNumericField Label="Seconds"
+                                         T="@int"
+                                         Variant="@Variant.Outlined"
+                                         Min="@Constants.MinSeconds"
+                                         Max="@Constants.MaxSeconds"
+                                         @bind-Value="@elapsedSecond"/>
+                    </div>
+                </div>
+            </MudStack>
+        </MudPaper>
+
+        <MudStack Row
+                  Spacing="2"
+                  Wrap="@Wrap.Wrap">
+            <MudButton OnClick="@Apply"
+                       Variant="@Variant.Filled"
+                       Color="@Color.Primary"
+                       StartIcon="@Icons.Material.Filled.Save">
+                Apply
+            </MudButton>
+            <MudButton OnClick="@Revert"
+                       Variant="@Variant.Outlined"
+                       StartIcon="@Icons.Material.Filled.Undo">
+                Revert
+            </MudButton>
+            <MudButton OnClick="@ResetClocks"
+                       Variant="@Variant.Outlined"
+                       Color="@Color.Warning"
+                       StartIcon="@Icons.Material.Filled.RestartAlt">
+                Reset to zero
+            </MudButton>
+            <MudButton OnClick="@BerryFix"
+                       Variant="@Variant.Outlined"
+                       Color="@Color.Secondary"
+                       StartIcon="@Icons.Material.Filled.HealthAndSafety">
+                Berry-glitch fix
+            </MudButton>
+        </MudStack>
+    </MudStack>
+}

--- a/Pkmds.Rcl/Components/MainTabPages/RtcTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/RtcTab.razor.cs
@@ -1,0 +1,92 @@
+namespace Pkmds.Rcl.Components.MainTabPages;
+
+public partial class RtcTab
+{
+    // RTC3.Day is stored as a UInt16; clamp UI input to that range.
+    private const int MaxDays = ushort.MaxValue;
+    private const int MaxHours = 23;
+
+    // Emerald's berry program triggers a 366-day reset; the WinForms editor advances
+    // ClockElapsed past two full years to bypass it after a dead-battery period.
+    private const int BerryFixMinDays = (2 * 366) + 2;
+
+    [Parameter]
+    [EditorRequired]
+    public SAV3? SaveFile { get; set; }
+
+    private ISaveBlock3SmallHoenn? saveBlock;
+
+    private int initialDay;
+    private int initialHour;
+    private int initialMinute;
+    private int initialSecond;
+
+    private int elapsedDay;
+    private int elapsedHour;
+    private int elapsedMinute;
+    private int elapsedSecond;
+
+    protected override void OnParametersSet()
+    {
+        base.OnParametersSet();
+        saveBlock = SaveFile?.SmallBlock as ISaveBlock3SmallHoenn;
+        LoadClocks();
+    }
+
+    private void LoadClocks()
+    {
+        if (saveBlock is null)
+        {
+            return;
+        }
+
+        var initial = saveBlock.ClockInitial;
+        initialDay = initial.Day;
+        initialHour = Math.Min(MaxHours, initial.Hour);
+        initialMinute = Math.Min(Constants.MaxMinutes, initial.Minute);
+        initialSecond = Math.Min(Constants.MaxSeconds, initial.Second);
+
+        var elapsed = saveBlock.ClockElapsed;
+        elapsedDay = elapsed.Day;
+        elapsedHour = Math.Min(MaxHours, elapsed.Hour);
+        elapsedMinute = Math.Min(Constants.MaxMinutes, elapsed.Minute);
+        elapsedSecond = Math.Min(Constants.MaxSeconds, elapsed.Second);
+    }
+
+    private void Apply()
+    {
+        if (saveBlock is null)
+        {
+            return;
+        }
+
+        // RTC3 getters return a copy backed by a fresh byte[]; mutate the copy
+        // and assign it back so the setter writes the bytes into the save span.
+        var initial = saveBlock.ClockInitial;
+        initial.Day = initialDay;
+        initial.Hour = initialHour;
+        initial.Minute = initialMinute;
+        initial.Second = initialSecond;
+        saveBlock.ClockInitial = initial;
+
+        var elapsed = saveBlock.ClockElapsed;
+        elapsed.Day = elapsedDay;
+        elapsed.Hour = elapsedHour;
+        elapsed.Minute = elapsedMinute;
+        elapsed.Second = elapsedSecond;
+        saveBlock.ClockElapsed = elapsed;
+
+        Snackbar.Add("RTC values applied to save.", Severity.Success);
+        RefreshService.Refresh();
+    }
+
+    private void Revert() => LoadClocks();
+
+    private void ResetClocks()
+    {
+        initialDay = initialHour = initialMinute = initialSecond = 0;
+        elapsedDay = elapsedHour = elapsedMinute = elapsedSecond = 0;
+    }
+
+    private void BerryFix() => elapsedDay = Math.Max(BerryFixMinDays, elapsedDay);
+}

--- a/Pkmds.Rcl/Components/SaveFileComponent.razor
+++ b/Pkmds.Rcl/Components/SaveFileComponent.razor
@@ -78,6 +78,15 @@ else
             <MudTabPanel Text="Records">
                 <RecordsTab SaveFile="@sav3"/>
             </MudTabPanel>
+
+            @if (saveFile is SAV3RS or SAV3E)
+            {
+                <MudTabPanel Text="RTC">
+                    <div class="mt-3">
+                        <RtcTab SaveFile="@sav3"/>
+                    </div>
+                </MudTabPanel>
+            }
         }
 
         @if (saveFile is SAV3RS or SAV3E or SAV4Sinnoh or SAV8BS)


### PR DESCRIPTION
## Summary
- Adds a Gen 3 RTC editor surfacing `ClockInitial` and `ClockElapsed` from `ISaveBlock3SmallHoenn` (RS/E only) with day/hour/minute/second inputs.
- Mirrors PKHeX WinForms' `SAV_RTC3`: explicit Apply, Revert, "Reset to zero", and a "Berry-glitch fix" button that bumps `ClockElapsed.Day` past 734 days to clear Emerald's berry-program reset after a battery replacement.
- New "RTC" tab is grouped with the existing Gen 3 Records tab and only shown for `SAV3RS` / `SAV3E`.

Closes #865.

## Test plan
- [ ] Load an Emerald save → confirm the RTC tab appears between Records and Feebas
- [ ] Load a FRLG save → confirm the RTC tab does **not** appear
- [ ] Load a non–Gen 3 save → confirm the RTC tab does not appear
- [ ] Edit Initial / Elapsed values → click Apply → reload the save and verify the values persisted
- [ ] Click "Reset to zero" → Apply → reload and verify both clocks read 0
- [ ] Click "Berry-glitch fix" → confirm `ClockElapsed.Day` jumps to ≥ 734 → Apply → reload to verify
- [ ] Click Revert with unsaved changes → fields snap back to the on-disk values

🤖 Generated with [Claude Code](https://claude.com/claude-code)