### PR TITLE
feat: #361 trainer customization (phases 1–5) + #870 Joyful records

### DIFF
--- a/Pkmds.Rcl/Components/Dialogs/SayingsDialog.razor
+++ b/Pkmds.Rcl/Components/Dialogs/SayingsDialog.razor
@@ -11,7 +11,7 @@
             {
                 <MudTextField Label="Trainer Card Nickname"
                               Variant="@Variant.Outlined"
-                              MaxLength="@NicknameMaxChars"
+                              ReadOnly="true"
                               @bind-Value="@nickname"
                               Class="mb-3"/>
             }
@@ -21,9 +21,8 @@
                 var index = i;
                 <MudTextField Label="@($"Saying {index + 1}")"
                               Variant="@Variant.Outlined"
-                              MaxLength="@SayingMaxChars"
+                              ReadOnly="true"
                               Value="@sayings[index]"
-                              ValueChanged="@(v => sayings[index] = v)"
                               T="@string"
                               Class="mb-2"/>
             }
@@ -32,9 +31,6 @@
     <DialogActions>
         <MudButton OnClick="@Cancel"
                    Variant="@Variant.Filled"
-                   Color="@Color.Default">Cancel</MudButton>
-        <MudButton OnClick="@Confirm"
-                   Variant="@Variant.Filled"
-                   Color="@Color.Primary">Confirm</MudButton>
+                   Color="@Color.Default">Close</MudButton>
     </DialogActions>
 </MudDialog>

