### PR TITLE
Fix ZA legalization freeze, SAV7b crash, and add safe cache-fix guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,6 +265,29 @@ Prefer reading local source over fetching from GitHub or relying solely on docs:
 - **Tests**: Do not run `dotnet test` locally — leave it to the CI GitHub Actions workflow (`.github/workflows/buildandtest.yml`). Run only `dotnet format` and `dotnet build -c Debug` to verify changes locally.
 - **PR review feedback**: (1) Review all comments and plan the response; (2) reply to each individual comment on the PR explaining what you're doing and why; (3) make code changes, commit, and push; (4) mark all addressed comments as resolved on the PR.
 
+## User-facing advice — protect user data
+
+When suggesting troubleshooting steps to users (in issue comments, emails, or docs),
+**never recommend "Clear site data"** (or equivalent browser commands that wipe the entire
+origin) as a fix for service worker or cache issues. Doing so silently destroys:
+
+- **Save backups** — stored in IndexedDB (`IBackupService`)
+- **Pokémon Bank** — stored in IndexedDB (`IBankService`)
+
+These are irreplaceable if the user has no other copy of their Pokémon.
+
+**Use targeted cache fixes instead:**
+
+1. Hard refresh (`Ctrl+Shift+R` / `⌘⇧R`) — bypasses SW cache for that request, safe.
+2. DevTools → Application → Service Workers → **Unregister** — removes only the cached
+   app files, leaves IndexedDB intact.
+3. Incognito / private window — bypasses the SW entirely for diagnosis.
+
+This rule applies to all agents, AI assistants, and contributors. The same principle
+extends to any advice that could destroy user-created content: always prefer the most
+targeted, reversible action. Confirm with the maintainer before recommending anything
+that cannot be undone.
+
 ## Notes
 
 - Respect the existing code style. Reference `.editorconfig` for formatting rules; Debug builds treat warnings as errors.

--- a/Pkmds.Rcl/Components/MainTabPages/LegalityReportTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/LegalityReportTab.razor.cs
@@ -309,16 +309,23 @@ public partial class LegalityReportTab : RefreshAwareComponent
         var entries = new List<LegalityReportEntry>();
 
         // --- Party slots ---
-        for (var i = 0; i < saveFile.PartyCount; i++)
+        // SAV7b (Let's Go) has no separate party buffer (HasParty=false); party members
+        // are flagged box slots and are already covered by the box scan below. Iterating
+        // GetPartySlotAtIndex on SAV7b can throw ArgumentOutOfRangeException when the
+        // PokeListInfo header contains an out-of-range slot index (emulator / JKSM dumps).
+        if (saveFile.HasParty)
         {
-            var pkm = saveFile.GetPartySlotAtIndex(i);
-            if (pkm is not { Species: > 0 })
+            for (var i = 0; i < saveFile.PartyCount; i++)
             {
-                continue;
-            }
+                var pkm = saveFile.GetPartySlotAtIndex(i);
+                if (pkm is not { Species: > 0 })
+                {
+                    continue;
+                }
 
-            var la = AppService.GetLegalityAnalysis(pkm, isParty: true);
-            entries.Add(BuildEntry(pkm, la, true, 0, i));
+                var la = AppService.GetLegalityAnalysis(pkm, isParty: true);
+                entries.Add(BuildEntry(pkm, la, true, 0, i));
+            }
         }
 
         // --- Box slots (yield after every box to keep the UI responsive) ---

--- a/Pkmds.Rcl/Services/AppService.cs
+++ b/Pkmds.Rcl/Services/AppService.cs
@@ -380,19 +380,25 @@ public class AppService(IAppState appState, IRefreshService refreshService, ILeg
             return;
         }
 
-        // Validate party requirements: must keep at least one non-Egg battle-ready Pokémon
+        // Validate party requirements: must keep at least one non-Egg battle-ready Pokémon.
+        // SAV7b (Let's Go) has no separate party buffer (HasParty=false); skip the count
+        // check to avoid ArgumentOutOfRangeException from PokeListInfo with invalid slot
+        // indices on emulator / JKSM dumps.
         var battleReadyCount = 0;
-        for (var i = 0; i < saveFile.PartyCount; i++)
+        if (saveFile.HasParty)
         {
-            if (i == partySlotNumber)
+            for (var i = 0; i < saveFile.PartyCount; i++)
             {
-                continue; // Skip the one being deleted
-            }
+                if (i == partySlotNumber)
+                {
+                    continue; // Skip the one being deleted
+                }
 
-            var partyMon = saveFile.GetPartySlotAtIndex(i);
-            if (partyMon is { Species: > 0, IsEgg: false })
-            {
-                battleReadyCount++;
+                var partyMon = saveFile.GetPartySlotAtIndex(i);
+                if (partyMon is { Species: > 0, IsEgg: false })
+                {
+                    battleReadyCount++;
+                }
             }
         }
 
