### PR TITLE
Edit Joyful Game records (Pokémon Jump / Dodrio Berry Picking) on Gen 3 saves

### DIFF
--- a/Pkmds.Rcl/Components/MainTabPages/RecordsTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/RecordsTab.razor
@@ -56,4 +56,92 @@
             </div>
         </div>
     }
+
+    @if (JoyfulBlock is not null)
+    {
+        <MudPaper Class="pa-4 mt-4"
+                  Outlined>
+            <MudStack Spacing="2">
+                <MudText Typo="@Typo.h6">Joyful Game Records</MudText>
+                <MudText Typo="@Typo.body2"
+                         Color="@Color.Tertiary">
+                    Mini-game scores from Pokémon Jump and Dodrio Berry Picking
+                    (FireRed / LeafGreen via Wireless Adapter; also stored in Emerald).
+                    Reach 200 points in both scores to earn the trainer-card stars for these games.
+                </MudText>
+
+                <MudText Typo="@Typo.subtitle1">Pokémon Jump</MudText>
+                <div class="form-grid">
+                    <div class="form-field">
+                        <MudNumericField Label="High score"
+                                         T="@uint"
+                                         Variant="@Variant.Outlined"
+                                         Min="0"
+                                         Max="@JoyfulScoreMax"
+                                         @bind-Value="@JoyfulJumpScore"/>
+                    </div>
+                    <div class="form-field">
+                        <MudNumericField Label="Jumps in a row"
+                                         T="@ushort"
+                                         Variant="@Variant.Outlined"
+                                         Min="0"
+                                         Max="@JoyfulCounterMax"
+                                         @bind-Value="@JoyfulJumpInRow"/>
+                    </div>
+                    <div class="form-field">
+                        <MudNumericField Label="Best 5-in-a-row streak"
+                                         T="@ushort"
+                                         Variant="@Variant.Outlined"
+                                         Min="0"
+                                         Max="@JoyfulCounterMax"
+                                         @bind-Value="@JoyfulJump5InRow"/>
+                    </div>
+                    <div class="form-field">
+                        <MudNumericField Label="Games with max players"
+                                         T="@ushort"
+                                         Variant="@Variant.Outlined"
+                                         Min="0"
+                                         Max="@JoyfulCounterMax"
+                                         @bind-Value="@JoyfulJumpGamesMaxPlayers"/>
+                    </div>
+                </div>
+
+                <MudText Typo="@Typo.subtitle1">Dodrio Berry Picking</MudText>
+                <div class="form-grid">
+                    <div class="form-field">
+                        <MudNumericField Label="High score"
+                                         T="@uint"
+                                         Variant="@Variant.Outlined"
+                                         Min="0"
+                                         Max="@JoyfulScoreMax"
+                                         @bind-Value="@JoyfulBerriesScore"/>
+                    </div>
+                    <div class="form-field">
+                        <MudNumericField Label="Berries in a row"
+                                         T="@ushort"
+                                         Variant="@Variant.Outlined"
+                                         Min="0"
+                                         Max="@JoyfulCounterMax"
+                                         @bind-Value="@JoyfulBerriesInRow"/>
+                    </div>
+                    <div class="form-field">
+                        <MudNumericField Label="Best 5-in-a-row streak"
+                                         T="@ushort"
+                                         Variant="@Variant.Outlined"
+                                         Min="0"
+                                         Max="@JoyfulCounterMax"
+                                         @bind-Value="@JoyfulBerries5InRow"/>
+                    </div>
+                    <div class="form-field">
+                        <MudNumericField Label="Berry Powder"
+                                         T="@uint"
+                                         Variant="@Variant.Outlined"
+                                         Min="0"
+                                         Max="@BerryPowderMax"
+                                         @bind-Value="@BerryPowder"/>
+                    </div>
+                </div>
+            </MudStack>
+        </MudPaper>
+    }
 }

