### PR TITLE
feat(perf): add WASM build config measurement harness (#883)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -369,3 +369,6 @@ Pkmds.Rcl/bin/sha256sums.txt
 
 # Local diagnostic output from tools/report-missing-descriptions.cs
 missing-flavor-report.txt
+
+# Local diagnostic output from measure-publish.ps1 (perf measurement reports)
+measurements/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,6 +202,47 @@ dotnet run tools/scrape-pokemondb-descriptions.cs -- --force            # re-scr
 
 The scraper is incremental — re-running it only fetches entries that aren't already in the cache (or that were previously 404, unless `--retry-notfound` is passed). Ctrl+C saves partial progress. After running the scraper, rerun `generate-descriptions.cs` to pick up the new overrides; passing `--overrides` is optional because it auto-discovers `tools/data/description-overrides.json` from the repo root.
 
+## Performance measurement
+
+Used to compare WASM build configs (AOT, SIMD, trim, ...) on build time, deploy size, and runtime perf. See issue #883 for the ongoing investigation.
+
+### `measure-publish.ps1`
+
+Publishes `Pkmds.Web` in Release with optional MSBuild args, measures publish time and output size, and writes a labeled markdown report to `measurements/<Label>.md`. Cleans `release/` AND `obj/Release` for each project before publishing so build-time numbers reflect a true cold build.
+
+```powershell
+# Baseline (current settings)
+./measure-publish.ps1 -Label baseline
+
+# Flip one or more knobs
+./measure-publish.ps1 -Label simd-on  -MSBuildArgs '-p:WasmEnableSIMD=true'
+./measure-publish.ps1 -Label aot-on   -MSBuildArgs '-p:RunAOTCompilation=true'
+./measure-publish.ps1 -Label aot-simd -MSBuildArgs '-p:RunAOTCompilation=true','-p:WasmEnableSIMD=true'
+
+# Also run the runtime benchmark via Playwright (see below)
+./measure-publish.ps1 -Label baseline -RunBenchmark
+```
+
+The `measurements/` directory is gitignored — these reports are local diagnostics, not artifacts to commit.
+
+### `tools/bench/` — Playwright runtime harness
+
+Drives the hidden `/bench` route in headless Chromium against a published build and appends runtime numbers to the same `measurements/<Label>.md` report.
+
+- `Pkmds.Rcl/Components/Pages/Benchmark.razor` — unlinked `/bench` page that runs four PKHeX hot-path workloads (legality analysis, encryption roundtrip, search filter over a full populated SAV, encounter generation) and reports JSON via `#bench-result` + `console.log`.
+- `Pkmds.Rcl/Services/BenchmarkRunner.cs` — synthetic SAV9SV factory + per-workload iteration + summary stats (mean/min/max/stddev/ops-per-sec).
+- `tools/bench/run-bench.mjs` — Node script that serves the published `wwwroot`, launches Chromium, navigates to `/bench`, waits for `data-bench-state="done"`, scrapes the JSON, and appends a markdown section.
+
+One-time setup:
+```powershell
+Push-Location tools/bench
+npm install
+npx playwright install chromium
+Pop-Location
+```
+
+The bench page is hidden — no nav link, just reachable by typing `/bench`. Triggered automatically by `measure-publish.ps1 -RunBenchmark`.
+
 ## MudBlazor and Razor gotchas
 
 - `ComboItem` (PKHeX) is a **sealed record** (reference type). Using `ComboItem?` in a Razor `@bind-Value` triggers CS8669 in the Razor-generated code — use `int?` with `.Value` for select bindings instead.

--- a/Pkmds.Rcl/Components/Pages/Benchmark.razor
+++ b/Pkmds.Rcl/Components/Pages/Benchmark.razor
@@ -1,0 +1,53 @@
+@page "/bench"
+@layout MinimalLayout
+@using System.Text.Json
+
+<PageTitle>Benchmark</PageTitle>
+
+<div id="bench-root" data-bench-state="@state">
+    <h1 style="font-family: monospace">PKHeX runtime benchmark</h1>
+    <p style="font-family: monospace">State: <strong>@state</strong></p>
+    @if (!string.IsNullOrEmpty(error))
+    {
+        <pre id="bench-error" style="color: red; white-space: pre-wrap;">@error</pre>
+    }
+    <pre id="bench-result" style="white-space: pre-wrap; font-family: monospace;">@resultJson</pre>
+</div>
+
+@code {
+    private string state = "init";
+    private string? error;
+    private string resultJson = "";
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender)
+        {
+            return;
+        }
+
+        state = "running";
+        StateHasChanged();
+        await Task.Yield();
+
+        try
+        {
+            var runner = new BenchmarkRunner();
+            var report = runner.Run();
+
+            var ua = await JSRuntime.InvokeAsync<string>("eval", "navigator.userAgent");
+            report = report with { UserAgent = ua };
+
+            resultJson = JsonSerializer.Serialize(report, new JsonSerializerOptions { WriteIndented = true });
+            state = "done";
+            await JSRuntime.InvokeVoidAsync("console.log", "BENCH_RESULT_JSON:" + JsonSerializer.Serialize(report));
+        }
+        catch (Exception ex)
+        {
+            error = ex.ToString();
+            state = "error";
+        }
+
+        StateHasChanged();
+    }
+}