--- a/Pkmds.Rcl/Components/Dialogs/SayingsDialog.razor
+++ b/Pkmds.Rcl/Components/Dialogs/SayingsDialog.razor
@@ -1,0 +1,40 @@
+@inherits BasePkmdsComponent
+
+<MudDialog>
+    <TitleContent>
+        <MudText Typo="@Typo.h6">Trainer Card Sayings</MudText>
+    </TitleContent>
+    <DialogContent>
+        @if (Status is not null)
+        {
+            @if (XyNickname is not null)
+            {
+                <MudTextField Label="Trainer Card Nickname"
+                              Variant="@Variant.Outlined"
+                              MaxLength="@NicknameMaxChars"
+                              @bind-Value="@nickname"
+                              Class="mb-3"/>
+            }
+
+            @for (var i = 0; i < sayings.Length; i++)
+            {
+                var index = i;
+                <MudTextField Label="@($"Saying {index + 1}")"
+                              Variant="@Variant.Outlined"
+                              MaxLength="@SayingMaxChars"
+                              Value="@sayings[index]"
+                              ValueChanged="@(v => sayings[index] = v)"
+                              T="@string"
+                              Class="mb-2"/>
+            }
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@Cancel"
+                   Variant="@Variant.Filled"
+                   Color="@Color.Default">Cancel</MudButton>
+        <MudButton OnClick="@Confirm"
+                   Variant="@Variant.Filled"
+                   Color="@Color.Primary">Confirm</MudButton>
+    </DialogActions>
+</MudDialog>

--- a/Pkmds.Rcl/Components/Dialogs/SayingsDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/SayingsDialog.razor.cs
@@ -1,0 +1,65 @@
+namespace Pkmds.Rcl.Components.Dialogs;
+
+public partial class SayingsDialog
+{
+    // PKHeX SAV6.LongStringLength = 0x22 bytes = 17 wide chars max per Saying.
+    private const int SayingMaxChars = 17;
+
+    // MyStatus6XY.Nickname max is 12 chars (StringConverter6 limit).
+    private const int NicknameMaxChars = 12;
+
+    private readonly string[] sayings = new string[5];
+    private string nickname = string.Empty;
+
+    [Parameter]
+    [EditorRequired]
+    public MyStatus6? Status { get; set; }
+
+    /// <summary>XY-only Trainer Card nickname. Pass null for ORAS (which has no separate nickname).</summary>
+    [Parameter]
+    public MyStatus6XY? XyNickname { get; set; }
+
+    [CascadingParameter]
+    private IMudDialogInstance? MudDialog { get; set; }
+
+    protected override void OnParametersSet()
+    {
+        if (Status is null)
+        {
+            return;
+        }
+
+        sayings[0] = Status.Saying1;
+        sayings[1] = Status.Saying2;
+        sayings[2] = Status.Saying3;
+        sayings[3] = Status.Saying4;
+        sayings[4] = Status.Saying5;
+
+        nickname = XyNickname?.Nickname ?? string.Empty;
+    }
+
+    private void Confirm()
+    {
+        if (Status is null)
+        {
+            MudDialog?.Close(DialogResult.Cancel());
+            return;
+        }
+
+        Status.Saying1 = sayings[0];
+        Status.Saying2 = sayings[1];
+        Status.Saying3 = sayings[2];
+        Status.Saying4 = sayings[3];
+        Status.Saying5 = sayings[4];
+
+        if (XyNickname is not null)
+        {
+            XyNickname.Nickname = nickname;
+        }
+
+        Haptics.Confirm();
+        MudDialog?.Close(DialogResult.Ok(true));
+    }
+
+    private void Cancel() => MudDialog?.Close(DialogResult.Cancel());
+}

--- a/Pkmds.Rcl/Components/Dialogs/SayingsDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/SayingsDialog.razor.cs
@@ -2,12 +2,6 @@ namespace Pkmds.Rcl.Components.Dialogs;
 
 public partial class SayingsDialog
 {
-    // PKHeX SAV6.LongStringLength = 0x22 bytes = 17 wide chars max per Saying.
-    private const int SayingMaxChars = 17;
-
-    // MyStatus6XY.Nickname max is 12 chars (StringConverter6 limit).
-    private const int NicknameMaxChars = 12;
-
     private readonly string[] sayings = new string[5];
     private string nickname = string.Empty;
 
@@ -36,29 +30,6 @@ public partial class SayingsDialog
         sayings[4] = Status.Saying5;
 
         nickname = XyNickname?.Nickname ?? string.Empty;
-    }
-
-    private void Confirm()
-    {
-        if (Status is null)
-        {
-            MudDialog?.Close(DialogResult.Cancel());
-            return;
-        }
-
-        Status.Saying1 = sayings[0];
-        Status.Saying2 = sayings[1];
-        Status.Saying3 = sayings[2];
-        Status.Saying4 = sayings[3];
-        Status.Saying5 = sayings[4];
-
-        if (XyNickname is not null)
-        {
-            XyNickname.Nickname = nickname;
-        }
-
-        Haptics.Confirm();
-        MudDialog?.Close(DialogResult.Ok(true));
     }
 
     private void Cancel() => MudDialog?.Close(DialogResult.Cancel());

--- a/Pkmds.Rcl/Components/Dialogs/TrainerCardDialog.razor
+++ b/Pkmds.Rcl/Components/Dialogs/TrainerCardDialog.razor
@@ -14,12 +14,14 @@
                           Class="mb-3"
                           HelperText="@($"Separate from the save OT ({saveFile.OT}). Defaults to it.")"/>
 
-            <MudTextField Label="Card Number"
-                          Variant="@Variant.Outlined"
-                          MaxLength="3"
-                          @bind-Value="@cardNumber"
-                          Class="mb-3"
-                          HelperText="Three ASCII characters. Also written to MyStatus.Number for in-game consistency."/>
+            <MudNumericField Label="Card Number"
+                             T="@int"
+                             Variant="@Variant.Outlined"
+                             Min="0"
+                             Max="999"
+                             @bind-Value="@cardNumber"
+                             Class="mb-3"
+                             HelperText="Three-digit number (000–999). Also written to MyStatus.Number for in-game consistency."/>
 
             <MudNumericField Label="Trainer ID (League Card)"
                              T="@int"

--- a/Pkmds.Rcl/Components/Dialogs/TrainerCardDialog.razor
+++ b/Pkmds.Rcl/Components/Dialogs/TrainerCardDialog.razor
@@ -1,0 +1,50 @@
+@inherits BasePkmdsComponent
+
+<MudDialog>
+    <TitleContent>
+        <MudText Typo="@Typo.h6">Trainer Card</MudText>
+    </TitleContent>
+    <DialogContent>
+        @if (Save is { } saveFile)
+        {
+            <MudTextField Label="Trainer Card Name"
+                          Variant="@Variant.Outlined"
+                          MaxLength="@saveFile.MaxStringLengthTrainer"
+                          @bind-Value="@cardOt"
+                          Class="mb-3"
+                          HelperText="@($"Separate from the save OT ({saveFile.OT}). Defaults to it.")"/>
+
+            <MudTextField Label="Card Number"
+                          Variant="@Variant.Outlined"
+                          MaxLength="3"
+                          @bind-Value="@cardNumber"
+                          Class="mb-3"
+                          HelperText="Three ASCII characters. Also written to MyStatus.Number for in-game consistency."/>
+
+            <MudNumericField Label="Trainer ID (League Card)"
+                             T="@int"
+                             Variant="@Variant.Outlined"
+                             Min="0"
+                             Max="@int.MaxValue"
+                             @bind-Value="@trainerId"
+                             Class="mb-3"
+                             HelperText="Six-digit display ID on the League Card. Independent of the save's TID/SID."/>
+
+            <MudNumericField Label="Roto Rally Score"
+                             T="@int"
+                             Variant="@Variant.Outlined"
+                             Min="0"
+                             Max="@TrainerCard8.RotoRallyScoreMax"
+                             @bind-Value="@rotoRallyScore"
+                             HelperText="@($"Max {TrainerCard8.RotoRallyScoreMax:N0}. Setter mirrors to the Roto Rally record block.")"/>
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@Cancel"
+                   Variant="@Variant.Filled"
+                   Color="@Color.Default">Cancel</MudButton>
+        <MudButton OnClick="@Confirm"
+                   Variant="@Variant.Filled"
+                   Color="@Color.Primary">Confirm</MudButton>
+    </DialogActions>
+</MudDialog>

--- a/Pkmds.Rcl/Components/Dialogs/TrainerCardDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/TrainerCardDialog.razor.cs
@@ -3,7 +3,7 @@ namespace Pkmds.Rcl.Components.Dialogs;
 public partial class TrainerCardDialog
 {
     private string cardOt = string.Empty;
-    private string cardNumber = string.Empty;
+    private int cardNumber;
     private int trainerId;
     private int rotoRallyScore;
 
@@ -23,7 +23,7 @@ public partial class TrainerCardDialog
 
         var card = Save.Blocks.TrainerCard;
         cardOt = card.OT;
-        cardNumber = card.Number;
+        cardNumber = int.TryParse(card.Number, out var n) ? n : 0;
         trainerId = card.TrainerID;
         rotoRallyScore = card.RotoRallyScore;
     }
@@ -44,8 +44,9 @@ public partial class TrainerCardDialog
 
         // PKHeX writes Number to both MyStatus and TrainerCard to keep them in sync —
         // mismatch leaves the in-game card displaying a different number than the trainer.
-        Save.Blocks.MyStatus.Number = cardNumber;
-        card.Number = cardNumber;
+        var cardNumberStr = cardNumber.ToString("D3");
+        Save.Blocks.MyStatus.Number = cardNumberStr;
+        card.Number = cardNumberStr;
 
         card.TrainerID = trainerId;
         // Setter auto-mirrors to the KRotoRally record block.

--- a/Pkmds.Rcl/Components/Dialogs/TrainerCardDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/TrainerCardDialog.razor.cs
@@ -1,0 +1,59 @@
+namespace Pkmds.Rcl.Components.Dialogs;
+
+public partial class TrainerCardDialog
+{
+    private string cardOt = string.Empty;
+    private string cardNumber = string.Empty;
+    private int trainerId;
+    private int rotoRallyScore;
+
+    [Parameter]
+    [EditorRequired]
+    public SAV8SWSH? Save { get; set; }
+
+    [CascadingParameter]
+    private IMudDialogInstance? MudDialog { get; set; }
+
+    protected override void OnParametersSet()
+    {
+        if (Save is null)
+        {
+            return;
+        }
+
+        var card = Save.Blocks.TrainerCard;
+        cardOt = card.OT;
+        cardNumber = card.Number;
+        trainerId = card.TrainerID;
+        rotoRallyScore = card.RotoRallyScore;
+    }
+
+    private void Confirm()
+    {
+        if (Save is null)
+        {
+            MudDialog?.Close(DialogResult.Cancel());
+            return;
+        }
+
+        var card = Save.Blocks.TrainerCard;
+        if (card.OT != cardOt)
+        {
+            card.OT = cardOt;
+        }
+
+        // PKHeX writes Number to both MyStatus and TrainerCard to keep them in sync —
+        // mismatch leaves the in-game card displaying a different number than the trainer.
+        Save.Blocks.MyStatus.Number = cardNumber;
+        card.Number = cardNumber;
+
+        card.TrainerID = trainerId;
+        // Setter auto-mirrors to the KRotoRally record block.
+        card.RotoRallyScore = rotoRallyScore;
+
+        Haptics.Confirm();
+        MudDialog?.Close(DialogResult.Ok(true));
+    }
+
+    private void Cancel() => MudDialog?.Close(DialogResult.Cancel());
+}

--- a/Pkmds.Rcl/Components/MainTabPages/RecordsTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/RecordsTab.razor
@@ -56,4 +56,92 @@
             </div>
         </div>
     }
+
+    @if (JoyfulBlock is not null)
+    {
+        <MudPaper Class="pa-4 mt-4"
+                  Outlined>
+            <MudStack Spacing="2">
+                <MudText Typo="@Typo.h6">Joyful Game Records</MudText>
+                <MudText Typo="@Typo.body2"
+                         Color="@Color.Tertiary">
+                    Mini-game scores from Pokémon Jump and Dodrio Berry Picking
+                    (FireRed / LeafGreen via Wireless Adapter; also stored in Emerald).
+                    Reach 200 points in both scores to earn the trainer-card stars for these games.
+                </MudText>
+
+                <MudText Typo="@Typo.subtitle1">Pokémon Jump</MudText>
+                <div class="form-grid">
+                    <div class="form-field">
+                        <MudNumericField Label="High score"
+                                         T="@uint"
+                                         Variant="@Variant.Outlined"
+                                         Min="0"
+                                         Max="@JoyfulScoreMax"
+                                         @bind-Value="@JoyfulJumpScore"/>
+                    </div>
+                    <div class="form-field">
+                        <MudNumericField Label="Jumps in a row"
+                                         T="@ushort"
+                                         Variant="@Variant.Outlined"
+                                         Min="0"
+                                         Max="@JoyfulCounterMax"
+                                         @bind-Value="@JoyfulJumpInRow"/>
+                    </div>
+                    <div class="form-field">
+                        <MudNumericField Label="Best 5-in-a-row streak"
+                                         T="@ushort"
+                                         Variant="@Variant.Outlined"
+                                         Min="0"
+                                         Max="@JoyfulCounterMax"
+                                         @bind-Value="@JoyfulJump5InRow"/>
+                    </div>
+                    <div class="form-field">
+                        <MudNumericField Label="Games with max players"
+                                         T="@ushort"
+                                         Variant="@Variant.Outlined"
+                                         Min="0"
+                                         Max="@JoyfulCounterMax"
+                                         @bind-Value="@JoyfulJumpGamesMaxPlayers"/>
+                    </div>
+                </div>
+
+                <MudText Typo="@Typo.subtitle1">Dodrio Berry Picking</MudText>
+                <div class="form-grid">
+                    <div class="form-field">
+                        <MudNumericField Label="High score"
+                                         T="@uint"
+                                         Variant="@Variant.Outlined"
+                                         Min="0"
+                                         Max="@JoyfulScoreMax"
+                                         @bind-Value="@JoyfulBerriesScore"/>
+                    </div>
+                    <div class="form-field">
+                        <MudNumericField Label="Berries in a row"
+                                         T="@ushort"
+                                         Variant="@Variant.Outlined"
+                                         Min="0"
+                                         Max="@JoyfulCounterMax"
+                                         @bind-Value="@JoyfulBerriesInRow"/>
+                    </div>
+                    <div class="form-field">
+                        <MudNumericField Label="Best 5-in-a-row streak"
+                                         T="@ushort"
+                                         Variant="@Variant.Outlined"
+                                         Min="0"
+                                         Max="@JoyfulCounterMax"
+                                         @bind-Value="@JoyfulBerries5InRow"/>
+                    </div>
+                    <div class="form-field">
+                        <MudNumericField Label="Berry Powder"
+                                         T="@uint"
+                                         Variant="@Variant.Outlined"
+                                         Min="0"
+                                         Max="@BerryPowderMax"
+                                         @bind-Value="@BerryPowder"/>
+                    </div>
+                </div>
+            </MudStack>
+        </MudPaper>
+    }
 }