@@ -439,6 +445,14 @@ public class AppService(IAppState appState, IRefreshService refreshService, ILeg
     public string ExportPartyAsShowdown()
     {
         if (AppState.SaveFile is not { PartyCount: var partyCount } saveFile || partyCount == 0)
+        {
+            return string.Empty;
+        }
+
+        // SAV7b (Let's Go) stores party members as flagged box slots; GetPartySlotAtIndex
+        // can throw when the PokeListInfo header has an out-of-range slot index (emulator /
+        // JKSM dumps). Skip party export entirely — the player can export via the box instead.
+        if (!saveFile.HasParty)
         {
             return string.Empty;
         }

--- a/Pkmds.Rcl/Services/LegalizationService.cs
+++ b/Pkmds.Rcl/Services/LegalizationService.cs
@@ -1098,6 +1098,14 @@ public sealed class LegalizationService(IAppState appState) : ILegalizationServi
         var laForRibbons = new LegalityAnalysis(pk);
         RibbonApplicator.SetAllValidRibbons(laForRibbons);
 
+        // Re-set Plus flags for ZA Pokémon after all mutations (level bump, move fixes, etc.).
+        // ApplySetDetails set them at set.Level; any subsequent CurrentLevel increase leaves
+        // moves at the new higher levels without their Plus flags set.
+        if (pk is PA9 pa9Rebuild && pk.PersonalInfo is IPermitPlus plusPermitRebuild)
+        {
+            pa9Rebuild.SetPlusFlags(plusPermitRebuild, PlusRecordApplicatorOption.LegalSeedTM);
+        }
+
         // Suggest legal ball.
         BallApplicator.ApplyBallLegalByColor(pk);
 
@@ -1156,6 +1164,13 @@ public sealed class LegalizationService(IAppState appState) : ILegalizationServi
         if (pk.MetLevel > pk.CurrentLevel)
         {
             pk.MetLevel = pk.CurrentLevel;
+        }
+
+        // MetLevel below enc.LevelMin causes EncounterSlot9a.IsMatchExact to reject the
+        // encounter via IsLevelWithinRange. Clamp up so the encounter can match.
+        if (pk.MetLevel < enc.LevelMin)
+        {
+            pk.MetLevel = enc.LevelMin;
         }
 
         if (pk is IObedienceLevel ob && ob.ObedienceLevel > pk.CurrentLevel)
@@ -1253,6 +1268,16 @@ public sealed class LegalizationService(IAppState appState) : ILegalizationServi
                     changed = true;
                     break;
             }
+        }
+
+        // Plus flags (Legends: Z-A mastery flags). LegendsZAVerifier reports these under
+        // CheckIdentifier.RelearnMove. Re-set after moves/relearn are fixed so the flags
+        // reflect the final moveset and level.
+        if (pk is PA9 pa9Preserve && pk.PersonalInfo is IPermitPlus plusPermitPreserve &&
+            la.Results.Any(r => r.Judgement == PKHeX.Core.Severity.Invalid && r.Identifier == CheckIdentifier.RelearnMove))
+        {
+            pa9Preserve.SetPlusFlags(plusPermitPreserve, PlusRecordApplicatorOption.LegalSeedTM);
+            changed = true;
         }
 
         return changed;

--- a/Pkmds.Web/wwwroot/BrowserNotSupported.html
+++ b/Pkmds.Web/wwwroot/BrowserNotSupported.html
@@ -70,6 +70,33 @@
     Want the gritty details? Check
     <a href="https://caniuse.com/wasm-simd" target="_blank" rel="noopener">caniuse.com/wasm-simd</a>.
 </p>
+
+<hr style="margin: 2rem 0; border: none; border-top: 1px solid #d1d5db;"/>
+
+<h2 style="font-size: 1.1rem;">Loading on a supported browser but still not working?</h2>
+
+<p>
+    A stale service worker cache can prevent the app from starting after an update.
+    Try these steps — they leave your save backups and Bank storage untouched:
+</p>
+
+<ol>
+    <li><strong>Hard refresh</strong> — <kbd>Ctrl+Shift+R</kbd> (Windows/Linux/ChromeOS) or <kbd>⌘⇧R</kbd> (Mac). Usually enough.</li>
+    <li>
+        <strong>Unregister the service worker</strong> — open DevTools (<kbd>F12</kbd>),
+        go to <strong>Application → Service Workers</strong>, and click <strong>Unregister</strong>
+        next to the PKMDS entry. Reload the page.
+        <br/>
+        <em>Do not use "Clear site data" — that also wipes your local backups and Bank.</em>
+    </li>
+    <li><strong>Incognito / private window</strong> — bypasses the service worker entirely to confirm the issue is cache-related.</li>
+</ol>
+
+<p>
+    If none of those help, please
+    <a href="https://github.com/codemonkey85/PKMDS-Blazor/issues" target="_blank" rel="noopener">open an issue</a>
+    and describe what you see (stuck spinner, error bar, or this page).
+</p>
 </body>
 
 </html>