--- a/Pkmds.Rcl/Components/Pages/Benchmark.razor
+++ b/Pkmds.Rcl/Components/Pages/Benchmark.razor
@@ -28,14 +28,14 @@
 
         state = "running";
         StateHasChanged();
-        await Task.Yield();
+        await Task.Delay(1);
 
         try
         {
             var runner = new BenchmarkRunner();
             var report = runner.Run();
 
-            var ua = await JSRuntime.InvokeAsync<string>("eval", "navigator.userAgent");
+            var ua = await JSRuntime.InvokeAsync<string>("pkmdsGetUserAgent");
             report = report with { UserAgent = ua };
 
             resultJson = JsonSerializer.Serialize(report, new JsonSerializerOptions { WriteIndented = true });

--- a/Pkmds.Rcl/Models/BenchmarkResult.cs
+++ b/Pkmds.Rcl/Models/BenchmarkResult.cs
@@ -1,0 +1,21 @@
+namespace Pkmds.Rcl.Models;
+
+public sealed record BenchmarkResult
+{
+    public required string Name { get; init; }
+    public required int Iterations { get; init; }
+    public required int OpsPerIteration { get; init; }
+    public required double TotalMs { get; init; }
+    public required double MeanMs { get; init; }
+    public required double MinMs { get; init; }
+    public required double MaxMs { get; init; }
+    public required double StdDevMs { get; init; }
+    public double OpsPerSecond => Iterations * OpsPerIteration / (TotalMs / 1000.0);
+}
+
+public sealed record BenchmarkReport
+{
+    public required DateTimeOffset Date { get; init; }
+    public required string UserAgent { get; init; }
+    public required IReadOnlyList<BenchmarkResult> Results { get; init; }
+}

--- a/Pkmds.Rcl/Models/BenchmarkResult.cs
+++ b/Pkmds.Rcl/Models/BenchmarkResult.cs
@@ -10,7 +10,7 @@ public sealed record BenchmarkResult
     public required double MinMs { get; init; }
     public required double MaxMs { get; init; }
     public required double StdDevMs { get; init; }
-    public double OpsPerSecond => Iterations * OpsPerIteration / (TotalMs / 1000.0);
+    public double OpsPerSecond => TotalMs > 0 ? Iterations * OpsPerIteration / (TotalMs / 1000.0) : 0;
 }
 
 public sealed record BenchmarkReport

