### PR TITLE
chore: disable SIMD and AOT to restore iOS < 16.4 compatibility

### DIFF
--- a/Pkmds.Web/Pkmds.Web.csproj
+++ b/Pkmds.Web/Pkmds.Web.csproj
@@ -6,11 +6,10 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <!-- Enable WASM SIMD codegen. PKHeX hot paths (legality, encryption,
-             encounter generation) benefit; cost is dropping Safari < 16.4 and
-             iOS < 16.4. The static feature test in wwwroot/index.html redirects
-             unsupported browsers to BrowserNotSupported.html. See issue #883. -->
-        <WasmEnableSIMD>true</WasmEnableSIMD>
+        <!-- SIMD disabled to restore compatibility with iOS < 16.4 / Safari < 16.4.
+             Re-enable (with the SIMD probe in index.html) if perf measurements
+             justify the browser support trade-off. See issue #883. -->
+        <WasmEnableSIMD>false</WasmEnableSIMD>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
@@ -42,11 +41,9 @@
              were hardened. -->
         <TrimMode>full</TrimMode>
         <PublishTrimmed>true</PublishTrimmed>
-        <!-- AOT-compile to native WASM for ~4-5x speedup on PKHeX hot paths
-             (legality analysis, encryption roundtrip, box search). Costs ~6 MB
-             extra brotli payload and ~3-4 min extra CI publish time. Combined
-             with SIMD above per /bench measurements on #883. -->
-        <RunAOTCompilation>true</RunAOTCompilation>
+        <!-- AOT disabled alongside SIMD. Re-enable both together once the
+             browser compatibility impact of SIMD is better understood. -->
+        <RunAOTCompilation>false</RunAOTCompilation>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/Pkmds.Web/wwwroot/index.html
+++ b/Pkmds.Web/wwwroot/index.html
@@ -138,26 +138,7 @@
         return false;
     })();
 
-    // WASM SIMD support. The Pkmds.Web build ships with WasmEnableSIMD=true,
-    // so browsers without SIMD (notably Safari < 16.4, iOS < 16.4) can't run
-    // the app — direct them to the fallback page instead of a silent failure.
-    // The payload below is the standard wasm-feature-detect SIMD probe: a
-    // minimal valid module whose only function returns a v128 produced by
-    // i8x16.splat (0xFD 0x0F) followed by i8x16.popcnt (0xFD 0x62). Engines
-    // without SIMD do not understand the 0xFD prefix and WebAssembly.validate
-    // returns false.
-    const wasmSimdSupported = (function () {
-        try {
-            return WebAssembly.validate(new Uint8Array([
-                0, 97, 115, 109, 1, 0, 0, 0, 1, 5, 1, 96, 0, 1, 123,
-                3, 2, 1, 0, 10, 10, 1, 8, 0, 65, 0, 253, 15, 253, 98, 11
-            ]));
-        } catch (e) {
-            return false;
-        }
-    })();
-
-    if (webassemblySupported && wasmSimdSupported) {
+    if (webassemblySupported) {
         Blazor.start({});
     } else {
         // Resolve against document.baseURI so the redirect lands on the


### PR DESCRIPTION
## Summary

- Sets `WasmEnableSIMD=false` and `RunAOTCompilation=false` in `Pkmds.Web.csproj`
- Removes the SIMD feature probe and redirect from `index.html` — the `BrowserNotSupported.html` fallback is now only triggered for browsers with no WebAssembly support at all
- Restores compatibility for iOS < 16.4 / Safari < 16.4 (previously blocked by the SIMD gate added in #883)

Both flags can be re-enabled together in the future once the browser compatibility impact is better understood.

Closes #910

🤖 Generated with [Claude Code](https://claude.com/claude-code)