### PR TITLE
fix(sw): resolve respondWith rejections that surface as TypeError on iOS Safari

### DIFF
--- a/Pkmds.Web/wwwroot/service-worker.published.js
+++ b/Pkmds.Web/wwwroot/service-worker.published.js
@@ -71,18 +71,23 @@ async function onActivate(event) {
 }
 
 async function onFetch(event) {
-    // Cache-first strategy for PokeAPI sprites — separate long-lived cache that survives app updates
+    // Cache-first strategy for PokeAPI sprites — separate long-lived cache that survives app updates.
+    // Return the promise rather than calling event.respondWith() here: the outer 'fetch' listener
+    // already wraps onFetch(event) in respondWith, and double-calling it throws InvalidStateError
+    // (and on iOS Safari surfaces as `FetchEvent.respondWith received an error: TypeError: ...`).
     if (event.request.method === 'GET' && event.request.url.startsWith(spriteOrigin)) {
-        event.respondWith(
-            caches.open(spriteCacheName).then(async cache => {
-                const cached = await cache.match(event.request);
-                if (cached) return cached;
-                const response = await fetch(event.request);
-                if (response.ok) cache.put(event.request, response.clone());
-                return response;
-            })
-        );
-        return;
+        const cache = await caches.open(spriteCacheName);
+        const cached = await cache.match(event.request);
+        if (cached) return cached;
+        try {
+            const response = await fetch(event.request);
+            if (response.ok) cache.put(event.request, response.clone());
+            return response;
+        } catch {
+            // Sprite fetch failed offline — return a synthetic empty response so respondWith
+            // resolves cleanly. Callers tolerate a missing sprite image.
+            return new Response('', {status: 504, statusText: 'Sprite fetch failed (offline)'});
+        }
     }
 
     let cachedResponse = null;
@@ -98,5 +103,19 @@ async function onFetch(event) {
         cachedResponse = await cache.match(request);
     }
 
-    return cachedResponse || fetch(event.request);
+    if (cachedResponse) return cachedResponse;
+
+    // Network fallback — catch the rejection so respondWith doesn't surface
+    // `TypeError: Load failed` on iOS Safari when the request fails mid-boot.
+    // For navigations, fall back to cached index.html so the SPA shell still loads offline.
+    try {
+        return await fetch(event.request);
+    } catch {
+        if (event.request.mode === 'navigate') {
+            const cache = await caches.open(cacheName);
+            const shellResponse = await cache.match('index.html');
+            if (shellResponse) return shellResponse;
+        }
+        return new Response('', {status: 504, statusText: 'Network unavailable'});
+    }
 }


### PR DESCRIPTION
## Summary

Fixes two bugs in `Pkmds.Web/wwwroot/service-worker.published.js` that produced `FetchEvent.respondWith received an error: TypeError: Load failed` on iOS Safari — the error surfaced by the new startup-crash auto-reporter (d077eed5) in #915 and #916.

- **Double `respondWith` in the sprite path.** The outer `fetch` listener wraps `onFetch(event)` in `event.respondWith(...)`, and the sprite branch of `onFetch` *also* called `event.respondWith(...)` then returned. Every PokeAPI sprite fetch was calling `respondWith` twice — the second call throws `InvalidStateError`, and the outer call resolved to `undefined` (which iOS Safari logs as `TypeError`). The sprite path now returns its promise like every other branch.
- **Unhandled network rejection.** `return cachedResponse || fetch(event.request)` let `fetch()` rejections bubble out to `respondWith` whenever the live network failed during SW boot (common on iOS Safari and flaky mobile networks). Now wrapped in `try/catch`: navigations fall back to cached `index.html` (offline SPA shell), asset fetches return a synthetic `504`, so `respondWith` always resolves cleanly.

## Why this matters

The startup-crash reporter added in d077eed5 catches `window.error` / `unhandledrejection` events and offers users a one-click "Report this bug" GitHub link. With the SW rejecting on every transient mobile fetch failure, that reporter was about to convert a long tail of recoverable iOS hiccups into a stream of duplicate `[Crash]` issues. #915 and #916 (same iPhone, 15 min apart) were the first two.

## Test plan

- [x] `dotnet format` — no changes
- [x] `dotnet build Pkmds.Web -c Debug` — 0 warnings, 0 errors
- [ ] Manual: load `pkmds.app` on iOS Safari with the new SW, force-quit and reopen offline, confirm shell loads from cache instead of a `TypeError` toast
- [ ] Manual: load a Pokémon with a sprite while offline, confirm no console error spam

Closes #915.

🤖 Generated with [Claude Code](https://claude.com/claude-code)