--- a/Pkmds.Rcl/Components/MainTabPages/RecordsTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/RecordsTab.razor.cs
@@ -55,98 +55,58 @@ public partial class RecordsTab
 
     private uint JoyfulJumpScore
     {
+        // ReSharper disable once UnusedMember.Local
         get => JoyfulBlock?.JoyfulJumpScore ?? 0U;
-        set
-        {
-            if (JoyfulBlock is not null)
-            {
-                JoyfulBlock.JoyfulJumpScore = Math.Min(JoyfulScoreMax, value);
-            }
-        }
+        set => JoyfulBlock?.JoyfulJumpScore = Math.Min(JoyfulScoreMax, value);
     }
 
     private ushort JoyfulJumpInRow
     {
-        get => JoyfulBlock?.JoyfulJumpInRow ?? (ushort)0;
-        set
-        {
-            if (JoyfulBlock is not null)
-            {
-                JoyfulBlock.JoyfulJumpInRow = Math.Min(JoyfulCounterMax, value);
-            }
-        }
+        // ReSharper disable once UnusedMember.Local
+        get => JoyfulBlock?.JoyfulJumpInRow ?? 0;
+        set => JoyfulBlock?.JoyfulJumpInRow = Math.Min(JoyfulCounterMax, value);
     }
 
     private ushort JoyfulJump5InRow
     {
-        get => JoyfulBlock?.JoyfulJump5InRow ?? (ushort)0;
-        set
-        {
-            if (JoyfulBlock is not null)
-            {
-                JoyfulBlock.JoyfulJump5InRow = Math.Min(JoyfulCounterMax, value);
-            }
-        }
+        // ReSharper disable once UnusedMember.Local
+        get => JoyfulBlock?.JoyfulJump5InRow ?? 0;
+        set => JoyfulBlock?.JoyfulJump5InRow = Math.Min(JoyfulCounterMax, value);
     }
 
     private ushort JoyfulJumpGamesMaxPlayers
     {
-        get => JoyfulBlock?.JoyfulJumpGamesMaxPlayers ?? (ushort)0;
-        set
-        {
-            if (JoyfulBlock is not null)
-            {
-                JoyfulBlock.JoyfulJumpGamesMaxPlayers = Math.Min(JoyfulCounterMax, value);
-            }
-        }
+        // ReSharper disable once UnusedMember.Local
+        get => JoyfulBlock?.JoyfulJumpGamesMaxPlayers ?? 0;
+        set => JoyfulBlock?.JoyfulJumpGamesMaxPlayers = Math.Min(JoyfulCounterMax, value);
     }
 
     private uint JoyfulBerriesScore
     {
+        // ReSharper disable once UnusedMember.Local
         get => JoyfulBlock?.JoyfulBerriesScore ?? 0U;
-        set
-        {
-            if (JoyfulBlock is not null)
-            {
-                JoyfulBlock.JoyfulBerriesScore = Math.Min(JoyfulScoreMax, value);
-            }
-        }
+        set => JoyfulBlock?.JoyfulBerriesScore = Math.Min(JoyfulScoreMax, value);
     }
 
     private ushort JoyfulBerriesInRow
     {
-        get => JoyfulBlock?.JoyfulBerriesInRow ?? (ushort)0;
-        set
-        {
-            if (JoyfulBlock is not null)
-            {
-                JoyfulBlock.JoyfulBerriesInRow = Math.Min(JoyfulCounterMax, value);
-            }
-        }
+        // ReSharper disable once UnusedMember.Local
+        get => JoyfulBlock?.JoyfulBerriesInRow ?? 0;
+        set => JoyfulBlock?.JoyfulBerriesInRow = Math.Min(JoyfulCounterMax, value);
     }
 
     private ushort JoyfulBerries5InRow
     {
-        get => JoyfulBlock?.JoyfulBerries5InRow ?? (ushort)0;
-        set
-        {
-            if (JoyfulBlock is not null)
-            {
-                JoyfulBlock.JoyfulBerries5InRow = Math.Min(JoyfulCounterMax, value);
-            }
-        }
+        // ReSharper disable once UnusedMember.Local
+        get => JoyfulBlock?.JoyfulBerries5InRow ?? 0;
+        set => JoyfulBlock?.JoyfulBerries5InRow = Math.Min(JoyfulCounterMax, value);
     }
 
     private uint BerryPowder
     {
+        // ReSharper disable once UnusedMember.Local
         get => JoyfulBlock?.BerryPowder ?? 0U;
-        set
-        {
-            if (JoyfulBlock is not null)
-            {
-                JoyfulBlock.BerryPowder = Math.Min(BerryPowderMax, value);
-            }
-        }
+        set => JoyfulBlock?.BerryPowder = Math.Min(BerryPowderMax, value);
     }
 
     private void GetRecord()

--- a/Pkmds.Rcl/Components/MainTabPages/RecordsTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/RecordsTab.razor.cs
@@ -2,6 +2,12 @@ namespace Pkmds.Rcl.Components.MainTabPages;
 
 public partial class RecordsTab
 {
+    // Trainer-card star thresholds (Pokémon Jump / Dodrio Berry Picking) require 200 points;
+    // PKHeX caps the underlying field at 99,990. See ISaveBlock3SmallExpansion.
+    private const uint JoyfulScoreMax = 99_990;
+    private const ushort JoyfulCounterMax = 9_999;
+    private const uint BerryPowderMax = 99_999;
+
     [Parameter]
     [EditorRequired]
     public SAV3? SaveFile { get; set; }
@@ -17,6 +23,8 @@ public partial class RecordsTab
     private byte HallOfFameMinutes { get; set; }
 
     private byte HallOfFameSeconds { get; set; }
+
+    private ISaveBlock3SmallExpansion? JoyfulBlock { get; set; }
 
     private bool HallOfFameIndexSelected => (SaveFile, CurrentRecordIndex) switch
     {
@@ -36,11 +44,109 @@ public partial class RecordsTab
     {
         if (SaveFile is null)
         {
+            JoyfulBlock = null;
             return;
         }
 
         RecordComboItems = Record3.GetItems(SaveFile);
+        JoyfulBlock = SaveFile.SmallBlock as ISaveBlock3SmallExpansion;
         GetRecord();
+    }
+
+    private uint JoyfulJumpScore
+    {
+        get => JoyfulBlock?.JoyfulJumpScore ?? 0U;
+        set
+        {
+            if (JoyfulBlock is not null)
+            {
+                JoyfulBlock.JoyfulJumpScore = Math.Min(JoyfulScoreMax, value);
+            }
+        }
+    }
+
+    private ushort JoyfulJumpInRow
+    {
+        get => JoyfulBlock?.JoyfulJumpInRow ?? (ushort)0;
+        set
+        {
+            if (JoyfulBlock is not null)
+            {
+                JoyfulBlock.JoyfulJumpInRow = Math.Min(JoyfulCounterMax, value);
+            }
+        }
+    }
+
+    private ushort JoyfulJump5InRow
+    {
+        get => JoyfulBlock?.JoyfulJump5InRow ?? (ushort)0;
+        set
+        {
+            if (JoyfulBlock is not null)
+            {
+                JoyfulBlock.JoyfulJump5InRow = Math.Min(JoyfulCounterMax, value);
+            }
+        }
+    }
+
+    private ushort JoyfulJumpGamesMaxPlayers
+    {
+        get => JoyfulBlock?.JoyfulJumpGamesMaxPlayers ?? (ushort)0;
+        set
+        {
+            if (JoyfulBlock is not null)
+            {
+                JoyfulBlock.JoyfulJumpGamesMaxPlayers = Math.Min(JoyfulCounterMax, value);
+            }
+        }
+    }
+
+    private uint JoyfulBerriesScore
+    {
+        get => JoyfulBlock?.JoyfulBerriesScore ?? 0U;
+        set
+        {
+            if (JoyfulBlock is not null)
+            {
+                JoyfulBlock.JoyfulBerriesScore = Math.Min(JoyfulScoreMax, value);
+            }
+        }
+    }
+
+    private ushort JoyfulBerriesInRow
+    {
+        get => JoyfulBlock?.JoyfulBerriesInRow ?? (ushort)0;
+        set
+        {
+            if (JoyfulBlock is not null)
+            {
+                JoyfulBlock.JoyfulBerriesInRow = Math.Min(JoyfulCounterMax, value);
+            }
+        }
+    }
+
+    private ushort JoyfulBerries5InRow
+    {
+        get => JoyfulBlock?.JoyfulBerries5InRow ?? (ushort)0;
+        set
+        {
+            if (JoyfulBlock is not null)
+            {
+                JoyfulBlock.JoyfulBerries5InRow = Math.Min(JoyfulCounterMax, value);
+            }
+        }
+    }
+
+    private uint BerryPowder
+    {
+        get => JoyfulBlock?.BerryPowder ?? 0U;
+        set
+        {
+            if (JoyfulBlock is not null)
+            {
+                JoyfulBlock.BerryPowder = Math.Min(BerryPowderMax, value);
+            }
+        }
     }
 
     private void GetRecord()

--- a/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor
@@ -431,6 +431,19 @@
             </div>
         }
 
+        @foreach (var currency in GetExtraCurrencies(saveFile))
+        {
+            <div class="form-field" @key="@currency.Label">
+                <MudNumericField Label="@currency.Label"
+                                 T="@uint"
+                                 Variant="@Variant.Outlined"
+                                 Min="@((uint)0)"
+                                 Max="@currency.Max"
+                                 Value="@currency.Value"
+                                 ValueChanged="@currency.Set"/>
+            </div>
+        }
+
         @if (saveFile is SAV3FRLG sav3FrLgTrainerCard)
         {
             @for (var i = 0; i < 6; i++)

--- a/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor
@@ -227,6 +227,46 @@
             </div>
         }
 
+        @if (saveFile is SAV5 sav5GameSync)
+        {
+            <div class="form-field">
+                <MudNumericField Label="Game Sync ID"
+                                 T="@uint"
+                                 Variant="@Variant.Outlined"
+                                 Min="0"
+                                 @bind-Value="@sav5GameSync.PlayerData.GameSyncID"
+                                 For="@(() => sav5GameSync.PlayerData.GameSyncID)"/>
+            </div>
+        }
+
+        @if (saveFile is IGameSync gameSync)
+        {
+            <div class="form-field">
+                <MudTextField Label="Game Sync ID"
+                              Variant="@Variant.Outlined"
+                              MaxLength="@gameSync.GameSyncIDSize"
+                              Placeholder="@($"{gameSync.GameSyncIDSize}-char hex")"
+                              @bind-Value:get="@gameSync.GameSyncID"
+                              @bind-Value:set="@(value => SetGameSyncId(gameSync, value))"
+                              Validation="@(new Func<string, string?>(v => ValidateHexString(v, gameSync.GameSyncIDSize)))"
+                              For="@(() => gameSync.GameSyncID)"/>
+            </div>
+        }
+
+        @if (saveFile is SAV7 sav7Nex)
+        {
+            <div class="form-field">
+                <MudTextField Label="Nex Unique ID"
+                              Variant="@Variant.Outlined"
+                              MaxLength="@MyStatus7.NexUniqueIDSize"
+                              Placeholder="@($"{MyStatus7.NexUniqueIDSize}-char hex")"
+                              @bind-Value:get="@sav7Nex.MyStatus.NexUniqueID"
+                              @bind-Value:set="@(value => SetNexUniqueId(sav7Nex.MyStatus, value))"
+                              Validation="@(new Func<string, string?>(v => ValidateHexString(v, MyStatus7.NexUniqueIDSize)))"
+                              For="@(() => sav7Nex.MyStatus.NexUniqueID)"/>
+            </div>
+        }
+
         <div class="form-field playtime-group">
             <div class="playtime-header">
                 <span class="playtime-label">Playtime</span>

--- a/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor
@@ -227,34 +227,40 @@
             </div>
         }
 