--- a/Pkmds.Web/wwwroot/index.html
+++ b/Pkmds.Web/wwwroot/index.html
@@ -108,6 +108,10 @@
 <script src="_content/Pkmds.Rcl/js/appCache.js"></script>
 <script src="js/app.js"></script>
 
+<!-- Must load before blazor.webassembly.js so the error listeners are
+     registered before the WASM / AOT bootstrap can throw. -->
+<script src="js/error-reporting.js"></script>
+
 <!--prevent autostarting-->
 <script autostart="false"
         src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>

--- a/Pkmds.Web/wwwroot/js/error-reporting.js
+++ b/Pkmds.Web/wwwroot/js/error-reporting.js
@@ -1,0 +1,142 @@
+// Startup crash reporting.
+//
+// The Blazor ErrorBoundary handles in-app C# exceptions and routes them to
+// the BugReportDialog. This file covers the complementary case: startup
+// failures (WASM instantiation errors, AOT runtime crashes, unhandled promise
+// rejections) where the .NET runtime never fully initialises and the only UI
+// we have is the #blazor-error-ui bar.
+//
+// When a startup crash is detected we:
+//   1. Inject the actual error message into the bar so users can see it.
+//   2. Add a "Copy error details" button (clipboard).
+//   3. Add a "Report this bug" link that pre-fills a GitHub issue with the
+//      error message, stack trace, user agent, and timestamp.
+
+(function () {
+    'use strict';
+
+    var injected = false;
+
+    function buildReport(message, stack) {
+        var lines = [
+            '**User agent:** ' + navigator.userAgent,
+            '**Time (UTC):** ' + new Date().toISOString(),
+            '**URL:** ' + location.href,
+            '',
+            '## Error message',
+            '```',
+            message,
+            '```',
+        ];
+        if (stack) {
+            lines.push('', '## Stack trace', '```', stack, '```');
+        }
+        lines.push(
+            '',
+            '## Description',
+            '<!-- Please describe what you were doing when the crash occurred. -->'
+        );
+        return lines.join('\n');
+    }
+
+    function buildIssueUrl(message, report) {
+        var title = '[Crash] Startup error: ' + message.slice(0, 80);
+        // GitHub caps issue body at ~65 535 chars in the URL; truncate generously.
+        var body = report.length > 4000 ? report.slice(0, 4000) + '\n\n*(truncated)*' : report;
+        return (
+            'https://github.com/codemonkey85/PKMDS-Blazor/issues/new' +
+            '?title=' + encodeURIComponent(title) +
+            '&body=' + encodeURIComponent(body) +
+            '&labels=' + encodeURIComponent('bug,crash')
+        );
+    }
+
+    function injectErrorDetails(message, stack) {
+        if (injected) return;
+        injected = true;
+
+        var ui = document.getElementById('blazor-error-ui');
+        if (!ui) return;
+
+        var report = buildReport(message, stack);
+        var issueUrl = buildIssueUrl(message, report);
+
+        // Error message line.
+        var msgEl = document.createElement('p');
+        msgEl.style.cssText = 'margin: 0.4rem 0 0; font-size: 0.8rem; font-family: monospace; word-break: break-all;';
+        msgEl.textContent = message;
+        ui.insertBefore(msgEl, ui.firstChild.nextSibling);
+
+        // Collapsible stack trace.
+        if (stack) {
+            var details = document.createElement('details');
+            details.style.cssText = 'margin-top: 0.4rem; font-size: 0.75rem;';
+            var summary = document.createElement('summary');
+            summary.textContent = 'Stack trace';
+            summary.style.cursor = 'pointer';
+            var pre = document.createElement('pre');
+            pre.style.cssText = 'overflow: auto; max-height: 120px; background: rgba(0,0,0,0.08); padding: 0.4rem; border-radius: 3px; margin: 0.3rem 0 0; font-size: 0.7rem; white-space: pre-wrap; word-break: break-all;';
+            pre.textContent = stack;
+            details.appendChild(summary);
+            details.appendChild(pre);
+            ui.insertBefore(details, msgEl.nextSibling);
+        }
+
+        // Button row.
+        var row = document.createElement('div');
+        row.style.cssText = 'margin-top: 0.5rem; display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center;';
+
+        var copyBtn = document.createElement('button');
+        copyBtn.textContent = 'Copy error details';
+        copyBtn.style.cssText = 'padding: 0.2rem 0.6rem; font-size: 0.78rem; cursor: pointer; border: 1px solid #888; background: #fff; border-radius: 3px;';
+        copyBtn.addEventListener('click', function () {
+            var done = function () {
+                copyBtn.textContent = 'Copied!';
+                setTimeout(function () { copyBtn.textContent = 'Copy error details'; }, 2000);
+            };
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                navigator.clipboard.writeText(report).then(done).catch(done);
+            } else {
+                var ta = document.createElement('textarea');
+                ta.value = report;
+                ta.style.position = 'fixed';
+                ta.style.opacity = '0';
+                document.body.appendChild(ta);
+                ta.focus();
+                ta.select();
+                try { document.execCommand('copy'); } catch (_) {}
+                document.body.removeChild(ta);
+                done();
+            }
+        });
+
+        var reportLink = document.createElement('a');
+        reportLink.href = issueUrl;
+        reportLink.target = '_blank';
+        reportLink.rel = 'noopener noreferrer';
+        reportLink.textContent = 'Report this bug';
+        reportLink.style.cssText = 'padding: 0.2rem 0.6rem; font-size: 0.78rem; background: #b91c1c; color: #fff; border-radius: 3px; text-decoration: none;';
+
+        row.appendChild(copyBtn);
+        row.appendChild(reportLink);
+
+        var insertAfter = stack ? details : msgEl;
+        ui.insertBefore(row, insertAfter.nextSibling);
+    }
+
+    // Unhandled promise rejections — covers WASM / AOT / Blazor bootstrap failures.
+    window.addEventListener('unhandledrejection', function (e) {
+        var reason = e.reason;
+        if (!reason) return;
+        var message = typeof reason.message === 'string' ? reason.message : String(reason);
+        var stack = typeof reason.stack === 'string' ? reason.stack : null;
+        injectErrorDetails(message, stack);
+    });
+
+    // Synchronous JS errors.
+    window.addEventListener('error', function (e) {
+        if (!e.message) return;
+        var stack = e.error && typeof e.error.stack === 'string' ? e.error.stack : null;
+        injectErrorDetails(e.message, stack);
+    });
+})();