--- a/Pkmds.Rcl/Components/MainTabPages/RecordsTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/RecordsTab.razor.cs
@@ -55,98 +55,58 @@ public partial class RecordsTab
 
     private uint JoyfulJumpScore
     {
+        // ReSharper disable once UnusedMember.Local
         get => JoyfulBlock?.JoyfulJumpScore ?? 0U;
-        set
-        {
-            if (JoyfulBlock is not null)
-            {
-                JoyfulBlock.JoyfulJumpScore = Math.Min(JoyfulScoreMax, value);
-            }
-        }
+        set => JoyfulBlock?.JoyfulJumpScore = Math.Min(JoyfulScoreMax, value);
     }
 
     private ushort JoyfulJumpInRow
     {
-        get => JoyfulBlock?.JoyfulJumpInRow ?? (ushort)0;
-        set
-        {
-            if (JoyfulBlock is not null)
-            {
-                JoyfulBlock.JoyfulJumpInRow = Math.Min(JoyfulCounterMax, value);
-            }
-        }
+        // ReSharper disable once UnusedMember.Local
+        get => JoyfulBlock?.JoyfulJumpInRow ?? 0;
+        set => JoyfulBlock?.JoyfulJumpInRow = Math.Min(JoyfulCounterMax, value);
     }
 
     private ushort JoyfulJump5InRow
     {
-        get => JoyfulBlock?.JoyfulJump5InRow ?? (ushort)0;
-        set
-        {
-            if (JoyfulBlock is not null)
-            {
-                JoyfulBlock.JoyfulJump5InRow = Math.Min(JoyfulCounterMax, value);
-            }
-        }
+        // ReSharper disable once UnusedMember.Local
+        get => JoyfulBlock?.JoyfulJump5InRow ?? 0;
+        set => JoyfulBlock?.JoyfulJump5InRow = Math.Min(JoyfulCounterMax, value);
     }
 
     private ushort JoyfulJumpGamesMaxPlayers
     {
-        get => JoyfulBlock?.JoyfulJumpGamesMaxPlayers ?? (ushort)0;
-        set
-        {
-            if (JoyfulBlock is not null)
-            {
-                JoyfulBlock.JoyfulJumpGamesMaxPlayers = Math.Min(JoyfulCounterMax, value);
-            }
-        }
+        // ReSharper disable once UnusedMember.Local
+        get => JoyfulBlock?.JoyfulJumpGamesMaxPlayers ?? 0;
+        set => JoyfulBlock?.JoyfulJumpGamesMaxPlayers = Math.Min(JoyfulCounterMax, value);
     }
 
     private uint JoyfulBerriesScore
     {
+        // ReSharper disable once UnusedMember.Local
         get => JoyfulBlock?.JoyfulBerriesScore ?? 0U;
-        set
-        {
-            if (JoyfulBlock is not null)
-            {
-                JoyfulBlock.JoyfulBerriesScore = Math.Min(JoyfulScoreMax, value);
-            }
-        }
+        set => JoyfulBlock?.JoyfulBerriesScore = Math.Min(JoyfulScoreMax, value);
     }
 
     private ushort JoyfulBerriesInRow
     {
-        get => JoyfulBlock?.JoyfulBerriesInRow ?? (ushort)0;
-        set
-        {
-            if (JoyfulBlock is not null)
-            {
-                JoyfulBlock.JoyfulBerriesInRow = Math.Min(JoyfulCounterMax, value);
-            }
-        }
+        // ReSharper disable once UnusedMember.Local
+        get => JoyfulBlock?.JoyfulBerriesInRow ?? 0;
+        set => JoyfulBlock?.JoyfulBerriesInRow = Math.Min(JoyfulCounterMax, value);
     }
 
     private ushort JoyfulBerries5InRow
     {
-        get => JoyfulBlock?.JoyfulBerries5InRow ?? (ushort)0;
-        set
-        {
-            if (JoyfulBlock is not null)
-            {
-                JoyfulBlock.JoyfulBerries5InRow = Math.Min(JoyfulCounterMax, value);
-            }
-        }
+        // ReSharper disable once UnusedMember.Local
+        get => JoyfulBlock?.JoyfulBerries5InRow ?? 0;
+        set => JoyfulBlock?.JoyfulBerries5InRow = Math.Min(JoyfulCounterMax, value);
     }
 
     private uint BerryPowder
     {
+        // ReSharper disable once UnusedMember.Local
         get => JoyfulBlock?.BerryPowder ?? 0U;
-        set
-        {
-            if (JoyfulBlock is not null)
-            {
-                JoyfulBlock.BerryPowder = Math.Min(BerryPowderMax, value);
-            }
-        }
+        set => JoyfulBlock?.BerryPowder = Math.Min(BerryPowderMax, value);
     }
 
     private void GetRecord()