--- a/Pkmds.Rcl/Services/BenchmarkRunner.cs
+++ b/Pkmds.Rcl/Services/BenchmarkRunner.cs
@@ -1,0 +1,252 @@
+using System.Diagnostics;
+using Pkmds.Rcl.Models;
+
+namespace Pkmds.Rcl.Services;
+
+/// <summary>
+/// Runs deterministic micro-benchmarks against PKHeX hot paths.
+/// Used by the /bench page to compare runtime perf between WASM build configs
+/// (SIMD, AOT, trim, ...) — see issue #883 and measure-publish.ps1.
+/// </summary>
+public sealed class BenchmarkRunner
+{
+    private static readonly ushort[] BenchSpecies =
+    [
+        (ushort)Species.Pikachu,        // 25
+        (ushort)Species.Charizard,      // 6
+        (ushort)Species.Garchomp,       // 445
+        (ushort)Species.Sprigatito,     // 906
+        (ushort)Species.IronHands,      // 1003
+        (ushort)Species.IronValiant,    // 1006
+    ];
+
+    private const int CopiesPerSpecies = 5;
+    private const int WarmupIterations = 5;
+
+    public record BenchmarkConfig(
+        int LegalityIterations = 100,
+        int EncryptionIterations = 5000,
+        int SearchIterations = 200,
+        int EncounterIterations = 10);
+
+    public BenchmarkReport Run(BenchmarkConfig? config = null)
+    {
+        config ??= new BenchmarkConfig();
+
+        var sav = BlankSaveFile.Get(GameVersion.SL, "BENCH", LanguageID.English);
+        var pkms = BuildBenchPkms(sav);
+        PopulateBox(sav, pkms);
+
+        var results = new List<BenchmarkResult>
+        {
+            RunLegality(pkms, config.LegalityIterations),
+            RunEncryption(pkms, config.EncryptionIterations),
+            RunSearch(sav, config.SearchIterations),
+            RunEncounterGeneration(sav, config.EncounterIterations),
+        };
+
+        return new BenchmarkReport
+        {
+            Date = DateTimeOffset.UtcNow,
+            UserAgent = "",
+            Results = results,
+        };
+    }
+
+    private static PK9[] BuildBenchPkms(SaveFile sav)
+    {
+        var list = new List<PK9>(BenchSpecies.Length * CopiesPerSpecies);
+        foreach (var species in BenchSpecies)
+        {
+            var template = (PK9)sav.BlankPKM.Clone();
+            template.Species = species;
+            var enc = EncounterMovesetGenerator.GenerateEncounters(template, sav, ReadOnlyMemory<ushort>.Empty).FirstOrDefault();
+            if (enc is null)
+            {
+                throw new InvalidOperationException($"No encounter generated for species {species} — bench cannot proceed.");
+            }
+            var pkm = (PK9)enc.ConvertToPKM(sav);
+            for (var i = 0; i < CopiesPerSpecies; i++)
+            {
+                list.Add((PK9)pkm.Clone());
+            }
+        }
+        return [.. list];
+    }
+
+    private static void PopulateBox(SaveFile sav, PK9[] pkms)
+    {
+        for (var i = 0; i < pkms.Length && i < sav.BoxCount * sav.BoxSlotCount; i++)
+        {
+            var box = i / sav.BoxSlotCount;
+            var slot = i % sav.BoxSlotCount;
+            sav.SetBoxSlotAtIndex(pkms[i], box, slot);
+        }
+    }
+
+    private static BenchmarkResult RunLegality(PK9[] pkms, int iterations)
+    {
+        for (var w = 0; w < WarmupIterations; w++)
+        {
+            foreach (var pkm in pkms)
+            {
+                _ = new LegalityAnalysis(pkm);
+            }
+        }
+
+        var timings = new double[iterations];
+        var sw = new Stopwatch();
+        for (var it = 0; it < iterations; it++)
+        {
+            sw.Restart();
+            foreach (var pkm in pkms)
+            {
+                _ = new LegalityAnalysis(pkm);
+            }
+            sw.Stop();
+            timings[it] = sw.Elapsed.TotalMilliseconds;
+        }
+
+        return Summarize("legality", timings, opsPerIteration: pkms.Length);
+    }
+
+    private static BenchmarkResult RunEncryption(PK9[] pkms, int iterations)
+    {
+        var buf = new byte[pkms[0].SIZE_PARTY];
+
+        for (var w = 0; w < WarmupIterations; w++)
+        {
+            foreach (var pkm in pkms)
+            {
+                pkm.WriteEncryptedDataParty(buf);
+                _ = new PK9(buf.AsMemory().ToArray());
+            }
+        }
+
+        var timings = new double[iterations];
+        var sw = new Stopwatch();
+        for (var it = 0; it < iterations; it++)
+        {
+            sw.Restart();
+            foreach (var pkm in pkms)
+            {
+                pkm.WriteEncryptedDataParty(buf);
+                _ = new PK9(buf.AsMemory().ToArray());
+            }
+            sw.Stop();
+            timings[it] = sw.Elapsed.TotalMilliseconds;
+        }
+
+        return Summarize("encryption", timings, opsPerIteration: pkms.Length);
+    }
+
+    private static BenchmarkResult RunSearch(SaveFile sav, int iterations)
+    {
+        var totalSlots = sav.BoxCount * sav.BoxSlotCount;
+        var targetSpecies = BenchSpecies[2];
+
+        for (var w = 0; w < WarmupIterations; w++)
+        {
+            _ = CountMatches(sav, targetSpecies);
+        }
+
+        var timings = new double[iterations];
+        var sw = new Stopwatch();
+        for (var it = 0; it < iterations; it++)
+        {
+            sw.Restart();
+            _ = CountMatches(sav, targetSpecies);
+            sw.Stop();
+            timings[it] = sw.Elapsed.TotalMilliseconds;
+        }
+
+        return Summarize("search", timings, opsPerIteration: totalSlots);
+    }
+
+    private static int CountMatches(SaveFile sav, ushort targetSpecies)
+    {
+        var count = 0;
+        for (var box = 0; box < sav.BoxCount; box++)
+        {
+            for (var slot = 0; slot < sav.BoxSlotCount; slot++)
+            {
+                var pkm = sav.GetBoxSlotAtIndex(box, slot);
+                if (pkm.Species == targetSpecies && pkm.IV_HP >= 0 && pkm.CurrentLevel > 0)
+                {
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
+
+    private static BenchmarkResult RunEncounterGeneration(SaveFile sav, int iterations)
+    {
+        var template = (PK9)sav.BlankPKM.Clone();
+
+        for (var w = 0; w < WarmupIterations; w++)
+        {
+            CountAllEncounters(sav, template);
+        }
+
+        var timings = new double[iterations];
+        var sw = new Stopwatch();
+        for (var it = 0; it < iterations; it++)
+        {
+            sw.Restart();
+            CountAllEncounters(sav, template);
+            sw.Stop();
+            timings[it] = sw.Elapsed.TotalMilliseconds;
+        }
+
+        return Summarize("encounter-generation", timings, opsPerIteration: BenchSpecies.Length);
+    }
+
+    private static int CountAllEncounters(SaveFile sav, PK9 template)
+    {
+        var total = 0;
+        foreach (var species in BenchSpecies)
+        {
+            template.Species = species;
+            foreach (var _ in EncounterMovesetGenerator.GenerateEncounters(template, sav, ReadOnlyMemory<ushort>.Empty))
+            {
+                total++;
+            }
+        }
+        return total;
+    }
+
+    private static BenchmarkResult Summarize(string name, double[] timings, int opsPerIteration)
+    {
+        var total = 0.0;
+        var min = double.MaxValue;
+        var max = double.MinValue;
+        foreach (var t in timings)
+        {
+            total += t;
+            if (t < min) min = t;
+            if (t > max) max = t;
+        }
+        var mean = total / timings.Length;
+
+        var varianceSum = 0.0;
+        foreach (var t in timings)
+        {
+            var d = t - mean;
+            varianceSum += d * d;
+        }
+        var stdDev = timings.Length > 1 ? Math.Sqrt(varianceSum / (timings.Length - 1)) : 0.0;
+
+        return new BenchmarkResult
+        {
+            Name = name,
+            Iterations = timings.Length,
+            OpsPerIteration = opsPerIteration,
+            TotalMs = total,
+            MeanMs = mean,
+            MinMs = min,
+            MaxMs = max,
+            StdDevMs = stdDev,
+        };
+    }
+}

--- a/Pkmds.Rcl/Services/BenchmarkRunner.cs
+++ b/Pkmds.Rcl/Services/BenchmarkRunner.cs
@@ -184,9 +184,10 @@ public sealed class BenchmarkRunner
     {
         var template = (PK9)sav.BlankPKM.Clone();
 
+        var opsPerIteration = 0;
         for (var w = 0; w < WarmupIterations; w++)
         {
-            CountAllEncounters(sav, template);
+            opsPerIteration = CountAllEncounters(sav, template);
         }
 
         var timings = new double[iterations];
@@ -199,7 +200,7 @@ public sealed class BenchmarkRunner
             timings[it] = sw.Elapsed.TotalMilliseconds;
         }
 
-        return Summarize("encounter-generation", timings, opsPerIteration: BenchSpecies.Length);
+        return Summarize("encounter-generation", timings, opsPerIteration: opsPerIteration);
     }
 
     private static int CountAllEncounters(SaveFile sav, PK9 template)

--- a/Pkmds.Web/wwwroot/js/app.js
+++ b/Pkmds.Web/wwwroot/js/app.js
@@ -94,6 +94,9 @@ if (pkmdsIsEmbedded()) {
     });
 })();
 
