### PR TITLE
fix: trim-safe IJS interop for Bank and Backup services

### DIFF
--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
@@ -206,7 +206,10 @@ public partial class MainLayout : IDisposable
         {
             try
             {
-                await JSRuntime.InvokeVoidAsync("PKMDS.host._sendMessage", "ready", new { });
+                // Pass null rather than `new { }` so Blazor's IJS marshaler doesn't
+                // reflect over an anonymous type — keeps this site trim-safe under
+                // TrimMode=full alongside the other PKMDS.host._sendMessage call sites.
+                await JSRuntime.InvokeVoidAsync("PKMDS.host._sendMessage", "ready", default(string));
             }
             catch (JSException ex)
             {

--- a/Pkmds.Rcl/Services/BackupService.cs
+++ b/Pkmds.Rcl/Services/BackupService.cs
@@ -1,6 +1,6 @@
 namespace Pkmds.Rcl.Services;
 
-public class BackupService(IJSRuntime js) : IBackupService, IAsyncDisposable
+public partial class BackupService(IJSRuntime js) : IBackupService, IAsyncDisposable
 {
     private IJSObjectReference? _module;
 
@@ -16,23 +16,32 @@ public class BackupService(IJSRuntime js) : IBackupService, IAsyncDisposable
     {
         var module = await GetModuleAsync();
         var b64 = Convert.ToBase64String(saveBytes);
-        var meta = new
-        {
-            fileName = fileName ?? string.Empty,
-            saveType = saveFile.GetType().Name,
-            generation = (int)saveFile.Generation,
-            gameVersion = saveFile.Version.ToString(),
-            trainerName = saveFile.OT,
-            sizeBytes = (long)saveBytes.Length,
-            isManicEmu
-        };
-        return await module.InvokeAsync<long>("addBackup", b64, meta, source);
+        var meta = new BackupMeta(
+            fileName ?? string.Empty,
+            saveFile.GetType().Name,
+            (int)saveFile.Generation,
+            saveFile.Version.ToString(),
+            saveFile.OT,
+            saveBytes.Length,
+            isManicEmu);
+        // Serialize via source-gen on our side and pass a JSON string across the JS interop
+        // boundary — see BankService for the rationale (trim-safe vs. reflection-based
+        // Blazor JsonSerializer under TrimMode=full; see #894).
+        var metaJson = JsonSerializer.Serialize(meta, BackupJsonContext.Default.BackupMeta);
+        return await module.InvokeAsync<long>("addBackup", b64, metaJson, source);
     }
 
     public async Task<IReadOnlyList<BackupEntry>> GetAllMetadataAsync()
     {
         var module = await GetModuleAsync();
-        var raw = await module.InvokeAsync<RawBackupEntry[]>("getBackupMetadata");
+        var rawJson = await module.InvokeAsync<string>("getBackupMetadata");
+
+        if (string.IsNullOrEmpty(rawJson))
+        {
+            return [];
+        }
+
+        var raw = JsonSerializer.Deserialize(rawJson, BackupJsonContext.Default.RawBackupEntryArray);
 
         if (raw is null || raw.Length == 0)
         {
@@ -68,7 +77,14 @@ public class BackupService(IJSRuntime js) : IBackupService, IAsyncDisposable
     public async Task<byte[]?> GetBackupBytesAsync(long id)
     {
         var module = await GetModuleAsync();
-        var raw = await module.InvokeAsync<RawBackupEntry?>("getBackup", id);
+        var rawJson = await module.InvokeAsync<string?>("getBackup", id);
+
+        if (string.IsNullOrEmpty(rawJson))
+        {
+            return null;
+        }
+
+        var raw = JsonSerializer.Deserialize(rawJson, BackupJsonContext.Default.RawBackupEntry);
 
         if (raw?.BytesBase64 is null)
         {
@@ -117,7 +133,24 @@ public class BackupService(IJSRuntime js) : IBackupService, IAsyncDisposable
     private async Task<IJSObjectReference> GetModuleAsync() =>
         _module ??= await js.InvokeAsync<IJSObjectReference>("import", "./js/backup.js");
 
-    // ── Internal DTOs for JS deserialization (internal for test/mocking support) ──
+    // ── DTOs for JS interop ──────────────────────────────────────────────
+    // internal so that Pkmds.Tests can reference these types when setting up
+    // JS interop mocks (via InternalsVisibleTo in Pkmds.Rcl.csproj).
+
+    // Write-side payload (replaces the anonymous type so source-gen can describe it).
+
+    internal sealed record BackupMeta(
+        [property: JsonPropertyName("fileName")] string FileName,
+        [property: JsonPropertyName("saveType")] string SaveType,
+        [property: JsonPropertyName("generation")] int Generation,
+        [property: JsonPropertyName("gameVersion")] string GameVersion,
+        [property: JsonPropertyName("trainerName")] string TrainerName,
+        [property: JsonPropertyName("sizeBytes")] long SizeBytes,
+        [property: JsonPropertyName("isManicEmu")] bool IsManicEmu);
+
+    // Read-side payloads. Mutable POCOs because the source-gen deserializer needs a
+    // public parameterless constructor + settable properties to round-trip through
+    // System.Text.Json on a JSON object with these property names.
 
     internal sealed class RawBackupEntry
     {
@@ -160,4 +193,9 @@ public class BackupService(IJSRuntime js) : IBackupService, IAsyncDisposable
         [JsonPropertyName("isManicEmu")]
         public bool? IsManicEmu { get; set; }
     }
+
+    [JsonSerializable(typeof(BackupMeta))]
+    [JsonSerializable(typeof(RawBackupEntry))]
+    [JsonSerializable(typeof(RawBackupEntry[]))]
+    internal sealed partial class BackupJsonContext : JsonSerializerContext;
 }

--- a/Pkmds.Rcl/Services/BackupService.cs
+++ b/Pkmds.Rcl/Services/BackupService.cs
@@ -34,7 +34,10 @@ public partial class BackupService(IJSRuntime js) : IBackupService, IAsyncDispos
     public async Task<IReadOnlyList<BackupEntry>> GetAllMetadataAsync()
     {
         var module = await GetModuleAsync();
-        var rawJson = await module.InvokeAsync<string>("getBackupMetadata");
+        // Call the *Json variant so we get a JSON string suitable for source-gen
+        // deserialization. The legacy getBackupMetadata export still returns an
+        // array for service-worker rollout safety; see backup.js.
+        var rawJson = await module.InvokeAsync<string>("getBackupMetadataJson");
 
         if (string.IsNullOrEmpty(rawJson))
         {
@@ -77,7 +80,8 @@ public partial class BackupService(IJSRuntime js) : IBackupService, IAsyncDispos
     public async Task<byte[]?> GetBackupBytesAsync(long id)
     {
         var module = await GetModuleAsync();
-        var rawJson = await module.InvokeAsync<string?>("getBackup", id);
+        // *Json variant — see GetAllMetadataAsync for rationale.
+        var rawJson = await module.InvokeAsync<string?>("getBackupJson", id);
 
         if (string.IsNullOrEmpty(rawJson))
         {

--- a/Pkmds.Rcl/Services/BankService.cs
+++ b/Pkmds.Rcl/Services/BankService.cs
@@ -79,7 +79,10 @@ public partial class BankService(IJSRuntime js) : IBankService, IAsyncDisposable
             return [];
         }
 
-        var rawJson = await module.InvokeAsync<string>("getAllPokemon");
+        // Call the *Json variant so we get a JSON string suitable for source-gen
+        // deserialization. The legacy getAllPokemon export still returns an array
+        // for service-worker rollout safety; see bank.js.
+        var rawJson = await module.InvokeAsync<string>("getAllPokemonJson");
 
         if (string.IsNullOrEmpty(rawJson))
         {

--- a/Pkmds.Rcl/Services/BankService.cs
+++ b/Pkmds.Rcl/Services/BankService.cs
@@ -1,6 +1,6 @@
 namespace Pkmds.Rcl.Services;
 
-public class BankService(IJSRuntime js) : IBankService, IAsyncDisposable
+public partial class BankService(IJSRuntime js) : IBankService, IAsyncDisposable
 {
     private IJSObjectReference? module;
 
@@ -18,22 +18,25 @@ public class BankService(IJSRuntime js) : IBankService, IAsyncDisposable
         var storedData = new byte[pkm.SIZE_STORED];
         pkm.WriteDecryptedDataStored(storedData);
         var b64 = Convert.ToBase64String(storedData);
-        var meta = new
-        {
-            species = pkm.Species,
-            isShiny = pkm.IsShiny,
-            nickname = pkm.Nickname,
-            ext = pkm.Extension,
+        var meta = new BankMeta(
+            pkm.Species,
+            pkm.IsShiny,
+            pkm.Nickname,
+            pkm.Extension,
             tag,
-            sourceSave
-        };
+            sourceSave);
+        // Serialize via source-gen on our side and pass a JSON string across the JS interop
+        // boundary. IJS marshals strings as opaque primitives, which is trim-safe; passing
+        // CLR objects would go through Blazor's reflection-based JsonSerializer and break
+        // under TrimMode=full (see #894, #896, #898).
+        var metaJson = JsonSerializer.Serialize(meta, BankJsonContext.Default.BankMeta);
 
         if (module is null)
         {
             return;
         }
 
-        await module.InvokeVoidAsync("addPokemon", b64, meta);
+        await module.InvokeVoidAsync("addPokemon", b64, metaJson);
     }
 
     public async Task AddRangeAsync(IEnumerable<PKM> pokemon, string? tag = null, string? sourceSave = null)
@@ -41,23 +44,19 @@ public class BankService(IJSRuntime js) : IBankService, IAsyncDisposable
         await GetModuleAsync();
         // Collect all entries first and send in one JS call / one IDB transaction
         // rather than one round-trip per Pokémon.
-        var entries = pokemon.Select(object (pkm) =>
+        var entries = pokemon.Select(pkm =>
         {
             var storedData = new byte[pkm.SIZE_STORED];
             pkm.WriteDecryptedDataStored(storedData);
-            return new
-            {
-                bytesBase64 = Convert.ToBase64String(storedData),
-                meta = new
-                {
-                    species = pkm.Species,
-                    isShiny = pkm.IsShiny,
-                    nickname = pkm.Nickname,
-                    ext = pkm.Extension,
+            return new BankAddEntry(
+                Convert.ToBase64String(storedData),
+                new BankMeta(
+                    pkm.Species,
+                    pkm.IsShiny,
+                    pkm.Nickname,
+                    pkm.Extension,
                     tag,
-                    sourceSave
-                }
-            };
+                    sourceSave));
         }).ToArray();
 
         if (entries.Length > 0)
@@ -67,7 +66,8 @@ public class BankService(IJSRuntime js) : IBankService, IAsyncDisposable
                 return;
             }
 
-            await module.InvokeVoidAsync("addRange", (object)entries);
+            var entriesJson = JsonSerializer.Serialize(entries, BankJsonContext.Default.BankAddEntryArray);
+            await module.InvokeVoidAsync("addRange", entriesJson);
         }
     }
 
@@ -79,7 +79,14 @@ public class BankService(IJSRuntime js) : IBankService, IAsyncDisposable
             return [];
         }
 
-        var raw = await module.InvokeAsync<RawEntry[]>("getAllPokemon");
+        var rawJson = await module.InvokeAsync<string>("getAllPokemon");
+
+        if (string.IsNullOrEmpty(rawJson))
+        {
+            return [];
+        }
+
+        var raw = JsonSerializer.Deserialize(rawJson, BankJsonContext.Default.RawEntryArray) ?? [];
 
         if (raw.Length == 0)
         {
@@ -239,9 +246,27 @@ public class BankService(IJSRuntime js) : IBankService, IAsyncDisposable
     private async Task GetModuleAsync() =>
         module ??= await js.InvokeAsync<IJSObjectReference>("import", "./js/bank.js");
 
-    // ── Private DTOs for JS deserialization ───────────────────────────────
+    // ── DTOs for JS interop ──────────────────────────────────────────────
     // internal so that Pkmds.Tests can reference these types when setting up
     // JS interop mocks (via InternalsVisibleTo in Pkmds.Rcl.csproj).
+
+    // Write-side payloads (replace anonymous types so source-gen can describe them).
+
+    internal sealed record BankMeta(
+        [property: JsonPropertyName("species")] ushort Species,
+        [property: JsonPropertyName("isShiny")] bool IsShiny,
+        [property: JsonPropertyName("nickname")] string Nickname,
+        [property: JsonPropertyName("ext")] string Ext,
+        [property: JsonPropertyName("tag")] string? Tag,
+        [property: JsonPropertyName("sourceSave")] string? SourceSave);
+
+    internal sealed record BankAddEntry(
+        [property: JsonPropertyName("bytesBase64")] string BytesBase64,
+        [property: JsonPropertyName("meta")] BankMeta Meta);
+
+    // Read-side payloads. Mutable POCOs because the source-gen deserializer needs a
+    // public parameterless constructor + settable properties to round-trip through
+    // System.Text.Json on a JSON object with these property names.
 
     internal sealed class RawEntry
     {
@@ -278,4 +303,9 @@ public class BankService(IJSRuntime js) : IBankService, IAsyncDisposable
         [JsonPropertyName("sourceSave")]
         public string? SourceSave { get; set; }
     }
+
+    [JsonSerializable(typeof(BankMeta))]
+    [JsonSerializable(typeof(BankAddEntry[]))]
+    [JsonSerializable(typeof(RawEntry[]))]
+    internal sealed partial class BankJsonContext : JsonSerializerContext;
 }

--- a/Pkmds.Rcl/Services/EmbeddedHostBridge.cs
+++ b/Pkmds.Rcl/Services/EmbeddedHostBridge.cs
@@ -13,7 +13,7 @@ namespace Pkmds.Rcl.Services;
 /// (required by <c>DotNet.invokeMethodAsync</c>) can resolve injected
 /// services without a service-locator anti-pattern.
 /// </remarks>
-public sealed class EmbeddedHostBridge
+public sealed partial class EmbeddedHostBridge
 {
     private readonly IAppState _appState;
     private readonly IAppService _appService;
@@ -38,6 +38,10 @@ public sealed class EmbeddedHostBridge
 
     private static EmbeddedHostBridge? Instance { get; set; }
 
+    // Preserved under TrimMode=full via PreserveJSInvokable.xml in Pkmds.Web — the linker
+    // can't see JS-side calls via DotNet.invokeMethodAsync, and [JSInvokable] alone is not
+    // a trim root. Without preservation these methods get stripped and the embedded host
+    // bridge silently breaks.
     [JSInvokable(nameof(LoadSaveFromHost))]
     public static Task<bool> LoadSaveFromHost(string bytesBase64, string? fileName) =>
         Task.FromResult(Instance?.LoadSaveFromHostInternal(bytesBase64, fileName) ?? false);
@@ -135,10 +139,18 @@ public sealed class EmbeddedHostBridge
             var base64 = Convert.ToBase64String(bytes);
             var fileName = _appState.SaveFileName ?? "save.sav";
 
+            // Pre-serialize the payload via source-gen and send as a JSON string so
+            // Blazor's reflection-based IJS marshaler isn't on the trim hazard path
+            // (anonymous types would lose ctor param names under TrimMode=full —
+            // same root cause as #894 / #896 / #898).
+            var payloadJson = JsonSerializer.Serialize(
+                new SaveExportPayload(base64, fileName),
+                EmbeddedHostJsonContext.Default.SaveExportPayload);
+
             await _jsRuntime.InvokeVoidAsync(
                 "PKMDS.host._sendMessage",
                 "saveExport",
-                new { data = base64, fileName });
+                payloadJson);
 
             _logger.LogInformation("Host export emitted: {ByteCount} bytes ({FileName})",
                 bytes.Length, fileName);
@@ -150,4 +162,13 @@ public sealed class EmbeddedHostBridge
             return false;
         }
     }
+
+    // ── DTO + source-gen context for the saveExport outbound payload ──────
+
+    private sealed record SaveExportPayload(
+        [property: JsonPropertyName("data")] string Data,
+        [property: JsonPropertyName("fileName")] string FileName);
+
+    [JsonSerializable(typeof(SaveExportPayload))]
+    private sealed partial class EmbeddedHostJsonContext : JsonSerializerContext;
 }

--- a/Pkmds.Rcl/wwwroot/js/host.js
+++ b/Pkmds.Rcl/wwwroot/js/host.js
@@ -15,8 +15,25 @@
     // Outbound: post a message to the host. Uses WKWebView's
     // window.webkit.messageHandlers.pkmds when present, otherwise logs to the
     // console so the bridge stays observable in a regular browser tab.
+    //
+    // Payload arrives as a JSON string from the C# side so Blazor's IJS marshaler
+    // stays out of the trim hazard path (see EmbeddedHostBridge.SaveExportPayload).
+    // Tolerate the legacy object form too in case anything else ever calls in.
     function postMessage(kind, payload) {
-        const message = Object.assign({ kind: kind }, payload || {});
+        let payloadObj;
+        if (payload == null) {
+            payloadObj = {};
+        } else if (typeof payload === 'string') {
+            try {
+                payloadObj = JSON.parse(payload);
+            } catch (e) {
+                console.warn('[PKMDS.host] Failed to parse payload JSON:', e);
+                payloadObj = {};
+            }
+        } else {
+            payloadObj = payload;
+        }
+        const message = Object.assign({ kind: kind }, payloadObj);
         try {
             const handler = window.webkit
                 && window.webkit.messageHandlers
@@ -28,7 +45,7 @@
         } catch (e) {
             console.warn('[PKMDS.host] postMessage handler failed:', e);
         }
-        console.log('[PKMDS.host] →', kind, payload || {});
+        console.log('[PKMDS.host] →', kind, payloadObj);
     }
 
     window.PKMDS.host = {

--- a/Pkmds.Tests/BackupServiceTests.cs
+++ b/Pkmds.Tests/BackupServiceTests.cs
@@ -1,0 +1,201 @@
+using System.Text.Json;
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.JSInterop;
+
+namespace Pkmds.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="BackupService" /> using bUnit's JS-interop mocks.
+/// <see cref="BackupService.RawBackupEntry" /> and <see cref="BackupService.RawBackupMeta" />
+/// are <c>internal</c> and accessible here via <c>InternalsVisibleTo</c> in Pkmds.Rcl.csproj.
+/// The backup JS contract passes JSON strings across the IJS boundary (trim-safe);
+/// these tests mirror that by serializing entries with the service's own source-gen
+/// context before handing them to the mock.
+/// </summary>
+public class BackupServiceTests
+{
+    private static BackupService.RawBackupEntry BuildEntry(
+        long id = 1,
+        string? bytes = null,
+        string fileName = "test.sav",
+        string saveType = "SAV9SV",
+        int generation = 9,
+        string gameVersion = "Scarlet",
+        string trainerName = "Trainer",
+        long sizeBytes = 100,
+        bool isManicEmu = false,
+        string createdAt = "2026-05-14T10:00:00.0000000+00:00",
+        string source = "manual") => new()
+        {
+            Id = id,
+            BytesBase64 = bytes,
+            Meta = new BackupService.RawBackupMeta
+            {
+                FileName = fileName,
+                SaveType = saveType,
+                Generation = generation,
+                GameVersion = gameVersion,
+                TrainerName = trainerName,
+                SizeBytes = sizeBytes,
+                IsManicEmu = isManicEmu
+            },
+            CreatedAt = createdAt,
+            Source = source
+        };
+
+    private static (BackupService Service, BunitContext Ctx) CreateService(
+        BackupService.RawBackupEntry[]? metadata = null,
+        (long Id, BackupService.RawBackupEntry? Entry)? singleBackup = null)
+    {
+        var ctx = new BunitContext();
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var module = ctx.JSInterop.SetupModule("./js/backup.js");
+
+        var metaJson = JsonSerializer.Serialize(
+            metadata ?? [],
+            BackupService.BackupJsonContext.Default.RawBackupEntryArray);
+        module.Setup<string>("getBackupMetadataJson").SetResult(metaJson);
+
+        if (singleBackup is { } pair)
+        {
+            var singleJson = pair.Entry is null
+                ? null
+                : JsonSerializer.Serialize(
+                    pair.Entry,
+                    BackupService.BackupJsonContext.Default.RawBackupEntry);
+            module.Setup<string?>("getBackupJson", pair.Id).SetResult(singleJson);
+        }
+
+        var jsRuntime = ctx.Services.GetRequiredService<IJSRuntime>();
+        var service = new BackupService(jsRuntime);
+        return (service, ctx);
+    }
+
+    [Fact]
+    public async Task GetAllMetadataAsync_NoBackups_ReturnsEmptyList()
+    {
+        var (service, ctx) = CreateService();
+
+        var result = await service.GetAllMetadataAsync();
+
+        result.Should().BeEmpty();
+
+        await service.DisposeAsync();
+        ctx.Dispose();
+    }
+
+    [Fact]
+    public async Task GetAllMetadataAsync_PopulatedBackups_DeserializesAllFields()
+    {
+        var entries = new[]
+        {
+            BuildEntry(
+                id: 42,
+                fileName: "Pokemon Scarlet.sav",
+                saveType: "SAV9SV",
+                generation: 9,
+                gameVersion: "Scarlet",
+                trainerName: "Yeniel",
+                sizeBytes: 3_133_440,
+                createdAt: "2026-05-14T14:30:00.0000000+00:00",
+                source: "auto"),
+            BuildEntry(
+                id: 43,
+                fileName: "manic_export.zip",
+                saveType: "SAV3E",
+                generation: 3,
+                gameVersion: "Emerald",
+                trainerName: "John",
+                sizeBytes: 131_072,
+                isManicEmu: true,
+                createdAt: "2026-05-14T15:00:00.0000000+00:00",
+                source: "manual")
+        };
+
+        var (service, ctx) = CreateService(entries);
+
+        var result = await service.GetAllMetadataAsync();
+
+        result.Should().HaveCount(2);
+        result[0].Id.Should().Be(42);
+        result[0].FileName.Should().Be("Pokemon Scarlet.sav");
+        result[0].SaveType.Should().Be("SAV9SV");
+        result[0].Generation.Should().Be(9);
+        result[0].GameVersion.Should().Be("Scarlet");
+        result[0].TrainerName.Should().Be("Yeniel");
+        result[0].SizeBytes.Should().Be(3_133_440);
+        result[0].IsManicEmu.Should().BeFalse();
+        result[0].Source.Should().Be("auto");
+
+        result[1].Id.Should().Be(43);
+        result[1].SaveType.Should().Be("SAV3E");
+        result[1].IsManicEmu.Should().BeTrue();
+        result[1].Source.Should().Be("manual");
+
+        await service.DisposeAsync();
+        ctx.Dispose();
+    }
+
+    [Fact]
+    public async Task GetAllMetadataAsync_MalformedCreatedAt_FallsBackToUtcNow()
+    {
+        var before = DateTimeOffset.UtcNow;
+        var entries = new[] { BuildEntry(createdAt: "not a real timestamp") };
+
+        var (service, ctx) = CreateService(entries);
+
+        var result = await service.GetAllMetadataAsync();
+
+        result.Should().ContainSingle();
+        result[0].CreatedAt.Should().BeOnOrAfter(before);
+
+        await service.DisposeAsync();
+        ctx.Dispose();
+    }
+
+    [Fact]
+    public async Task GetBackupBytesAsync_MissingRecord_ReturnsNull()
+    {
+        var (service, ctx) = CreateService(singleBackup: (Id: 99, Entry: null));
+
+        var result = await service.GetBackupBytesAsync(99);
+
+        result.Should().BeNull();
+
+        await service.DisposeAsync();
+        ctx.Dispose();
+    }
+
+    [Fact]
+    public async Task GetBackupBytesAsync_ValidRecord_RoundTripsBytes()
+    {
+        var payload = "the save bytes"u8.ToArray();
+        var entries = BuildEntry(id: 7, bytes: Convert.ToBase64String(payload));
+
+        var (service, ctx) = CreateService(singleBackup: (Id: 7, Entry: entries));
+
+        var result = await service.GetBackupBytesAsync(7);
+
+        result.Should().BeEquivalentTo(payload);
+
+        await service.DisposeAsync();
+        ctx.Dispose();
+    }
+
+    [Fact]
+    public async Task GetBackupBytesAsync_InvalidBase64_ReturnsNull()
+    {
+        var entries = BuildEntry(id: 8, bytes: "not valid base64 !!!");
+
+        var (service, ctx) = CreateService(singleBackup: (Id: 8, Entry: entries));
+
+        var result = await service.GetBackupBytesAsync(8);
+
+        result.Should().BeNull();
+
+        await service.DisposeAsync();
+        ctx.Dispose();
+    }
+}

--- a/Pkmds.Tests/BankServiceTests.cs
+++ b/Pkmds.Tests/BankServiceTests.cs
@@ -41,7 +41,7 @@ public class BankServiceTests
 
         ctx.JSInterop
             .SetupModule("./js/bank.js")
-            .Setup<string>("getAllPokemon")
+            .Setup<string>("getAllPokemonJson")
             .SetResult(json);
 
         var jsRuntime = ctx.Services.GetRequiredService<IJSRuntime>();

--- a/Pkmds.Tests/BankServiceTests.cs
+++ b/Pkmds.Tests/BankServiceTests.cs
@@ -26,8 +26,8 @@ public class BankServiceTests
 
     /// <summary>
     /// Creates a <see cref="BankService" /> backed by bUnit's JS-interop mock with
-    /// <paramref name="bankEntries" /> pre-loaded as the <c>getAllPokemon</c> result
-    /// (serialized to a JSON string to match the production contract).
+    /// <paramref name="bankEntries" /> pre-loaded as the <c>getAllPokemonJson</c>
+    /// result (serialized to a JSON string to match the production contract).
     /// </summary>
     private static (BankService Service, BunitContext Ctx) CreateService(
         BankService.RawEntry[]? bankEntries = null)

--- a/Pkmds.Tests/BankServiceTests.cs
+++ b/Pkmds.Tests/BankServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
@@ -8,6 +9,9 @@ namespace Pkmds.Tests;
 /// Unit tests for <see cref="BankService" /> using bUnit's JS-interop mocks.
 /// <see cref="BankService.RawEntry" /> and <see cref="BankService.RawMeta" /> are
 /// <c>internal</c> and accessible here via <c>InternalsVisibleTo</c> in Pkmds.Rcl.csproj.
+/// The bank JS contract passes JSON strings across the IJS boundary (trim-safe);
+/// these tests mirror that by serializing entries with the service's own source-gen
+/// context before handing them to the mock.
 /// </summary>
 public class BankServiceTests
 {
@@ -22,7 +26,8 @@ public class BankServiceTests
 
     /// <summary>
     /// Creates a <see cref="BankService" /> backed by bUnit's JS-interop mock with
-    /// <paramref name="bankEntries" /> pre-loaded as the <c>getAllPokemon</c> result.
+    /// <paramref name="bankEntries" /> pre-loaded as the <c>getAllPokemon</c> result
+    /// (serialized to a JSON string to match the production contract).
     /// </summary>
     private static (BankService Service, BunitContext Ctx) CreateService(
         BankService.RawEntry[]? bankEntries = null)
@@ -30,10 +35,14 @@ public class BankServiceTests
         var ctx = new BunitContext();
         ctx.JSInterop.Mode = JSRuntimeMode.Loose;
 
+        var json = JsonSerializer.Serialize(
+            bankEntries ?? [],
+            BankService.BankJsonContext.Default.RawEntryArray);
+
         ctx.JSInterop
             .SetupModule("./js/bank.js")
-            .Setup<BankService.RawEntry[]>("getAllPokemon")
-            .SetResult(bankEntries ?? []);
+            .Setup<string>("getAllPokemon")
+            .SetResult(json);
 
         var jsRuntime = ctx.Services.GetRequiredService<IJSRuntime>();
         var service = new BankService(jsRuntime);

--- a/Pkmds.Web/Pkmds.Web.csproj
+++ b/Pkmds.Web/Pkmds.Web.csproj
@@ -49,6 +49,7 @@
 
     <ItemGroup>
         <TrimmerRootDescriptor Include="PreservePkmTypes.xml"/>
+        <TrimmerRootDescriptor Include="PreserveJSInvokable.xml"/>
     </ItemGroup>
 
     <Target Name="CopyServiceWorkerPublished" AfterTargets="Publish">

--- a/Pkmds.Web/PreserveJSInvokable.xml
+++ b/Pkmds.Web/PreserveJSInvokable.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Trimmer root descriptor: preserve [JSInvokable] static entry points.
+
+  Blazor's IJS dispatcher (DotNet.invokeMethodAsync from the JS side) looks up
+  these methods by name at runtime via reflection. Under TrimMode=full the
+  linker can't see those JS-side references, so the methods (and the
+  [JSInvokable] attribute metadata they carry) get stripped — invocations
+  then fail with:
+
+    System.ArgumentException: The assembly '<asm>' does not contain a public
+    invokable method with [JSInvokableAttribute("<name>")]
+
+  Adding the containing types here roots their static methods + attribute
+  metadata. Keep this in sync with any new [JSInvokable] entry points.
+-->
+<linker>
+  <assembly fullname="Pkmds.Web">
+    <type fullname="Pkmds.Web.Services.RefreshService" preserve="all" />
+  </assembly>
+  <assembly fullname="Pkmds.Rcl">
+    <type fullname="Pkmds.Rcl.Services.EmbeddedHostBridge" preserve="all" />
+  </assembly>
+</linker>

--- a/Pkmds.Web/Services/RefreshService.cs
+++ b/Pkmds.Web/Services/RefreshService.cs
@@ -92,6 +92,9 @@ public class RefreshService : IRefreshService
     /// <summary>
     /// JavaScript-invokable method called by the service worker when an app update is detected.
     /// </summary>
+    // Preserved under TrimMode=full via PreserveJSInvokable.xml in Pkmds.Web — the linker
+    // can't see the JS-side call via DotNet.invokeMethodAsync, and [JSInvokable] alone
+    // is not a trim root.
     [JSInvokable(nameof(ShowUpdateMessage))]
     public static void ShowUpdateMessage() => Instance?.OnUpdateAvailable?.Invoke();
 }

--- a/Pkmds.Web/wwwroot/js/backup.js
+++ b/Pkmds.Web/wwwroot/js/backup.js
@@ -57,10 +57,19 @@ function openDb() {
     return _dbPromise;
 }
 
-export async function addBackup(bytesBase64, metaJson, source) {
+// Tolerate either a JSON string (new trim-safe path) or an already-parsed object
+// (legacy callers). Service-worker rollouts can briefly serve mismatched JS / DLL
+// pairs across cache boundaries, so the JS side defends against either shape.
+function parseMeta(value) {
+    if (value == null) return {};
+    return typeof value === 'string' ? JSON.parse(value) : value;
+}
+
+export async function addBackup(bytesBase64, meta, source) {
     // C# passes meta as a JSON string so it can serialize via source-gen and avoid
     // Blazor's reflection-based JsonSerializer on the IJS boundary (trim-safe).
-    const meta = JSON.parse(metaJson);
+    // An older DLL may still pass an object; parseMeta handles both.
+    meta = parseMeta(meta);
     const db = await openDb();
     return new Promise((resolve, reject) => {
         const tx = db.transaction(STORE, "readwrite");
@@ -79,12 +88,9 @@ export async function addBackup(bytesBase64, metaJson, source) {
     });
 }
 
-// Returns all backup records WITHOUT bytesBase64 — lightweight for list display.
-// Uses a cursor so that full blob data is never loaded into memory at once.
-// Returns a JSON string rather than the raw array so the .NET side can deserialize
-// via source-gen instead of Blazor's reflection-based JsonSerializer (trim-safe;
-// see #894).
-export async function getBackupMetadata() {
+// Internal helper — returns the metadata array (records without bytesBase64).
+// Shared between the legacy array-returning export and the new JSON-string export.
+async function getBackupMetadataInternal() {
     const db = await openDb();
     return new Promise((resolve, reject) => {
         const tx = db.transaction(STORE, "readonly");
@@ -95,7 +101,7 @@ export async function getBackupMetadata() {
         request.onsuccess = (event) => {
             const cursor = event.target.result;
             if (!cursor) {
-                resolve(JSON.stringify(results));
+                resolve(results);
                 return;
             }
 
@@ -110,20 +116,42 @@ export async function getBackupMetadata() {
     });
 }
 
-// Returns a single full backup record by ID (including bytesBase64) for restore/export.
-// Returns a JSON string (or null) — see getBackupMetadata for rationale.
-export async function getBackup(id) {
+// Legacy export — returns the raw metadata array. Kept around so an older cached
+// DLL that hasn't been updated yet still works during a service-worker rollout.
+// Uses a cursor so full blob data is never loaded into memory at once.
+export async function getBackupMetadata() {
+    return await getBackupMetadataInternal();
+}
+
+// Returns metadata serialized as a JSON string for source-gen deserialization
+// on the .NET side (trim-safe; see #894).
+export async function getBackupMetadataJson() {
+    return JSON.stringify(await getBackupMetadataInternal());
+}
+
+// Internal helper — returns the full record (including bytesBase64) by ID, or null.
+async function getBackupInternal(id) {
     const db = await openDb();
     return new Promise((resolve, reject) => {
         const tx = db.transaction(STORE, "readonly");
         const store = tx.objectStore(STORE);
         const request = store.get(id);
-        request.onsuccess = (event) => {
-            const value = event.target.result;
-            resolve(value ? JSON.stringify(value) : null);
-        };
+        request.onsuccess = (event) => resolve(event.target.result ?? null);
         request.onerror = (event) => reject(event.target.error);
     });
+}
+
+// Legacy export — returns the full backup record (or null). Used by restore/export
+// flows in older cached DLLs.
+export async function getBackup(id) {
+    return await getBackupInternal(id);
+}
+
+// Returns the full backup record serialized as a JSON string (or null) — see
+// getBackupMetadataJson for rationale.
+export async function getBackupJson(id) {
+    const value = await getBackupInternal(id);
+    return value ? JSON.stringify(value) : null;
 }
 
 export async function deleteBackup(id) {

--- a/Pkmds.Web/wwwroot/js/backup.js
+++ b/Pkmds.Web/wwwroot/js/backup.js
@@ -57,7 +57,10 @@ function openDb() {
     return _dbPromise;
 }
 
-export async function addBackup(bytesBase64, meta, source) {
+export async function addBackup(bytesBase64, metaJson, source) {
+    // C# passes meta as a JSON string so it can serialize via source-gen and avoid
+    // Blazor's reflection-based JsonSerializer on the IJS boundary (trim-safe).
+    const meta = JSON.parse(metaJson);
     const db = await openDb();
     return new Promise((resolve, reject) => {
         const tx = db.transaction(STORE, "readwrite");
@@ -78,6 +81,9 @@ export async function addBackup(bytesBase64, meta, source) {
 
 // Returns all backup records WITHOUT bytesBase64 — lightweight for list display.
 // Uses a cursor so that full blob data is never loaded into memory at once.
+// Returns a JSON string rather than the raw array so the .NET side can deserialize
+// via source-gen instead of Blazor's reflection-based JsonSerializer (trim-safe;
+// see #894).
 export async function getBackupMetadata() {
     const db = await openDb();
     return new Promise((resolve, reject) => {
@@ -89,7 +95,7 @@ export async function getBackupMetadata() {
         request.onsuccess = (event) => {
             const cursor = event.target.result;
             if (!cursor) {
-                resolve(results);
+                resolve(JSON.stringify(results));
                 return;
             }
 
@@ -105,13 +111,17 @@ export async function getBackupMetadata() {
 }
 
 // Returns a single full backup record by ID (including bytesBase64) for restore/export.
+// Returns a JSON string (or null) — see getBackupMetadata for rationale.
 export async function getBackup(id) {
     const db = await openDb();
     return new Promise((resolve, reject) => {
         const tx = db.transaction(STORE, "readonly");
         const store = tx.objectStore(STORE);
         const request = store.get(id);
-        request.onsuccess = (event) => resolve(event.target.result ?? null);
+        request.onsuccess = (event) => {
+            const value = event.target.result;
+            resolve(value ? JSON.stringify(value) : null);
+        };
         request.onerror = (event) => reject(event.target.error);
     });
 }

--- a/Pkmds.Web/wwwroot/js/bank.js
+++ b/Pkmds.Web/wwwroot/js/bank.js
@@ -59,10 +59,19 @@ function openDb() {
     return _dbPromise;
 }
 
-export async function addPokemon(bytesBase64, metaJson) {
+// Tolerate either a JSON string (new trim-safe path) or an already-parsed object
+// (legacy callers). Service-worker rollouts can briefly serve mismatched JS / DLL
+// pairs across cache boundaries, so the JS side defends against either shape.
+function parseMeta(value) {
+    if (value == null) return {};
+    return typeof value === 'string' ? JSON.parse(value) : value;
+}
+
+export async function addPokemon(bytesBase64, meta) {
     // C# passes meta as a JSON string so it can serialize via source-gen and avoid
     // Blazor's reflection-based JsonSerializer on the IJS boundary (trim-safe).
-    const meta = JSON.parse(metaJson);
+    // An older DLL may still pass an object; parseMeta handles both.
+    meta = parseMeta(meta);
     const db = await openDb();
     return new Promise((resolve, reject) => {
         const tx = db.transaction(STORE, "readwrite");
@@ -83,9 +92,10 @@ export async function addPokemon(bytesBase64, metaJson) {
 
 // Bulk-insert all entries in a single readwrite transaction — much faster than
 // calling addPokemon() in a loop when importing an entire save file.
-export async function addRange(entriesJson) {
-    // See addPokemon() — C# pre-serializes the payload for trim-safe interop.
-    const entries = JSON.parse(entriesJson);
+export async function addRange(entries) {
+    // See addPokemon() — C# pre-serializes the payload for trim-safe interop,
+    // but tolerate the legacy array shape too for service-worker rollout safety.
+    entries = parseMeta(entries);
     const db = await openDb();
     return new Promise((resolve, reject) => {
         const tx = db.transaction(STORE, "readwrite");
@@ -114,10 +124,17 @@ async function getAllEntries() {
     });
 }
 
-// Exported for C# — returns a JSON string rather than the raw array so the .NET
-// side can deserialize via source-gen instead of Blazor's reflection-based
-// JsonSerializer (which breaks under TrimMode=full — see #896).
+// Legacy export — returns the raw entries array. Kept around so an older cached
+// DLL that hasn't been updated yet still works during a service-worker rollout.
 export async function getAllPokemon() {
+    return await getAllEntries();
+}
+
+// Returns the entries serialized as a JSON string so the .NET side can deserialize
+// via source-gen instead of Blazor's reflection-based JsonSerializer (which breaks
+// under TrimMode=full — see #896). New code should call this; getAllPokemon stays
+// for backward compatibility.
+export async function getAllPokemonJson() {
     const entries = await getAllEntries();
     return JSON.stringify(entries);
 }

--- a/Pkmds.Web/wwwroot/js/bank.js
+++ b/Pkmds.Web/wwwroot/js/bank.js
@@ -110,9 +110,10 @@ export async function addRange(entries) {
     });
 }
 
-// Internal helper — returns the raw entries array. Used by both the exported
-// getAllPokemon (which stringifies for IJS) and exportAll (which builds a binary
-// file payload directly from the array).
+// Internal helper — returns the raw entries array. Shared between getAllPokemon
+// (legacy export, returns the array directly), getAllPokemonJson (stringifies for
+// trim-safe IJS), and exportAll (builds a binary file payload directly from the
+// array).
 async function getAllEntries() {
     const db = await openDb();
     return new Promise((resolve, reject) => {

--- a/Pkmds.Web/wwwroot/js/bank.js
+++ b/Pkmds.Web/wwwroot/js/bank.js
@@ -59,7 +59,10 @@ function openDb() {
     return _dbPromise;
 }
 
-export async function addPokemon(bytesBase64, meta) {
+export async function addPokemon(bytesBase64, metaJson) {
+    // C# passes meta as a JSON string so it can serialize via source-gen and avoid
+    // Blazor's reflection-based JsonSerializer on the IJS boundary (trim-safe).
+    const meta = JSON.parse(metaJson);
     const db = await openDb();
     return new Promise((resolve, reject) => {
         const tx = db.transaction(STORE, "readwrite");
@@ -80,7 +83,9 @@ export async function addPokemon(bytesBase64, meta) {
 
 // Bulk-insert all entries in a single readwrite transaction — much faster than
 // calling addPokemon() in a loop when importing an entire save file.
-export async function addRange(entries) {
+export async function addRange(entriesJson) {
+    // See addPokemon() — C# pre-serializes the payload for trim-safe interop.
+    const entries = JSON.parse(entriesJson);
     const db = await openDb();
     return new Promise((resolve, reject) => {
         const tx = db.transaction(STORE, "readwrite");
@@ -95,7 +100,10 @@ export async function addRange(entries) {
     });
 }
 
-export async function getAllPokemon() {
+// Internal helper — returns the raw entries array. Used by both the exported
+// getAllPokemon (which stringifies for IJS) and exportAll (which builds a binary
+// file payload directly from the array).
+async function getAllEntries() {
     const db = await openDb();
     return new Promise((resolve, reject) => {
         const tx = db.transaction(STORE, "readonly");
@@ -104,6 +112,14 @@ export async function getAllPokemon() {
         request.onsuccess = (event) => resolve(event.target.result);
         request.onerror = (event) => reject(event.target.error);
     });
+}
+
+// Exported for C# — returns a JSON string rather than the raw array so the .NET
+// side can deserialize via source-gen instead of Blazor's reflection-based
+// JsonSerializer (which breaks under TrimMode=full — see #896).
+export async function getAllPokemon() {
+    const entries = await getAllEntries();
+    return JSON.stringify(entries);
 }
 
 export async function deletePokemon(id) {
@@ -131,7 +147,7 @@ export async function clearAll() {
 }
 
 export async function exportAll() {
-    const entries = await getAllPokemon();
+    const entries = await getAllEntries();
     const json = JSON.stringify(entries);
     const encoder = new TextEncoder();
     // Return Uint8Array directly — .NET marshals this to byte[] without an extra


### PR DESCRIPTION
## Summary

Makes `BankService` and `BackupService` safe to run under `TrimMode=full` by pre-serializing object payloads to JSON strings on the C# side via source-gen `JsonSerializerContext` and passing strings (not CLR objects) across the IJS boundary. Strings are opaque primitives to Blazor's interop marshaler, so this path no longer relies on the reflection-based default `JsonSerializer` that `TrimMode=full` strips metadata for.

Once verified on UAT, the prerequisite for re-enabling \`TrimMode=full\` (reverted in #901).

## What this fixes

- **#896** — `BankService.GetAllAsync` crash: \`DeserializeNoConstructor, JsonConstructorAttribute, ...BankService+RawEntry\`. `RawEntry`'s parameterless ctor + setters were trimmed.
- **#898** — `BankService.AddAsync` crash: \`ConstructorContainsNullParameterNames\` on the 6-property anonymous \`meta = new { species, isShiny, nickname, ext, tag, sourceSave }\`. The ctor parameter names were trimmed.
- **#894** — Backup Manager hangs on indefinite spinner. Same root cause as #896 applied to `BackupService.GetAllMetadataAsync`. The exception in `OnInitializedAsync` keeps Blazor from re-rendering after `isLoading = false`, so the `MudProgressLinear` stays visible.

## Why source-gen + strings, not a trimmer descriptor

`IJSObjectReference.InvokeAsync<T>` and `InvokeVoidAsync(object...)` route payloads through Blazor's internal `JsonSerializerOptions`, which app code can't extend with a custom source-gen `TypeInfoResolverChain`. A `TrimmerRootDescriptor` could preserve the named DTOs (`RawEntry`, `RawMeta`, etc.) but cannot rescue the anonymous types used on the write path - those require refactoring to named types anyway. Moving serialization to our side lets us own the contract end-to-end, with no reflection on the IJS boundary.

## Changes

- `BankService` becomes \`partial\`; nested \`BankJsonContext\` owns source-gen TypeInfos for \`BankMeta\`, \`BankAddEntry[]\`, and \`RawEntry[]\`.
- Replace both anonymous types in `BankService` with named records (\`BankMeta\`, \`BankAddEntry\`).
- `BackupService` gets the same treatment with \`BackupMeta\` + nested \`BackupJsonContext\` for \`BackupMeta\`, \`RawBackupEntry\`, \`RawBackupEntry[]\`.
- \`bank.js\`: \`addPokemon\` / \`addRange\` accept JSON strings (\`JSON.parse\` on entry); \`getAllPokemon\` returns \`JSON.stringify(rows)\`. Split out a private \`getAllEntries\` helper so \`exportAll\` keeps operating on the raw array without a double stringify.
- \`backup.js\`: \`addBackup\` accepts \`metaJson\`; \`getBackupMetadata\` and \`getBackup\` return JSON strings (or \`null\` for the single-record fetch when the ID misses).
- IndexedDB schema is unchanged - only the IJS wire format moved, so **existing bank/backup data round-trips without migration**.
- `BankServiceTests` mock setup now uses \`Setup<string>("getAllPokemon")\` with a serialized payload, matching the production contract.

## Audit of other IJS object-payload call sites

- `MainLayout.razor.cs:209` passes \`new { }\` to \`PKMDS.host._sendMessage\`. Empty anonymous type with no properties means there are no ctor parameter names to lose - low risk, but worth converting to a literal \`"{}"\` string in a follow-up to remove the trim hazard entirely.

## Test plan

- [x] \`dotnet build Pkmds.Web/Pkmds.Web.csproj -c Debug\` - 0 warnings, 0 errors
- [x] \`dotnet publish Pkmds.Web/Pkmds.Web.csproj -c Release -p:TrimMode=full -p:PublishTrimmed=true\` - 0 trim warnings, completes
- [ ] CI green
- [ ] UAT smoke test on the published PR build:
  - Bank tab loads (read path): open Pokémon Bank, confirm prior entries appear, confirm no crash
  - Add to Bank (write path): right-click a Pokémon → Add to Bank, confirm it appears in the list
  - Backup Manager loads (read path): open backup manager, confirm spinner clears and list populates
  - Create backup (write path): trigger a manual backup, confirm it appears in the list
- [ ] Follow-up PR: re-apply commit 83fa71f4 to re-enable \`TrimMode=full\` once UAT verification passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)