### PR TITLE
fix(sw): resolve respondWith rejections that surface as TypeError on iOS Safari

### DIFF
--- a/Pkmds.Web/wwwroot/service-worker.published.js
+++ b/Pkmds.Web/wwwroot/service-worker.published.js
@@ -71,18 +71,23 @@ async function onActivate(event) {
 }
 
 async function onFetch(event) {
-    // Cache-first strategy for PokeAPI sprites — separate long-lived cache that survives app updates
+    // Cache-first strategy for PokeAPI sprites — separate long-lived cache that survives app updates.
+    // Return the promise rather than calling event.respondWith() here: the outer 'fetch' listener
+    // already wraps onFetch(event) in respondWith, and double-calling it throws InvalidStateError
+    // (and on iOS Safari surfaces as `FetchEvent.respondWith received an error: TypeError: ...`).
     if (event.request.method === 'GET' && event.request.url.startsWith(spriteOrigin)) {
-        event.respondWith(
-            caches.open(spriteCacheName).then(async cache => {
-                const cached = await cache.match(event.request);
-                if (cached) return cached;
-                const response = await fetch(event.request);
-                if (response.ok) cache.put(event.request, response.clone());
-                return response;
-            })
-        );
-        return;
+        const cache = await caches.open(spriteCacheName);
+        const cached = await cache.match(event.request);
+        if (cached) return cached;
+        try {
+            const response = await fetch(event.request);
+            if (response.ok) cache.put(event.request, response.clone());
+            return response;
+        } catch {
+            // Sprite fetch failed offline — return a synthetic empty response so respondWith
+            // resolves cleanly. Callers tolerate a missing sprite image.
+            return new Response('', {status: 504, statusText: 'Sprite fetch failed (offline)'});
+        }
     }
 
     let cachedResponse = null;
@@ -98,5 +103,19 @@ async function onFetch(event) {
         cachedResponse = await cache.match(request);
     }
 
-    return cachedResponse || fetch(event.request);
+    if (cachedResponse) return cachedResponse;
+
+    // Network fallback — catch the rejection so respondWith doesn't surface
+    // `TypeError: Load failed` on iOS Safari when the request fails mid-boot.
+    // For navigations, fall back to cached index.html so the SPA shell still loads offline.
+    try {
+        return await fetch(event.request);
+    } catch {
+        if (event.request.mode === 'navigate') {
+            const cache = await caches.open(cacheName);
+            const shellResponse = await cache.match('index.html');
+            if (shellResponse) return shellResponse;
+        }
+        return new Response('', {status: 504, statusText: 'Network unavailable'});
+    }
 }


### PR DESCRIPTION
## Summary

Promotes #918 from `dev` to `main` for deploy. Two service-worker fixes that eliminate `FetchEvent.respondWith received an error: TypeError: Load failed` on iOS Safari (the error surfaced by the startup-crash auto-reporter in #915/#916):

- Sprite path no longer double-calls `event.respondWith` — returns its promise like every other branch.
- Network fallback wrapped in `try/catch`: navigations fall back to cached `index.html` (offline SPA shell); asset fetches return a synthetic `504`. `respondWith` always resolves cleanly, so transient mobile network hiccups no longer convert into `[Crash]` reports.

## Test plan

- [x] CI green on #918
- [ ] After deploy: load `pkmds.app` on iOS Safari, force-quit and reopen offline, confirm the SPA shell loads from cache instead of a `TypeError` toast
- [ ] After deploy: watch for any new `[Crash] Startup error: FetchEvent.respondWith...` issues from the auto-reporter — should drop to zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)