### PR DESCRIPTION
## Summary

- **fix(legalization): Legends: Z-A Pokémon freeze** (closes #908) — Three cooperating bugs caused any ZA legalization attempt to run the full 15-second timeout:
  1. `ApplyPreserveModeFixes` bumped `CurrentLevel` to `enc.LevelMin` but left `MetLevel` below it, causing `EncounterSlot9a.IsMatchExact` to reject every ZA encounter.
  2. `ApplyTargetedFixesFromAnalysis` (preserve mode) never re-set ZA Plus/mastery flags when `LegendsZAVerifier` reported them invalid.
  3. `ApplyPostGenerationFixes` (rebuild mode) set Plus flags at `set.Level` then bumped `CurrentLevel` to `enc.LevelMin`, leaving moves at the new higher level without their flags.

- **fix(lgpe): SAV7b `ArgumentOutOfRangeException` crash** (closes #909) — `SAV7b.HasParty = false`; its "party" is flagged box slots. Calling `GetPartySlotAtIndex` on a save with out-of-range `PokeListInfo` values (emulator/JKSM dumps) throws `ArgumentOutOfRangeException`. Guarded three call sites — Legality Report scan, Export Party as Showdown, and the delete battle-ready count — with `saveFile.HasParty` checks.

- **docs: protect users from destructive cache-clearing advice** — `AGENTS.md` now carries an explicit rule (targeting all AI agents and contributors) to never recommend "Clear site data" for cache issues. `BrowserNotSupported.html` gains a troubleshooting section with safe steps.

- **feat(errors): capture startup crashes in the error bar** — `error-reporting.js` registers `error`/`unhandledrejection` listeners before `blazor.webassembly.js` loads. On a startup crash (WASM instantiation failure, AOT runtime crash) it injects the actual error message, a collapsible stack trace, a "Copy error details" button, and a "Report this bug" link that pre-fills a GitHub issue — all in the `#blazor-error-ui` bar, without requiring Blazor to be running.

## Test plan

- [ ] Load a ZA save and legalize a Pikachu — should complete in under a second rather than freezing for 15 s
- [ ] Load a SAV7b (Let's Go) save and run Legality Report → Scan — should not crash
- [ ] Load a SAV7b save and use Export Party as Showdown — should return empty rather than crashing
- [ ] Simulate a startup crash (e.g. throw in index.html before Blazor.start) and verify the error bar shows the message, stack, copy button, and report link
- [ ] Visit `/BrowserNotSupported.html` and verify the troubleshooting section renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)