-        <div class="form-field">
-            <MudNumericField Label="Hours"
-                             T="@int"
-                             Variant="@Variant.Outlined"
-                             Min="0"
-                             Max="@ushort.MaxValue"
-                             @bind-Value="@saveFile.PlayedHours"
-                             For="@(() => saveFile.PlayedHours)"/>
-        </div>
-
-        <div class="form-field">
-            <MudNumericField Label="Minutes"
-                             T="@int"
-                             Variant="@Variant.Outlined"
-                             Min="0"
-                             Max="59"
-                             @bind-Value="@saveFile.PlayedMinutes"
-                             For="@(() => saveFile.PlayedMinutes)"/>
-        </div>
-
-        <div class="form-field">
-            <MudNumericField Label="Seconds"
-                             T="@int"
-                             Variant="@Variant.Outlined"
-                             Min="0"
-                             Max="59"
-                             @bind-Value="@saveFile.PlayedSeconds"
-                             For="@(() => saveFile.PlayedSeconds)"/>
+        <div class="form-field playtime-group">
+            <div class="playtime-header">
+                <span class="playtime-label">Playtime</span>
+                <span class="playtime-readout">@FormatPlaytime(saveFile)</span>
+                <MudTooltip Text="Reset to 0:00:00">
+                    <MudIconButton Icon="@Icons.Material.Filled.RestartAlt"
+                                   Size="@Size.Small"
+                                   OnClick="@(() => ResetPlaytime(saveFile))"
+                                   aria-label="Reset playtime"/>
+                </MudTooltip>
+            </div>
+            <div class="playtime-inputs">
+                <MudNumericField Label="Hours"
+                                 T="@int"
+                                 Variant="@Variant.Outlined"
+                                 Min="0"
+                                 Max="@ushort.MaxValue"
+                                 @bind-Value="@saveFile.PlayedHours"
+                                 For="@(() => saveFile.PlayedHours)"/>
+                <MudNumericField Label="Minutes"
+                                 T="@int"
+                                 Variant="@Variant.Outlined"
+                                 Min="0"
+                                 Max="59"
+                                 @bind-Value="@saveFile.PlayedMinutes"
+                                 For="@(() => saveFile.PlayedMinutes)"/>
+                <MudNumericField Label="Seconds"
+                                 T="@int"
+                                 Variant="@Variant.Outlined"
+                                 Min="0"
+                                 Max="59"
+                                 @bind-Value="@saveFile.PlayedSeconds"
+                                 For="@(() => saveFile.PlayedSeconds)"/>
+            </div>
         </div>
 
         @if (saveGeneration >= 4)

--- a/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor
@@ -379,7 +379,7 @@
                            Color="@Color.Primary"
                            StartIcon="@Icons.Material.Filled.Edit"
                            OnClick="@(() => OpenSayingsDialog(sav6Sayings))">
-                    Edit Trainer Card Sayings…
+                    View Trainer Card Sayings…
                 </MudButton>
             </div>
         }

--- a/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor
@@ -372,6 +372,30 @@
             </div>
         }
 
+        @if (saveFile is SAV6 sav6Sayings)
+        {
+            <div class="form-field">
+                <MudButton Variant="@Variant.Filled"
+                           Color="@Color.Primary"
+                           StartIcon="@Icons.Material.Filled.Edit"
+                           OnClick="@(() => OpenSayingsDialog(sav6Sayings))">
+                    Edit Trainer Card Sayings…
+                </MudButton>
+            </div>
+        }
+
+        @if (saveFile is SAV8SWSH sav8Card)
+        {
+            <div class="form-field">
+                <MudButton Variant="@Variant.Filled"
+                           Color="@Color.Primary"
+                           StartIcon="@Icons.Material.Filled.Edit"
+                           OnClick="@(() => OpenTrainerCardDialog(sav8Card))">
+                    Edit Trainer Card…
+                </MudButton>
+            </div>
+        }
+
         @if (saveFile is SAV1 sav1Rival)
         {
             <div class="form-field">

--- a/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor
@@ -339,6 +339,39 @@
             }
         }
 
+        @if (saveFile is SAV7 sav7Festa)
+        {
+            <div class="form-field">
+                <MudTextField Label="Festival Plaza Name"
+                              Variant="@Variant.Outlined"
+                              MaxLength="20"
+                              @bind-Value="@sav7Festa.Festa.FestivalPlazaName"
+                              For="@(() => sav7Festa.Festa.FestivalPlazaName)"/>
+            </div>
+        }
+
+        @if (saveFile is SAV9SV sav9Birthday)
+        {
+            <div class="form-field">
+                <MudNumericField Label="Birth Month"
+                                 T="@byte"
+                                 Variant="@Variant.Outlined"
+                                 Min="@((byte)1)"
+                                 Max="@((byte)12)"
+                                 @bind-Value="@sav9Birthday.MyStatus.BirthMonth"
+                                 For="@(() => sav9Birthday.MyStatus.BirthMonth)"/>
+            </div>
+            <div class="form-field">
+                <MudNumericField Label="Birth Day"
+                                 T="@byte"
+                                 Variant="@Variant.Outlined"
+                                 Min="@((byte)1)"
+                                 Max="@((byte)31)"
+                                 @bind-Value="@sav9Birthday.MyStatus.BirthDay"
+                                 For="@(() => sav9Birthday.MyStatus.BirthDay)"/>
+            </div>
+        }
+
         @if (saveFile is SAV1 sav1Rival)
         {
             <div class="form-field">

--- a/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor
@@ -144,6 +144,89 @@
             </div>
         }
 
