### PR TITLE
fix(perf): guard measure-publish.ps1 against clean working tree

### DIFF
--- a/measure-publish.ps1
+++ b/measure-publish.ps1
@@ -73,9 +73,11 @@ foreach ($d in $objDirs) {
     Remove-Item -Recurse -Force $d
 }
 
-$gitHead = (git -C $repoRoot rev-parse --short HEAD).Trim()
-$gitBranch = (git -C $repoRoot rev-parse --abbrev-ref HEAD).Trim()
-$gitStatus = (git -C $repoRoot status --porcelain).Trim()
+$gitHead = "$(git -C $repoRoot rev-parse --short HEAD)".Trim()
+$gitBranch = "$(git -C $repoRoot rev-parse --abbrev-ref HEAD)".Trim()
+# git status --porcelain returns no output (null in PowerShell) when the tree
+# is clean — coerce to string before checking so .Trim() doesn't NRE.
+$gitStatus = "$(git -C $repoRoot status --porcelain)".Trim()
 $gitDirty = if ($gitStatus) { "yes" } else { "no" }
 
 Write-Host "Publishing '$Label'..." -ForegroundColor Cyan


### PR DESCRIPTION
git status --porcelain returns no output (null in PowerShell) when the tree is clean. The dirty-tree check called .Trim() on that directly, which NRE'd. Latent since the script landed — never triggered because every measurement up to now had uncommitted diagnostic infra or trim work in the tree.

Coerce all three git invocations to string with subexpression syntax before .Trim() so they work on a clean tree too.