### PR TITLE
fix(sw): cache appsettings.json to prevent 429 boot failures on iOS Safari

### DIFF
--- a/Pkmds.Web/wwwroot/service-worker.published.js
+++ b/Pkmds.Web/wwwroot/service-worker.published.js
@@ -27,7 +27,12 @@ const offlineAssetsInclude = [/\.dll$/, /\.pdb$/, /\.wasm/, /\.html/, /\.js$/, /
 // on the fingerprinted asset), so returning users with a populated HTTP
 // cache still get offline reload; only stone-cold first-load-offline fails
 // for this single file, which has always been a thin scenario.
-const offlineAssetsExclude = [/^service-worker\.js$/, /^appsettings.*\.json$/, /^staticwebapp\.config\.json$/, /^_framework\/dotnet\.native\.[^\/]+\.wasm$/];
+//
+// appsettings*.json is intentionally NOT excluded: our appsettings.json is
+// static (just the Azure function URL) and excluding it caused 429 failures
+// for users on iCloud Private Relay / GitHub Pages rate-limited IPs, crashing
+// the Blazor bootstrap before the app could start (issue #910).
+const offlineAssetsExclude = [/^service-worker\.js$/, /^staticwebapp\.config\.json$/, /^_framework\/dotnet\.native\.[^\/]+\.wasm$/];
 
 // Replace with your base path if you are hosting on a subfolder. Ensure there is a trailing '/'.
 const base = "/";


### PR DESCRIPTION
## Summary

`appsettings.json` was excluded from the service worker pre-cache following the Blazor template default (to allow live config updates). However, the file is purely static — it only contains the Azure function URL and never changes independently of a full deploy.

Excluding it caused the Blazor bootstrap to fetch it live on every page load. Users on **iCloud Private Relay** (whose traffic routes through shared Apple relay IPs) received HTTP 429 Too Many Requests from GitHub Pages, crashing the app before any .NET code ran. The crash surfaced via the new `error-reporting.js` introduced in the previous PR — the very first use of the feature diagnosed this bug exactly.

The fix is one line: remove `appsettings*.json` from `offlineAssetsExclude` so it is pre-cached alongside all other static assets. The existing cache-bust mechanism (`assetsManifest.version + CACHE_VERSION`) ensures clients pick up future changes on the next deploy.

**Reporter:** Jay (#910), iPhone 8 Plus / iOS 16.7.7 / Safari 16.6

Error bar screenshot (from Jay, after the error-reporting feature shipped):

> An unhandled error has occurred.
> `download 'https://pkmds.app/appsettings.json' for ../appsettings.json failed 429`

## Test plan

- [ ] Deploy and confirm `appsettings.json` is served from the SW cache on reload (Application → Cache Storage in DevTools)
- [ ] Ask Jay (#910) to test again after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)