+        @if (saveFile is SAV5 sav5Geo)
+        {
+            <div class="form-field">
+                <MudSelect Label="Country"
+                           Variant="@Variant.Outlined"
+                           @bind-Value="@sav5Geo.Country"
+                           @bind-Value:after="@UpdateCountry"
+                           For="@(() => sav5Geo.Country)">
+                    @foreach (var country in Countries.OrderBy(c => c.Text))
+                    {
+                        <MudSelectItem Value="@country.Value"
+                                       @key="@country.Value">
+                            @country.Text
+                        </MudSelectItem>
+                    }
+                </MudSelect>
+            </div>
+            <div class="form-field">
+                <MudSelect Label="Region"
+                           Variant="@Variant.Outlined"
+                           @bind-Value="@sav5Geo.Region"
+                           For="@(() => sav5Geo.Region)">
+                    @foreach (var region in Regions)
+                    {
+                        <MudSelectItem Value="@region.Value"
+                                       @key="@region.Value">
+                            @region.Text
+                        </MudSelectItem>
+                    }
+                </MudSelect>
+            </div>
+        }
+
+        @if (saveFile is IRegionOrigin regionSave)
+        {
+            <div class="form-field">
+                <MudSelect Label="Country"
+                           Variant="@Variant.Outlined"
+                           T="@byte"
+                           @bind-Value="@regionSave.Country"
+                           @bind-Value:after="@UpdateCountry"
+                           For="@(() => regionSave.Country)">
+                    @foreach (var country in Countries.OrderBy(c => c.Text))
+                    {
+                        <MudSelectItem Value="@((byte)country.Value)"
+                                       @key="@country.Value">
+                            @country.Text
+                        </MudSelectItem>
+                    }
+                </MudSelect>
+            </div>
+            <div class="form-field">
+                <MudSelect Label="Region"
+                           Variant="@Variant.Outlined"
+                           T="@byte"
+                           @bind-Value="@regionSave.Region"
+                           For="@(() => regionSave.Region)">
+                    @foreach (var region in Regions)
+                    {
+                        <MudSelectItem Value="@((byte)region.Value)"
+                                       @key="@region.Value">
+                            @region.Text
+                        </MudSelectItem>
+                    }
+                </MudSelect>
+            </div>
+            <div class="form-field">
+                <MudSelect Label="3DS Region"
+                           Variant="@Variant.Outlined"
+                           T="@byte"
+                           @bind-Value="@regionSave.ConsoleRegion"
+                           For="@(() => regionSave.ConsoleRegion)">
+                    @foreach (var consoleRegion in ConsoleRegions)
+                    {
+                        <MudSelectItem Value="@((byte)consoleRegion.Value)"
+                                       @key="@consoleRegion.Value">
+                            @consoleRegion.Text
+                        </MudSelectItem>
+                    }
+                </MudSelect>
+            </div>
+        }
+
         <div class="form-field">
             <MudNumericField Label="Hours"
                              T="@int"

--- a/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor
@@ -150,7 +150,7 @@
                 <MudSelect Label="Country"
                            Variant="@Variant.Outlined"
                            @bind-Value="@sav5Geo.Country"
-                           @bind-Value:after="@UpdateCountry"
+                           @bind-Value:after="@(() => OnSav5CountryChanged(sav5Geo))"
                            For="@(() => sav5Geo.Country)">
                     @foreach (var country in Countries.OrderBy(c => c.Text))
                     {
@@ -184,7 +184,7 @@
                            Variant="@Variant.Outlined"
                            T="@byte"
                            @bind-Value="@regionSave.Country"
-                           @bind-Value:after="@UpdateCountry"
+                           @bind-Value:after="@(() => OnRegionOriginCountryChanged(regionSave))"
                            For="@(() => regionSave.Country)">
                     @foreach (var country in Countries.OrderBy(c => c.Text))
                     {

--- a/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor
@@ -93,6 +93,24 @@
             </div>
         }
 
+        @if (Languages.Count > 0)
+        {
+            <div class="form-field">
+                <MudSelect Label="Language"
+                           Variant="@Variant.Outlined"
+                           @bind-Value="@saveFile.Language"
+                           For="@(() => saveFile.Language)">
+                    @foreach (var language in Languages)
+                    {
+                        <MudSelectItem Value="@language.Value"
+                                       @key="@language.Value">
+                            @language.Text
+                        </MudSelectItem>
+                    }
+                </MudSelect>
+            </div>
+        }
+
         @if (saveFile is SAV4 sav4Geo)
         {
             <div class="form-field">

--- a/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor.cs
@@ -98,6 +98,20 @@ public partial class TrainerInfoTab : IDisposable
             : [];
     }
 
+    private void OnSav5CountryChanged(SAV5 sav5)
+    {
+        // The previous sub-region value is almost certainly invalid for the new country's
+        // list; mirror the OtMiscTab.SetRegionOriginCountry pattern and zero it.
+        sav5.Region = 0;
+        UpdateCountry();
+    }
+
+    private void OnRegionOriginCountryChanged(IRegionOrigin regionSave)
+    {
+        regionSave.Region = 0;
+        UpdateCountry();
+    }
+
     private void UpdateCountry()
     {
         if (AppState.SaveFile is not { Generation: { } saveGeneration } saveFile)
@@ -471,7 +485,9 @@ public partial class TrainerInfoTab : IDisposable
                     "Poké Miles",
                     (uint)sav6.GetRecord(63),
                     v => sav6.SetRecord(63, (int)v),
-                    uint.MaxValue);
+                    // PKHeX's record store is int-typed. Cap the UI at int.MaxValue so the
+                    // cast in the setter can't overflow into a negative value.
+                    (uint)int.MaxValue);
                 break;
 
             case SAV7 sav7:

--- a/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor.cs
@@ -408,6 +408,37 @@ public partial class TrainerInfoTab : IDisposable
         }
     }
 
+    private async Task OpenSayingsDialog(SAV6 sav6)
+    {
+        var parameters = new DialogParameters
+        {
+            { nameof(SayingsDialog.Status), sav6.Status },
+            { nameof(SayingsDialog.XyNickname), sav6 is SAV6XY xy ? xy.Status : null },
+        };
+        var options = await DialogOptionsHelper.BuildAsync(MaxWidth.Small);
+        var dialog = await DialogService.ShowAsync<SayingsDialog>("Trainer Card Sayings", parameters, options);
+        var result = await dialog.Result;
+        if (result is { Canceled: false })
+        {
+            StateHasChanged();
+        }
+    }
+
+    private async Task OpenTrainerCardDialog(SAV8SWSH sav8)
+    {
+        var parameters = new DialogParameters
+        {
+            { nameof(TrainerCardDialog.Save), sav8 },
+        };
+        var options = await DialogOptionsHelper.BuildAsync(MaxWidth.Small);
+        var dialog = await DialogService.ShowAsync<TrainerCardDialog>("Trainer Card", parameters, options);
+        var result = await dialog.Result;
+        if (result is { Canceled: false })
+        {
+            StateHasChanged();
+        }
+    }
+
     private sealed record CurrencyDescriptor(string Label, uint Value, Action<uint> Set, uint Max);
 
     private static IEnumerable<CurrencyDescriptor> GetExtraCurrencies(SaveFile saveFile)

--- a/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor.cs
@@ -55,6 +55,8 @@ public partial class TrainerInfoTab : IDisposable
 
     private List<ComboItem> Regions { get; set; } = [];
 
+    private List<ComboItem> Languages { get; set; } = [];
+
     public void Dispose() =>
         RefreshService.OnAppStateChanged -= StateHasChanged;
 
@@ -67,7 +69,7 @@ public partial class TrainerInfoTab : IDisposable
         (GameStartedDate, GameStartedTime) = GetGameStarted();
         (HallOfFameDate, HallOfFameTime) = GetHallOfFame();
 
-        if (AppState.SaveFile is not { Generation: { } saveGeneration })
+        if (AppState.SaveFile is not { Generation: { } saveGeneration } saveFile)
         {
             return;
         }
@@ -81,6 +83,10 @@ public partial class TrainerInfoTab : IDisposable
 
         Countries = Util.GetCountryRegionList(countriesName, GameInfo.CurrentLanguage);
         UpdateCountry();
+
+        Languages = saveGeneration >= 3 && saveFile.Language >= 0
+            ? [..GameInfo.LanguageDataSource(saveGeneration, saveFile.Context)]
+            : [];
     }
 
     private void UpdateCountry()

--- a/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor.cs
@@ -15,15 +15,7 @@ public partial class TrainerInfoTab : IDisposable
         }
     }
 