--- a/Pkmds.Rcl/Components/MainTabPages/RecordsTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/RecordsTab.razor.cs
@@ -2,6 +2,12 @@ namespace Pkmds.Rcl.Components.MainTabPages;
 
 public partial class RecordsTab
 {
+    // Trainer-card star thresholds (Pokémon Jump / Dodrio Berry Picking) require 200 points;
+    // PKHeX caps the underlying field at 99,990. See ISaveBlock3SmallExpansion.
+    private const uint JoyfulScoreMax = 99_990;
+    private const ushort JoyfulCounterMax = 9_999;
+    private const uint BerryPowderMax = 99_999;
+
     [Parameter]
     [EditorRequired]
     public SAV3? SaveFile { get; set; }
@@ -17,6 +23,8 @@ public partial class RecordsTab
     private byte HallOfFameMinutes { get; set; }
 
     private byte HallOfFameSeconds { get; set; }
+
+    private ISaveBlock3SmallExpansion? JoyfulBlock { get; set; }
 
     private bool HallOfFameIndexSelected => (SaveFile, CurrentRecordIndex) switch
     {
@@ -36,11 +44,109 @@ public partial class RecordsTab
     {
         if (SaveFile is null)
         {
+            JoyfulBlock = null;
             return;
         }
 
         RecordComboItems = Record3.GetItems(SaveFile);
+        JoyfulBlock = SaveFile.SmallBlock as ISaveBlock3SmallExpansion;
         GetRecord();
+    }
+
+    private uint JoyfulJumpScore
+    {
+        get => JoyfulBlock?.JoyfulJumpScore ?? 0U;
+        set
+        {
+            if (JoyfulBlock is not null)
+            {
+                JoyfulBlock.JoyfulJumpScore = Math.Min(JoyfulScoreMax, value);
+            }
+        }
+    }
+
+    private ushort JoyfulJumpInRow
+    {
+        get => JoyfulBlock?.JoyfulJumpInRow ?? (ushort)0;
+        set
+        {
+            if (JoyfulBlock is not null)
+            {
+                JoyfulBlock.JoyfulJumpInRow = Math.Min(JoyfulCounterMax, value);
+            }
+        }
+    }
+
+    private ushort JoyfulJump5InRow
+    {
+        get => JoyfulBlock?.JoyfulJump5InRow ?? (ushort)0;
+        set
+        {
+            if (JoyfulBlock is not null)
+            {
+                JoyfulBlock.JoyfulJump5InRow = Math.Min(JoyfulCounterMax, value);
+            }
+        }
+    }
+
+    private ushort JoyfulJumpGamesMaxPlayers
+    {
+        get => JoyfulBlock?.JoyfulJumpGamesMaxPlayers ?? (ushort)0;
+        set
+        {
+            if (JoyfulBlock is not null)
+            {
+                JoyfulBlock.JoyfulJumpGamesMaxPlayers = Math.Min(JoyfulCounterMax, value);
+            }
+        }
+    }
+
+    private uint JoyfulBerriesScore
+    {
+        get => JoyfulBlock?.JoyfulBerriesScore ?? 0U;
+        set
+        {
+            if (JoyfulBlock is not null)
+            {
+                JoyfulBlock.JoyfulBerriesScore = Math.Min(JoyfulScoreMax, value);
+            }
+        }
+    }
+
+    private ushort JoyfulBerriesInRow
+    {
+        get => JoyfulBlock?.JoyfulBerriesInRow ?? (ushort)0;
+        set
+        {
+            if (JoyfulBlock is not null)
+            {
+                JoyfulBlock.JoyfulBerriesInRow = Math.Min(JoyfulCounterMax, value);
+            }
+        }
+    }
+
+    private ushort JoyfulBerries5InRow
+    {
+        get => JoyfulBlock?.JoyfulBerries5InRow ?? (ushort)0;
+        set
+        {
+            if (JoyfulBlock is not null)
+            {
+                JoyfulBlock.JoyfulBerries5InRow = Math.Min(JoyfulCounterMax, value);
+            }
+        }
+    }
+
+    private uint BerryPowder
+    {
+        get => JoyfulBlock?.BerryPowder ?? 0U;
+        set
+        {
+            if (JoyfulBlock is not null)
+            {
+                JoyfulBlock.BerryPowder = Math.Min(BerryPowderMax, value);
+            }
+        }
     }
 
     private void GetRecord()


### PR DESCRIPTION
## Summary
- Adds a **Joyful Game Records** section to the Gen 3 **Records** tab.
- Surfaces every field PKHeX exposes through `ISaveBlock3SmallExpansion` (FR/LG and Emerald): Pokémon Jump (high score, in-a-row, 5-in-a-row, max-player games), Dodrio Berry Picking (high score, in-a-row, 5-in-a-row), and Berry Powder.
- Lets players reach the 200-point threshold required for the Pokémon Jump and Berry Picking trainer-card stars on FireRed/LeafGreen even when a wireless-adapter link partner isn't available — closes #870.

Section is only rendered when the underlying small block implements `ISaveBlock3SmallExpansion`, so it stays hidden for Ruby/Sapphire saves.

## Test plan
- [ ] Load a FireRed/LeafGreen save → Records tab → confirm the **Joyful Game Records** card appears.
- [ ] Set Pokémon Jump and Dodrio Berry Picking scores to 200, save, reload in PKHeX/the game → trainer-card star awarded.
- [ ] Load a Ruby/Sapphire save → section is hidden; existing Records dropdown still works.
- [ ] Load an Emerald save → section appears (Emerald's small block also implements the interface).
- [ ] Verify counter fields clamp at 9,999 and score fields at 99,990 in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)