### PR TITLE
hotfix: revert TrimMode=full to restore Bank and Backup Manager

### DIFF
--- a/Pkmds.Web/Pkmds.Web.csproj
+++ b/Pkmds.Web/Pkmds.Web.csproj
@@ -21,13 +21,6 @@
     <PropertyGroup Condition="'$(Configuration)' == 'Release'">
         <BlazorWebAssemblyEnableLinking>true</BlazorWebAssemblyEnableLinking>
         <BlazorEnableCompression>true</BlazorEnableCompression>
-        <!-- Trim app code (PKHeX.Core, MudBlazor, Pkmds.Rcl) in addition to the
-             framework. Saves ~610 KB brotli; safe because PreservePkmTypes.xml
-             and Pkmds.Rcl/PreserveRoutes.xml root the reflection-discovered
-             types Blazor's Router and PKHeX's EntityBatchEditor need at
-             runtime. See issue #883 for the analysis. -->
-        <TrimMode>full</TrimMode>
-        <PublishTrimmed>true</PublishTrimmed>
     </PropertyGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
## Summary

Reverts commit 83fa71f4 (PR #891) which enabled `TrimMode=full` for Release builds. That setting broke `BankService` and `BackupService` IJS interop at runtime, causing three reported crashes:

- **#894** — Backup Manager hangs on indefinite spinner after update (`GetAllMetadataAsync` throws inside `OnInitializedAsync`, Blazor doesn't re-render after the exception, `isLoading` stays visually true)
- **#896** — Bank tab crashes with `JSException: DeserializeNoConstructor, JsonConstructorAttribute, ...BankService+RawEntry`
- **#898** — Adding to Bank crashes with `NotSupportedException: ConstructorContainsNullParameterNames` on the 6-property anonymous `meta` type

## Root cause

`IJSObjectReference.InvokeAsync<T>` / `InvokeVoidAsync(object…)` marshal payloads via Blazor's internal `System.Text.Json` options — reflection-based, not the source-gen `PkmdsJsonContext`. Under `TrimMode=full` the trimmer strips:

- Parameterless constructors of internal sealed DTOs (`RawEntry`, `RawMeta`, `RawBackupEntry`, `RawBackupMeta`) → `DeserializeNoConstructor` on read
- Constructor parameter names on anonymous types (`new { species, isShiny, … }`) → `ConstructorContainsNullParameterNames` on write

The source-gen migration in #883 phase 1 (commit 91ea6d79) covered every direct `JsonSerializer.Serialize/Deserialize` call but not the IJS interop boundary, where the runtime owns the serializer.

## Why a full revert vs. a targeted preserve

A trimmer descriptor preserving the four DTO types would fix the read paths but not the anonymous-type write paths, and there is no clean way to preserve anonymous types short of refactoring them to named records anyway. Doing that work safely takes more than a few minutes, and three reports are already in — including one user (#894) who lost backups when our (now-disabled) triage bot incorrectly told them to clear site data. Fastest path to safe is to revert now and re-enable trim after the IJS boundary is migrated to source-gen + JSON strings on a follow-up branch.

## What is preserved

The other #883 commits remain on `main`: source-gen migration (91ea6d79), Blazor route preserve descriptor (9800e2b1), PKM hierarchy preserve descriptor (0aa9e7f6), batch editor smoke test (bb2e96ad), layout preserve fix (4a46fb64), measurement harness (fcea0954). They're all dormant without `TrimMode=full` and useful when it's re-enabled.

## Cost

~610 KB brotli per cold load (the size win PR #891 reported). Acceptable rollback cost given the data-loss risk.

## Test plan

- [x] `dotnet build Pkmds.Web/Pkmds.Web.csproj -c Debug` — 0 warnings, 0 errors
- [ ] CI build/test workflow green
- [ ] After merge to main: GitHub Pages redeploys, manually verify Bank and Backup Manager tabs load on the live site
- [ ] Post resolution updates on #894, #896, #898

🤖 Generated with [Claude Code](https://claude.com/claude-code)