-    private TimeSpan? GameStartedTime
-    {
-        get;
-        set
-        {
-            field = value;
-            UpdateGameStarted();
-        }
-    }
+
 
     private DateTime? HallOfFameDate
     {
@@ -71,7 +63,7 @@ public partial class TrainerInfoTab : IDisposable
     protected override void OnParametersSet()
     {
         base.OnParametersSet();
-        (GameStartedDate, GameStartedTime) = GetGameStarted();
+        GameStartedDate = GetGameStarted();
         (HallOfFameDate, HallOfFameTime) = GetHallOfFame();
 
         if (AppState.SaveFile is not { Generation: { } saveGeneration } saveFile)
@@ -93,7 +85,7 @@ public partial class TrainerInfoTab : IDisposable
             ? [..GameInfo.FilteredSources.ConsoleRegions]
             : [];
 
-        Languages = saveGeneration >= 3 && saveFile.Language >= 0
+        Languages = saveFile is not ILangDeviantSave && saveGeneration >= 3 && saveFile.Language >= 0
             ? [..GameInfo.LanguageDataSource(saveGeneration, saveFile.Context)]
             : [];
     }
@@ -635,29 +627,28 @@ public partial class TrainerInfoTab : IDisposable
         sav.SetWork(0x43 + index, g3Species);
     }
 