+// Bench page helper — called from Benchmark.razor instead of eval to avoid unsafe-eval.
+window.pkmdsGetUserAgent = () => navigator.userAgent;
+
 // Listen for update events and forward to Blazor
 window.addUpdateListener = () => {
     window.addEventListener('updateAvailable', () => {

--- a/measure-publish.ps1
+++ b/measure-publish.ps1
@@ -1,0 +1,196 @@
+<#
+.SYNOPSIS
+    Publishes Pkmds.Web in Release with optional MSBuild args and measures
+    publish time and output size.
+
+.DESCRIPTION
+    Used to compare the effect of WASM perf knobs (AOT, SIMD, full trim,
+    InvariantGlobalization, lazy loading, ...) on build time and deploy size.
+    Writes a labeled markdown report to measurements/<label>.md so successive
+    runs can be diffed.
+
+    This script does NOT measure runtime performance. Open the published site
+    in a browser for that.
+
+.PARAMETER Label
+    Short name for this measurement (e.g. 'baseline', 'simd-on', 'aot-on').
+    The report is written to measurements/<Label>.md.
+
+.PARAMETER MSBuildArgs
+    Optional array of extra MSBuild property args.
+
+.PARAMETER OutputDir
+    Publish output directory. Defaults to 'release'.
+
+.EXAMPLE
+    ./measure-publish.ps1 -Label baseline
+
+.EXAMPLE
+    ./measure-publish.ps1 -Label simd-on -MSBuildArgs '-p:WasmEnableSIMD=true'
+
+.EXAMPLE
+    ./measure-publish.ps1 -Label aot-simd `
+        -MSBuildArgs '-p:RunAOTCompilation=true','-p:WasmEnableSIMD=true'
+#>
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Label,
+
+    [string[]]$MSBuildArgs = @(),
+
+    [string]$OutputDir = "release",
+
+    [switch]$RunBenchmark
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = $PSScriptRoot
+$project = Join-Path $repoRoot "Pkmds.Web/Pkmds.Web.csproj"
+$publishDir = Join-Path $repoRoot $OutputDir
+$measurementsDir = Join-Path $repoRoot "measurements"
+$reportPath = Join-Path $measurementsDir "$Label.md"
+
+if (-not (Test-Path $measurementsDir)) {
+    New-Item -ItemType Directory -Path $measurementsDir | Out-Null
+}
+
+# Clean prior output so we don't measure stale files.
+if (Test-Path $publishDir) {
+    Write-Host "Cleaning $publishDir..."
+    Remove-Item -Recurse -Force $publishDir
+}
+
+# Wipe Release obj/ for all projects so emcc native-object caching doesn't
+# make a re-run look artificially fast. This forces a true cold build.
+$objDirs = @(
+    "Pkmds.Web\obj\Release",
+    "Pkmds.Rcl\obj\Release",
+    "Pkmds.Core\obj\Release"
+) | ForEach-Object { Join-Path $repoRoot $_ } | Where-Object { Test-Path $_ }
+foreach ($d in $objDirs) {
+    Write-Host "Cleaning $d..."
+    Remove-Item -Recurse -Force $d
+}
+
+$gitHead = (git -C $repoRoot rev-parse --short HEAD).Trim()
+$gitBranch = (git -C $repoRoot rev-parse --abbrev-ref HEAD).Trim()
+$gitStatus = (git -C $repoRoot status --porcelain).Trim()
+$gitDirty = if ($gitStatus) { "yes" } else { "no" }
+
+Write-Host "Publishing '$Label'..." -ForegroundColor Cyan
+Write-Host "  HEAD:  $gitHead ($gitBranch, dirty=$gitDirty)"
+if ($MSBuildArgs.Count -gt 0) {
+    Write-Host "  Extra: $($MSBuildArgs -join ' ')"
+}
+
+$env:DOTNET_CLI_TELEMETRY_OPTOUT = 1
+$sw = [System.Diagnostics.Stopwatch]::StartNew()
+dotnet publish $project -c Release -o $publishDir --nologo @MSBuildArgs
+$exitCode = $LASTEXITCODE
+$sw.Stop()
+
+if ($exitCode -ne 0) {
+    throw "dotnet publish failed with exit code $exitCode"
+}
+
+$publishSeconds = [math]::Round($sw.Elapsed.TotalSeconds, 1)
+Write-Host "Publish completed in ${publishSeconds}s" -ForegroundColor Green
+
+function Format-Size {
+    param([long]$Bytes)
+    if ($Bytes -ge 1MB) { "{0:N2} MB" -f ($Bytes / 1MB) }
+    elseif ($Bytes -ge 1KB) { "{0:N2} KB" -f ($Bytes / 1KB) }
+    else { "$Bytes B" }
+}
+
+function Get-SumLength {
+    param([System.IO.FileInfo[]]$Files)
+    if (-not $Files) { return 0 }
+    $sum = ($Files | Measure-Object -Property Length -Sum).Sum
+    if ($null -eq $sum) { 0 } else { [long]$sum }
+}
+
+$wwwroot = Join-Path $publishDir "wwwroot"
+$framework = Join-Path $wwwroot "_framework"
+
+$wwwrootFiles = Get-ChildItem $wwwroot -Recurse -File
+$wwwrootSize = Get-SumLength $wwwrootFiles
+
+$frameworkAll = Get-ChildItem $framework -File
+$frameworkRawFiles = $frameworkAll | Where-Object { $_.Extension -notin '.br','.gz' }
+$frameworkBrFiles  = $frameworkAll | Where-Object { $_.Extension -eq '.br' }
+$frameworkGzFiles  = $frameworkAll | Where-Object { $_.Extension -eq '.gz' }
+
+$frameworkRaw = Get-SumLength $frameworkRawFiles
+$frameworkBr  = Get-SumLength $frameworkBrFiles
+$frameworkGz  = Get-SumLength $frameworkGzFiles
+
+# Top 20 largest framework files by raw size, with brotli sibling for comparison.
+$topFiles = $frameworkRawFiles |
+    Sort-Object Length -Descending |
+    Select-Object -First 20 |
+    ForEach-Object {
+        $brPath = "$($_.FullName).br"
+        $brSize = if (Test-Path $brPath) { (Get-Item $brPath).Length } else { 0 }
+        [pscustomobject]@{
+            Name = $_.Name
+            Raw = $_.Length
+            Brotli = $brSize
+        }
+    }
+
+$sb = [System.Text.StringBuilder]::new()
+[void]$sb.AppendLine("# Publish measurement: $Label")
+[void]$sb.AppendLine("")
+[void]$sb.AppendLine("- Date: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss zzz')")
+[void]$sb.AppendLine("- Git HEAD: ``$gitHead`` ($gitBranch, dirty=$gitDirty)")
+$argsCell = if ($MSBuildArgs.Count -gt 0) { '`' + ($MSBuildArgs -join ' ') + '`' } else { '_(none)_' }
+[void]$sb.AppendLine("- MSBuild args: $argsCell")
+[void]$sb.AppendLine("- Publish time: **${publishSeconds}s**")
+[void]$sb.AppendLine("")
+[void]$sb.AppendLine("## Output size")
+[void]$sb.AppendLine("")
+[void]$sb.AppendLine("| Bucket | Size |")
+[void]$sb.AppendLine("| --- | ---: |")
+[void]$sb.AppendLine("| Total ``wwwroot/`` (incl. .br/.gz) | $(Format-Size $wwwrootSize) |")
+[void]$sb.AppendLine("| ``_framework/`` raw (no .br/.gz) | $(Format-Size $frameworkRaw) |")
+[void]$sb.AppendLine("| ``_framework/`` brotli | $(Format-Size $frameworkBr) |")
+[void]$sb.AppendLine("| ``_framework/`` gzip | $(Format-Size $frameworkGz) |")
+[void]$sb.AppendLine("")
+[void]$sb.AppendLine("## Top 20 largest framework files (raw)")
+[void]$sb.AppendLine("")
+[void]$sb.AppendLine("| File | Raw | Brotli |")
+[void]$sb.AppendLine("| --- | ---: | ---: |")
+foreach ($f in $topFiles) {
+    $brCell = if ($f.Brotli -gt 0) { Format-Size $f.Brotli } else { '—' }
+    [void]$sb.AppendLine("| ``$($f.Name)`` | $(Format-Size $f.Raw) | $brCell |")
+}
+
+Set-Content -Path $reportPath -Value $sb.ToString() -Encoding UTF8
+
+Write-Host ""
+Write-Host "Report:  $reportPath" -ForegroundColor Green
+Write-Host ""
+Write-Host "Summary:"
+Write-Host ("  Publish time:       {0}s" -f $publishSeconds)
+Write-Host ("  wwwroot total:      {0}" -f (Format-Size $wwwrootSize))
+Write-Host ("  _framework raw:     {0}" -f (Format-Size $frameworkRaw))
+Write-Host ("  _framework brotli:  {0}" -f (Format-Size $frameworkBr))
+Write-Host ("  _framework gzip:    {0}" -f (Format-Size $frameworkGz))
+
+if ($RunBenchmark) {
+    Write-Host ""
+    Write-Host "Running runtime benchmark via Playwright..." -ForegroundColor Cyan
+    $benchDir = Join-Path $repoRoot "tools\bench"
+    Push-Location $benchDir
+    try {
+        node run-bench.mjs --label $Label --site $wwwroot --output $reportPath
+        if ($LASTEXITCODE -ne 0) {
+            throw "Bench runner failed with exit code $LASTEXITCODE"
+        }
+    }
+    finally {
+        Pop-Location
+    }
+}

--- a/measure-publish.ps1
+++ b/measure-publish.ps1
@@ -64,10 +64,10 @@ if (Test-Path $publishDir) {
 # Wipe Release obj/ for all projects so emcc native-object caching doesn't
 # make a re-run look artificially fast. This forces a true cold build.
 $objDirs = @(
-    "Pkmds.Web\obj\Release",
-    "Pkmds.Rcl\obj\Release",
-    "Pkmds.Core\obj\Release"
-) | ForEach-Object { Join-Path $repoRoot $_ } | Where-Object { Test-Path $_ }
+    (Join-Path $repoRoot 'Pkmds.Web' 'obj' 'Release'),
+    (Join-Path $repoRoot 'Pkmds.Rcl' 'obj' 'Release'),
+    (Join-Path $repoRoot 'Pkmds.Core' 'obj' 'Release')
+) | Where-Object { Test-Path $_ }
 foreach ($d in $objDirs) {
     Write-Host "Cleaning $d..."
     Remove-Item -Recurse -Force $d
@@ -182,7 +182,7 @@ Write-Host ("  _framework gzip:    {0}" -f (Format-Size $frameworkGz))
 if ($RunBenchmark) {
     Write-Host ""
     Write-Host "Running runtime benchmark via Playwright..." -ForegroundColor Cyan
-    $benchDir = Join-Path $repoRoot "tools\bench"
+    $benchDir = Join-Path $repoRoot 'tools' 'bench'
     Push-Location $benchDir
     try {
         node run-bench.mjs --label $Label --site $wwwroot --output $reportPath

--- a/tools/bench/package-lock.json
+++ b/tools/bench/package-lock.json
@@ -1,0 +1,59 @@
+{
+  "name": "pkmds-bench",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pkmds-bench",
+      "version": "0.0.0",
+      "dependencies": {
+        "playwright": "^1.49.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/tools/bench/package.json
+++ b/tools/bench/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "pkmds-bench",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Playwright runner for the /bench page. Used by measure-publish.ps1 (see issue #883).",
+  "scripts": {
+    "bench": "node run-bench.mjs"
+  },
+  "dependencies": {
+    "playwright": "^1.49.0"
+  }
+}

--- a/tools/bench/run-bench.mjs
+++ b/tools/bench/run-bench.mjs
@@ -1,0 +1,157 @@
+// Drives the /bench page in headless Chromium against a published Blazor build
+// and appends runtime numbers to measurements/<label>.md alongside the size
+// numbers produced by measure-publish.ps1. See issue #883.
+
+import { createServer } from 'node:http';
+import { readFile, stat, appendFile } from 'node:fs/promises';
+import { join, resolve, extname, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..', '..');
+
+const args = parseArgs(process.argv.slice(2));
+const label = args.label;
+if (!label) {
+    console.error('usage: node run-bench.mjs --label <name> [--site <path>] [--output <path>] [--timeout <ms>]');
+    process.exit(2);
+}
+const siteDir = resolve(args.site ?? join(repoRoot, 'release', 'wwwroot'));
+const outputPath = resolve(args.output ?? join(repoRoot, 'measurements', `${label}.md`));
+const benchTimeoutMs = Number(args.timeout ?? 300_000);
+
+await stat(siteDir).catch(() => {
+    console.error(`Site directory not found: ${siteDir}`);
+    process.exit(2);
+});
+
+const MIME = {
+    '.html': 'text/html; charset=utf-8',
+    '.htm': 'text/html; charset=utf-8',
+    '.js': 'application/javascript; charset=utf-8',
+    '.mjs': 'application/javascript; charset=utf-8',
+    '.css': 'text/css; charset=utf-8',
+    '.json': 'application/json; charset=utf-8',
+    '.wasm': 'application/wasm',
+    '.dat': 'application/octet-stream',
+    '.dll': 'application/octet-stream',
+    '.pdb': 'application/octet-stream',
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.svg': 'image/svg+xml',
+    '.webp': 'image/webp',
+    '.ico': 'image/x-icon',
+    '.woff': 'font-woff',
+    '.woff2': 'font/woff2',
+};
+
+const server = createServer(async (req, res) => {
+    try {
+        const url = new URL(req.url, 'http://localhost');
+        let path = decodeURIComponent(url.pathname);
+        if (path.endsWith('/')) path += 'index.html';
+        let filePath = join(siteDir, path);
+
+        // SPA fallback: any path without an extension falls back to index.html.
+        if (!extname(filePath)) {
+            filePath = join(siteDir, 'index.html');
+        }
+
+        const data = await readFile(filePath).catch(async () => {
+            // Asset miss — try SPA fallback once more for client-side routes.
+            return await readFile(join(siteDir, 'index.html'));
+        });
+
+        const mime = MIME[extname(filePath).toLowerCase()] ?? 'application/octet-stream';
+        res.writeHead(200, { 'content-type': mime, 'cache-control': 'no-store' });
+        res.end(data);
+    } catch (err) {
+        res.writeHead(500, { 'content-type': 'text/plain' });
+        res.end(String(err));
+    }
+});
+
+const port = await new Promise((resolvePort) => {
+    server.listen(0, '127.0.0.1', () => resolvePort(server.address().port));
+});
+const baseUrl = `http://127.0.0.1:${port}`;
+console.log(`Serving ${siteDir} on ${baseUrl}`);
+
+const browser = await chromium.launch({ headless: true });
+let report;
+try {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    page.on('pageerror', (e) => console.error('[page error]', e.message));
+    page.on('console', (msg) => {
+        const text = msg.text();
+        if (text.startsWith('BENCH_RESULT_JSON:')) return; // surfaced via the DOM scrape instead
+        if (msg.type() === 'error') console.error('[page console]', text);
+    });
+
+    const navStart = Date.now();
+    await page.goto(`${baseUrl}/bench`, { waitUntil: 'load', timeout: 60_000 });
+    await page.waitForSelector('#bench-root[data-bench-state="done"], #bench-root[data-bench-state="error"]', {
+        timeout: benchTimeoutMs,
+    });
+    const elapsedMs = Date.now() - navStart;
+
+    const state = await page.getAttribute('#bench-root', 'data-bench-state');
+    if (state === 'error') {
+        const err = await page.textContent('#bench-error');
+        throw new Error(`Bench page reported error:\n${err}`);
+    }
+
+    const resultText = await page.textContent('#bench-result');
+    report = JSON.parse(resultText);
+    report.NavToReadyMs = elapsedMs;
+} finally {
+    await browser.close();
+    server.close();
+}
+
+const md = renderMarkdown(label, report);
+await appendFile(outputPath, md);
+console.log(`Appended runtime numbers to ${outputPath}`);
+
+function parseArgs(argv) {
+    const out = {};
+    for (let i = 0; i < argv.length; i++) {
+        const arg = argv[i];
+        if (arg.startsWith('--')) {
+            const key = arg.slice(2);
+            const next = argv[i + 1];
+            if (next && !next.startsWith('--')) {
+                out[key] = next;
+                i++;
+            } else {
+                out[key] = true;
+            }
+        }
+    }
+    return out;
+}
+
+function renderMarkdown(label, report) {
+    const lines = [];
+    lines.push('');
+    lines.push('## Runtime benchmark');
+    lines.push('');
+    lines.push(`- Label: ${label}`);
+    lines.push(`- Date: ${report.Date}`);
+    lines.push(`- Nav → ready: **${report.NavToReadyMs} ms**`);
+    lines.push(`- UA: \`${report.UserAgent}\``);
+    lines.push('');
+    lines.push('| Workload | Iter | Ops/iter | Mean (ms) | Min (ms) | Max (ms) | StdDev (ms) | Ops/sec |');
+    lines.push('| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |');
+    for (const r of report.Results) {
+        const opsPerSec = (r.Iterations * r.OpsPerIteration) / (r.TotalMs / 1000);
+        lines.push(
+            `| ${r.Name} | ${r.Iterations} | ${r.OpsPerIteration} | ${r.MeanMs.toFixed(3)} | ${r.MinMs.toFixed(3)} | ${r.MaxMs.toFixed(3)} | ${r.StdDevMs.toFixed(3)} | ${opsPerSec.toFixed(0)} |`
+        );
+    }
+    lines.push('');
+    return lines.join('\n');
+}

--- a/tools/bench/run-bench.mjs
+++ b/tools/bench/run-bench.mjs
@@ -49,21 +49,31 @@ const MIME = {
 const server = createServer(async (req, res) => {
     try {
         const url = new URL(req.url, 'http://localhost');
-        let path = decodeURIComponent(url.pathname);
-        if (path.endsWith('/')) path += 'index.html';
-        let filePath = join(siteDir, path);
+        let pathname = decodeURIComponent(url.pathname);
+        if (pathname.endsWith('/')) pathname += 'index.html';
 
-        // SPA fallback: any path without an extension falls back to index.html.
-        if (!extname(filePath)) {
-            filePath = join(siteDir, 'index.html');
+        // Security: reject path traversal — resolved path must stay within siteDir.
+        const filePath = resolve(join(siteDir, pathname));
+        if (!filePath.startsWith(siteDir + '/') && filePath !== siteDir) {
+            res.writeHead(400, { 'content-type': 'text/plain' });
+            res.end('Bad request');
+            return;
         }
 
-        const data = await readFile(filePath).catch(async () => {
-            // Asset miss — try SPA fallback once more for client-side routes.
-            return await readFile(join(siteDir, 'index.html'));
-        });
+        // SPA fallback only for extensionless routes (Blazor client-side navigation).
+        // Asset requests with a known extension return 404 on miss so errors aren't masked.
+        const servePath = extname(filePath) ? filePath : join(siteDir, 'index.html');
 
-        const mime = MIME[extname(filePath).toLowerCase()] ?? 'application/octet-stream';
+        let data;
+        try {
+            data = await readFile(servePath);
+        } catch {
+            res.writeHead(404, { 'content-type': 'text/plain' });
+            res.end('Not found');
+            return;
+        }
+
+        const mime = MIME[extname(servePath).toLowerCase()] ?? 'application/octet-stream';
         res.writeHead(200, { 'content-type': mime, 'cache-control': 'no-store' });
         res.end(data);
     } catch (err) {


### PR DESCRIPTION
Captures publish time, deploy size, and runtime perf for arbitrary combinations of WASM MSBuild flags (AOT, SIMD, trim) so configs can be compared apples-to-apples. Surfaced the trim-full breakage on Blazor route reflection that motivates the upcoming trim-fix work.

- measure-publish.ps1 cleans obj/Release for a true cold build and captures raw/brotli/gzip totals plus the 20 largest framework files
- Pkmds.Rcl/Components/Pages/Benchmark.razor: unlinked /bench route exercising legality, encryption roundtrip, box search, and encounter generation against a synthetic SAV9SV
- tools/bench/run-bench.mjs: Playwright runner serves release/wwwroot, drives /bench, scrapes JSON, appends runtime numbers to the same measurements/<label>.md report
- measurements/ is gitignored; reports are local diagnostics