-    private (DateTime? Date, TimeSpan? Time) GetGameStarted()
+    private DateTime? GetGameStarted()
     {
         if (AppState.SaveFile is not { } saveFile)
         {
-            return (null, null);
+            return null;
         }
 
         DateTime date;
-        DateTime time;
 
         switch (saveFile)
         {
             case SAV4 sav:
-                DateUtil.GetDateTime2000(sav.SecondsToStart, out date, out time);
+                DateUtil.GetDateTime2000(sav.SecondsToStart, out date, out _);
                 break;
             case SAV5 sav:
-                DateUtil.GetDateTime2000(sav.SecondsToStart, out date, out time);
+                DateUtil.GetDateTime2000(sav.SecondsToStart, out date, out _);
                 break;
             case SAV6 sav:
-                DateUtil.GetDateTime2000(sav.SecondsToStart, out date, out time);
+                DateUtil.GetDateTime2000(sav.SecondsToStart, out date, out _);
                 break;
             case SAV7 sav:
-                DateUtil.GetDateTime2000(sav.SecondsToStart, out date, out time);
+                DateUtil.GetDateTime2000(sav.SecondsToStart, out date, out _);
                 break;
             case SAV8SWSH sav:
             {
@@ -666,58 +657,54 @@ public partial class TrainerInfoTab : IDisposable
                 var card = sav.Blocks.TrainerCard;
                 if (card.StartedYear == 0)
                 {
-                    return (null, null);
+                    return null;
                 }
                 date = new DateTime(card.StartedYear, card.StartedMonth, card.StartedDay);
-                time = date;
                 break;
             }
             case SAV8BS sav:
                 // BDSP stores the start as a real DateTime under SystemData8b, not seconds.
                 date = sav.System.LocalTimestampStart;
-                time = date;
                 break;
             case SAV8LA sav:
-                DateUtil.GetDateTime2000(sav.SecondsToStart, out date, out time);
+                DateUtil.GetDateTime2000(sav.SecondsToStart, out date, out _);
                 break;
             case SAV9SV sav:
                 date = sav.EnrollmentDate.Timestamp;
-                time = sav.EnrollmentDate.Timestamp;
                 break;
             default:
-                return (null, null);
+                return null;
         }
 
-        return (date, time.TimeOfDay);
+        return date;
     }
 
     private void UpdateGameStarted()
     {
-        if (AppState.SaveFile is not { } saveFile || GameStartedDate is null || GameStartedTime is null)
+        if (AppState.SaveFile is not { } saveFile || GameStartedDate is null)
         {
             return;
         }
 
         var date = GameStartedDate.Value;
-        var time = GameStartedTime.Value;
 
         switch (saveFile)
         {
             case SAV4 sav:
                 sav.SecondsToStart =
-                    (uint)DateUtil.GetSecondsFrom2000(date, new(2000, 1, 1, time.Hours, time.Minutes, time.Seconds));
+                    (uint)DateUtil.GetSecondsFrom2000(date, new(2000, 1, 1, date.Hour, date.Minute, date.Second));
                 break;
             case SAV5 sav:
                 sav.SecondsToStart =
-                    (uint)DateUtil.GetSecondsFrom2000(date, new(2000, 1, 1, time.Hours, time.Minutes, time.Seconds));
+                    (uint)DateUtil.GetSecondsFrom2000(date, new(2000, 1, 1, date.Hour, date.Minute, date.Second));
                 break;
             case SAV6 sav:
                 sav.SecondsToStart =
-                    (uint)DateUtil.GetSecondsFrom2000(date, new(2000, 1, 1, time.Hours, time.Minutes, time.Seconds));
+                    (uint)DateUtil.GetSecondsFrom2000(date, new(2000, 1, 1, date.Hour, date.Minute, date.Second));
                 break;
             case SAV7 sav:
                 sav.SecondsToStart =
-                    (uint)DateUtil.GetSecondsFrom2000(date, new(2000, 1, 1, time.Hours, time.Minutes, time.Seconds));
+                    (uint)DateUtil.GetSecondsFrom2000(date, new(2000, 1, 1, date.Hour, date.Minute, date.Second));
                 break;
             case SAV8SWSH sav:
             {
@@ -730,12 +717,12 @@ public partial class TrainerInfoTab : IDisposable
             case SAV8BS sav:
                 sav.System.LocalTimestampStart = new DateTime(
                     date.Year, date.Month, date.Day,
-                    time.Hours, time.Minutes, time.Seconds,
+                    date.Hour, date.Minute, date.Second,
                     DateTimeKind.Local);
                 break;
             case SAV8LA sav:
                 sav.SecondsToStart =
-                    (uint)DateUtil.GetSecondsFrom2000(date, new(2000, 1, 1, time.Hours, time.Minutes, time.Seconds));
+                    (uint)DateUtil.GetSecondsFrom2000(date, new(2000, 1, 1, date.Hour, date.Minute, date.Second));
                 break;
             case SAV9SV sav:
                 sav.EnrollmentDate.Timestamp = date;
@@ -802,35 +789,35 @@ public partial class TrainerInfoTab : IDisposable
         {
             case SAV4 sav:
                 sav.SecondsToFame =
-                    (uint)DateUtil.GetSecondsFrom2000(date, new(2000, 1, 1, time.Hours, time.Minutes, time.Seconds));
+                    (uint)DateUtil.GetSecondsFrom2000(date, new(2000, 1, 1, date.Hour, date.Minute, date.Second));
                 break;
             case SAV5 sav:
                 sav.SecondsToFame =
-                    (uint)DateUtil.GetSecondsFrom2000(date, new(2000, 1, 1, time.Hours, time.Minutes, time.Seconds));
+                    (uint)DateUtil.GetSecondsFrom2000(date, new(2000, 1, 1, date.Hour, date.Minute, date.Second));
                 break;
             case SAV6 sav:
                 sav.SecondsToFame =
-                    (uint)DateUtil.GetSecondsFrom2000(date, new(2000, 1, 1, time.Hours, time.Minutes, time.Seconds));
+                    (uint)DateUtil.GetSecondsFrom2000(date, new(2000, 1, 1, date.Hour, date.Minute, date.Second));
                 break;
             case SAV7 sav:
                 sav.SecondsToFame =
-                    (uint)DateUtil.GetSecondsFrom2000(date, new(2000, 1, 1, time.Hours, time.Minutes, time.Seconds));
+                    (uint)DateUtil.GetSecondsFrom2000(date, new(2000, 1, 1, date.Hour, date.Minute, date.Second));
                 break;
             case SAV8SWSH sav:
                 sav.SecondsToFame =
-                    (uint)DateUtil.GetSecondsFrom2000(date, new(2000, 1, 1, time.Hours, time.Minutes, time.Seconds));
+                    (uint)DateUtil.GetSecondsFrom2000(date, new(2000, 1, 1, date.Hour, date.Minute, date.Second));
                 break;
             case SAV8BS sav:
                 sav.SecondsToFame =
-                    (uint)DateUtil.GetSecondsFrom2000(date, new(2000, 1, 1, time.Hours, time.Minutes, time.Seconds));
+                    (uint)DateUtil.GetSecondsFrom2000(date, new(2000, 1, 1, date.Hour, date.Minute, date.Second));
                 break;
             case SAV8LA sav:
                 sav.SecondsToFame =
-                    (uint)DateUtil.GetSecondsFrom2000(date, new(2000, 1, 1, time.Hours, time.Minutes, time.Seconds));
+                    (uint)DateUtil.GetSecondsFrom2000(date, new(2000, 1, 1, date.Hour, date.Minute, date.Second));
                 break;
             case SAV9SV sav:
                 sav.SecondsToFame =
-                    (uint)DateUtil.GetSecondsFrom2000(date, new(2000, 1, 1, time.Hours, time.Minutes, time.Seconds));
+                    (uint)DateUtil.GetSecondsFrom2000(date, new(2000, 1, 1, date.Hour, date.Minute, date.Second));
                 break;
             default:
                 return;

--- a/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor.cs
@@ -356,6 +356,16 @@ public partial class TrainerInfoTab : IDisposable
         // Gen 3 does not store OT gender on the PKM, so skip the gender check for those.
         (pkm.Format <= 3 || pkm.OriginalTrainerGender == gender);
 
+    private static string FormatPlaytime(SaveFile saveFile) =>
+        $"{saveFile.PlayedHours}:{saveFile.PlayedMinutes:D2}:{saveFile.PlayedSeconds:D2}";
+
+    private static void ResetPlaytime(SaveFile saveFile)
+    {
+        saveFile.PlayedHours = 0;
+        saveFile.PlayedMinutes = 0;
+        saveFile.PlayedSeconds = 0;
+    }
+
     private uint GetCoins() => AppState.SaveFile switch
     {
         SAV1 sav => sav.Coin,

--- a/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor.cs
@@ -366,6 +366,45 @@ public partial class TrainerInfoTab : IDisposable
         saveFile.PlayedSeconds = 0;
     }
 
+    private static string? ValidateHexString(string value, int expectedLength)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return "Required";
+        }
+
+        if (value.Length != expectedLength)
+        {
+            return $"Must be exactly {expectedLength} characters";
+        }
+
+        return value.All(IsHexChar) ? null : "Hex digits only (0-9, A-F)";
+    }
+
+    private static bool IsHexChar(char c) =>
+        (c is >= '0' and <= '9') ||
+        (c is >= 'a' and <= 'f') ||
+        (c is >= 'A' and <= 'F');
+
+    private static void SetGameSyncId(IGameSync sync, string value)
+    {
+        // PKHeX's setter throws ArgumentOutOfRangeException on length mismatch and
+        // silently accepts non-hex chars (treating them as 0). Guard both before
+        // committing so partial input stays in the textbox without corrupting the save.
+        if (value.Length == sync.GameSyncIDSize && value.All(IsHexChar))
+        {
+            sync.GameSyncID = value;
+        }
+    }
+
+    private static void SetNexUniqueId(MyStatus7 status, string value)
+    {
+        if (value.Length == MyStatus7.NexUniqueIDSize && value.All(IsHexChar))
+        {
+            status.NexUniqueID = value;
+        }
+    }
+
     private uint GetCoins() => AppState.SaveFile switch
     {
         SAV1 sav => sav.Coin,

--- a/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor.cs
@@ -47,7 +47,10 @@ public partial class TrainerInfoTab : IDisposable
 
     private InputDateType GameStartType => AppState.SaveFile switch
     {
-        SAV4 or SAV5 or SAV6 or SAV7 or SAV8SWSH or SAV8BS or SAV8LA => InputDateType.DateTimeLocal,
+        // SwSh stores the adventure-start as Year/Month/Day on the Trainer Card
+        // with no time component, so use a date-only picker.
+        SAV8SWSH => InputDateType.Date,
+        SAV4 or SAV5 or SAV6 or SAV7 or SAV8BS or SAV8LA => InputDateType.DateTimeLocal,
         _ => InputDateType.Date
     };
 
@@ -610,10 +613,22 @@ public partial class TrainerInfoTab : IDisposable
                 DateUtil.GetDateTime2000(sav.SecondsToStart, out date, out time);
                 break;
             case SAV8SWSH sav:
-                DateUtil.GetDateTime2000(sav.SecondsToStart, out date, out time);
+            {
+                // SwSh doesn't use SecondsToStart; adventure-start lives on the Trainer Card
+                // as separate Y/M/D bytes. Year=0 means uninitialized.
+                var card = sav.Blocks.TrainerCard;
+                if (card.StartedYear == 0)
+                {
+                    return (null, null);
+                }
+                date = new DateTime(card.StartedYear, card.StartedMonth, card.StartedDay);
+                time = date;
                 break;
+            }
             case SAV8BS sav:
-                DateUtil.GetDateTime2000(sav.SecondsToStart, out date, out time);
+                // BDSP stores the start as a real DateTime under SystemData8b, not seconds.
+                date = sav.System.LocalTimestampStart;
+                time = date;
                 break;
             case SAV8LA sav:
                 DateUtil.GetDateTime2000(sav.SecondsToStart, out date, out time);
@@ -658,12 +673,18 @@ public partial class TrainerInfoTab : IDisposable
                     (uint)DateUtil.GetSecondsFrom2000(date, new(2000, 1, 1, time.Hours, time.Minutes, time.Seconds));
                 break;
             case SAV8SWSH sav:
-                sav.SecondsToStart =
-                    (uint)DateUtil.GetSecondsFrom2000(date, new(2000, 1, 1, time.Hours, time.Minutes, time.Seconds));
+            {
+                var card = sav.Blocks.TrainerCard;
+                card.StartedYear = (ushort)date.Year;
+                card.StartedMonth = (byte)date.Month;
+                card.StartedDay = (byte)date.Day;
                 break;
+            }
             case SAV8BS sav:
-                sav.SecondsToStart =
-                    (uint)DateUtil.GetSecondsFrom2000(date, new(2000, 1, 1, time.Hours, time.Minutes, time.Seconds));
+                sav.System.LocalTimestampStart = new DateTime(
+                    date.Year, date.Month, date.Day,
+                    time.Hours, time.Minutes, time.Seconds,
+                    DateTimeKind.Local);
                 break;
             case SAV8LA sav:
                 sav.SecondsToStart =

--- a/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor.cs
@@ -55,6 +55,8 @@ public partial class TrainerInfoTab : IDisposable
 
     private List<ComboItem> Regions { get; set; } = [];
 
+    private List<ComboItem> ConsoleRegions { get; set; } = [];
+
     private List<ComboItem> Languages { get; set; } = [];
 
     public void Dispose() =>
@@ -83,6 +85,10 @@ public partial class TrainerInfoTab : IDisposable
 
         Countries = Util.GetCountryRegionList(countriesName, GameInfo.CurrentLanguage);
         UpdateCountry();
+
+        ConsoleRegions = saveFile is IRegionOrigin
+            ? [..GameInfo.FilteredSources.ConsoleRegions]
+            : [];
 
         Languages = saveGeneration >= 3 && saveFile.Language >= 0
             ? [..GameInfo.LanguageDataSource(saveGeneration, saveFile.Context)]

--- a/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor.cs
@@ -405,6 +405,136 @@ public partial class TrainerInfoTab : IDisposable
         }
     }
 
+    private sealed record CurrencyDescriptor(string Label, uint Value, Action<uint> Set, uint Max);
+
+    private static IEnumerable<CurrencyDescriptor> GetExtraCurrencies(SaveFile saveFile)
+    {
+        switch (saveFile)
+        {
+            case SAV4HGSS hgss:
+                yield return new CurrencyDescriptor(
+                    "Pokéathlon Points",
+                    hgss.PokeathlonPoints,
+                    v => hgss.PokeathlonPoints = v,
+                    uint.MaxValue);
+                break;
+
+            case SAV5 sav5:
+                yield return new CurrencyDescriptor(
+                    "Battle Subway BP",
+                    (uint)sav5.BattleSubway.BP,
+                    v => sav5.BattleSubway.BP = (int)v,
+                    9999);
+                break;
+
+            case SAV6 sav6:
+                yield return new CurrencyDescriptor(
+                    "BP",
+                    (uint)sav6.BP,
+                    v => sav6.BP = (int)v,
+                    9999);
+                yield return new CurrencyDescriptor(
+                    "Poké Miles",
+                    (uint)sav6.GetRecord(63),
+                    v => sav6.SetRecord(63, (int)v),
+                    uint.MaxValue);
+                break;
+
+            case SAV7 sav7:
+                yield return new CurrencyDescriptor(
+                    "BP",
+                    sav7.Misc.BP,
+                    v => sav7.Misc.BP = v,
+                    9999);
+                yield return new CurrencyDescriptor(
+                    "Festival Coins",
+                    (uint)sav7.Festa.FestaCoins,
+                    // Setter mirrors to TotalFestaCoins via SAV.GetRecord(038) + value; never bypass.
+                    v => sav7.Festa.FestaCoins = (int)v,
+                    9_999_999);
+                break;
+
+            case SAV8SWSH swsh:
+                yield return new CurrencyDescriptor(
+                    "BP",
+                    (uint)swsh.Misc.BP,
+                    v => swsh.Misc.BP = (int)v,
+                    9999);
+                yield return new CurrencyDescriptor(
+                    "Watt",
+                    swsh.MyStatus.Watt,
+                    v =>
+                    {
+                        swsh.MyStatus.Watt = v;
+                        // Mirror to the WattTotal record so legality stays clean (mirrors SAV_Trainer8.cs).
+                        if (swsh.GetRecord(Record8.WattTotal) < (int)v)
+                        {
+                            swsh.SetRecord(Record8.WattTotal, (int)v);
+                        }
+                    },
+                    9_999_999);
+                break;
+
+            case SAV8BS bs:
+                yield return new CurrencyDescriptor(
+                    "BP",
+                    bs.BattleTower.BP,
+                    v => bs.BattleTower.BP = v,
+                    uint.MaxValue);
+                break;
+
+            case SAV8LA la:
+                yield return new CurrencyDescriptor(
+                    "Merit Points",
+                    la.Blocks.GetBlockValue<uint>(SaveBlockAccessor8LA.KMeritCurrent),
+                    v => la.Blocks.SetBlockValue(SaveBlockAccessor8LA.KMeritCurrent, v),
+                    uint.MaxValue);
+                yield return new CurrencyDescriptor(
+                    "Merit Earned (Total)",
+                    la.Blocks.GetBlockValue<uint>(SaveBlockAccessor8LA.KMeritEarnedTotal),
+                    v => la.Blocks.SetBlockValue(SaveBlockAccessor8LA.KMeritEarnedTotal, v),
+                    uint.MaxValue);
+                break;
+
+            case SAV9SV sv:
+                yield return new CurrencyDescriptor(
+                    "League Points",
+                    sv.LeaguePoints,
+                    v => sv.LeaguePoints = v,
+                    uint.MaxValue);
+                if (sv.SaveRevision >= 2)
+                {
+                    yield return new CurrencyDescriptor(
+                        "Blueberry Points",
+                        sv.BlueberryPoints,
+                        v => sv.BlueberryPoints = v,
+                        uint.MaxValue);
+                }
+                break;
+
+            case SAV9ZA za:
+                yield return new CurrencyDescriptor(
+                    "Royale Points",
+                    za.TicketPointsRoyale,
+                    v => za.TicketPointsRoyale = v,
+                    310_000);
+                yield return new CurrencyDescriptor(
+                    "Royale Points (Infinite)",
+                    za.TicketPointsRoyaleInfinite,
+                    v => za.TicketPointsRoyaleInfinite = v,
+                    50_000);
+                if (za.SaveRevision != 0)
+                {
+                    yield return new CurrencyDescriptor(
+                        "Hyperspace Survey Points",
+                        za.Blocks.GetBlockValue<uint>(SaveBlockAccessor9ZA.KHyperspaceSurveyPoints),
+                        v => za.Blocks.SetBlockValue(SaveBlockAccessor9ZA.KHyperspaceSurveyPoints, v),
+                        100_000);
+                }
+                break;
+        }
+    }
+
     private uint GetCoins() => AppState.SaveFile switch
     {
         SAV1 sav => sav.Coin,

--- a/Pkmds.Rcl/wwwroot/css/app.css
+++ b/Pkmds.Rcl/wwwroot/css/app.css
@@ -603,6 +603,42 @@ body, html {
     margin-bottom: 0.5rem;
 }
 
+.playtime-group {
+    grid-column: 1 / -1;
+}
+
+.playtime-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.playtime-label {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--mud-palette-text-secondary);
+}
+
+.playtime-readout {
+    font-family: var(--mud-typography-monospace-family, ui-monospace, monospace);
+    font-size: 0.875rem;
+    color: var(--mud-palette-text-primary);
+}
+
+.playtime-inputs {
+    display: flex;
+    gap: 0.75rem;
+    align-items: flex-start;
+    flex-wrap: wrap;
+}
+
+.playtime-inputs > .mud-input-control {
+    flex: 1 1 6rem;
+    min-width: 5rem;
+    max-width: 10rem;
+}
+
 .pkmds-splash {
     position: fixed;
     inset: 0;


### PR DESCRIPTION
## Summary

Promotes two ticket rollouts from `dev` to `main`.

### #361 — Trainer customization, phases 1–5

Bundles seven commits implementing the first five phases of the roadmap. Phase 6 (appearance editor) was extracted to #873; phase 7 (memo/notes) was dropped. See the [rollout summary on #361](https://github.com/codemonkey85/PKMDS-Blazor/issues/361#issuecomment-4425469957) for the full breakdown.

- **Phase 1** — Language `MudSelect` for Gen 3 GC + Gen 4+. Also surfaces the SAV5/6/7 Country/Region selects (the code-behind populated them, only SAV4 had Razor markup) plus a new 3DS Console Region select for `IRegionOrigin` saves.
- **Phase 2** — Grouped Hours/Min/Sec into one row with `HH:MM:SS` readout and reset button.
- **Phase 3** — Game Sync ID: Gen 5 uint, Gen 6/7/7b 16-char hex (validated client-side to avoid PKHeX's `ArgumentOutOfRangeException` on partial input). Gen 7 `NexUniqueID` (32-char hex).
- **Phase 4** — Per-gen currency editors via a new `CurrencyDescriptor` registry: Pokéathlon (HGSS), Battle Subway BP (Gen 5), BP + Poké Miles (Gen 6), BP + Festival Coins (Gen 7), BP + Watt with `Record8.WattTotal` mirror (SwSh), BP (BDSP), Merit Current/Earned (PLA), League Points + Blueberry Points (SV, revision-gated), Royale + Royale Infinite + Hyperspace Survey (ZA, revision-gated).
- **Phase 5** —
  - **Bug fix**: SwSh and BDSP "Game Start" date never persisted before — both fell through to `SaveFile.SecondsToStart`'s base auto-property. Re-routed SwSh through `TrainerCard.StartedYear/Month/Day` and BDSP through `System.LocalTimestampStart`.
  - Inline: Gen 7 Festival Plaza name; Gen 9 SV Birth Month/Day.
  - New `SayingsDialog` for Gen 6 (5 PSS Sayings + XY Nickname, snapshot/apply).
  - New `TrainerCardDialog` for SwSh (OT, Number synced to `MyStatus.Number`, TrainerID, RotoRallyScore which auto-mirrors `KRotoRally`).

### #870 — Joyful Game Records (Gen 3)

- Adds a **Joyful Game Records** section to the Gen 3 **Records** tab.
- Surfaces every field PKHeX exposes through `ISaveBlock3SmallExpansion` (FR/LG and Emerald): Pokémon Jump (high score, in-a-row, 5-in-a-row, max-player games), Dodrio Berry Picking (high score, in-a-row, 5-in-a-row), and Berry Powder.
- Lets players reach the 200-point threshold for the FR/LG trainer-card stars without a wireless-adapter link partner.
- Section is gated on `ISaveBlock3SmallExpansion` so Ruby/Sapphire saves remain unchanged.

## Test plan

### #361 trainer customization
- [ ] Load a Gen 4+ save → Language dropdown reflects current language → change → save → reload → persists.
- [ ] Load XY / ORAS / SM / USUM → Country + Region + 3DS Region selects render with correct per-gen lists.
- [ ] Edit Playtime fields → live `HH:MM:SS` readout updates; reset button zeros all three.
- [ ] Edit Gen 5 Game Sync ID (uint) and Gen 6/7 16-char hex → validation error on partial input, no crash, no save corruption.
- [ ] Edit per-gen currencies. Specifically: SwSh Watt above the current `Record8.WattTotal` value → reopen in PKHeX desktop → legality remains clean.
- [ ] **Critical regression**: SwSh + BDSP Game Start date — set a distinctive date (e.g. 2023-03-15) → save → reload → date sticks. Previously silently dropped.
- [ ] Gen 6 "Edit Trainer Card Sayings…" — edit each saying → Confirm persists, Cancel reverts.
- [ ] SwSh "Edit Trainer Card…" — edit OT/Number/TrainerID/RotoRallyScore → verify Number propagates to both `MyStatus.Number` and `TrainerCard.Number`.
- [ ] Gen 7 Festival Plaza Name and Gen 9 SV Birth Month/Day inline edits round-trip.
- [ ] Existing trainer features (OT/TID/SID sync, gender toggle, rival names, money, coins, Gen 3 BP/EarnedBP, Game Start for Gen 4–7 / LA / SV) — no regression.

### #870 Joyful records
- [x] Load a FireRed/LeafGreen save → Records tab → confirm the **Joyful Game Records** card appears.
- [ ] Set Pokémon Jump and Dodrio Berry Picking scores to 200, save, reload in PKHeX/the game → trainer-card star awarded.
- [x] Load a Ruby/Sapphire save → section is hidden; existing Records dropdown still works.
- [x] Load an Emerald save → section appears (Emerald's small block also implements the interface).
- [x] Verify counter fields clamp at 9,999 and score fields at 99,990 in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)