### PR TITLE
chore: suppress IL2026 at reflection call sites for upcoming PKHeX tr…

### DIFF
--- a/Pkmds.Rcl/Components/EditForms/Tabs/RibbonsTab.razor.cs
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/RibbonsTab.razor.cs
@@ -139,6 +139,8 @@ public partial class RibbonsTab : IDisposable
     private List<RibbonInfo> GetAllRibbonInfo() =>
         RibbonHelper.GetAllRibbonInfo(Pokemon);
 
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026",
+        Justification = "All PKM types and their members are preserved via PreservePkmTypes.xml.")]
     private void ToggleRibbon(string propertyName)
     {
         if (Pokemon is null)
@@ -151,6 +153,8 @@ public partial class RibbonsTab : IDisposable
         StateHasChanged();
     }
 
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026",
+        Justification = "All PKM types and their members are preserved via PreservePkmTypes.xml.")]
     private void SetRibbonCount(string propertyName, int count)
     {
         if (Pokemon is null)
@@ -190,6 +194,8 @@ public partial class RibbonsTab : IDisposable
         StateHasChanged();
     }
 
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026",
+        Justification = "All PKM types and their members are preserved via PreservePkmTypes.xml.")]
     private void GiveAllRibbons()
     {
         if (Pokemon is null)
@@ -209,6 +215,8 @@ public partial class RibbonsTab : IDisposable
         StateHasChanged();
     }
 
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026",
+        Justification = "All PKM types and their members are preserved via PreservePkmTypes.xml.")]
     private void ClearAllRibbons()
     {
         if (Pokemon is null)

--- a/Pkmds.Rcl/RibbonHelper.cs
+++ b/Pkmds.Rcl/RibbonHelper.cs
@@ -46,6 +46,8 @@ public static class RibbonHelper
     /// Gets all ribbon info entries for the given Pokémon, or an empty list if <paramref name="pokemon" /> is
     /// <see langword="null" />.
     /// </summary>
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026",
+        Justification = "All PKM types and their members are preserved via PreservePkmTypes.xml.")]
     public static List<RibbonInfo> GetAllRibbonInfo(PKM? pokemon) =>
         pokemon is not null
             ? RibbonInfo.GetRibbonInfo(pokemon)

--- a/Pkmds.Rcl/Services/PkmDiffer.cs
+++ b/Pkmds.Rcl/Services/PkmDiffer.cs
@@ -410,6 +410,8 @@ public static class PkmDiffer
         }
     }
 
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026",
+        Justification = "All PKM types and their members are preserved via PreservePkmTypes.xml.")]
     private static void AddRibbonDelta(PKM b, PKM a, List<LegalizationChange> changes)
     {
         // Collapse to a single "added / removed" entry. Listing each ribbon would

--- a/Pkmds.Web/PreservePkmTypes.xml
+++ b/Pkmds.Web/PreservePkmTypes.xml
@@ -2,17 +2,23 @@
 <!--
   Trimmer root descriptor: preserve PKM type hierarchy in PKHeX.Core.
 
-  EntityBatchEditor (consumed by Pkmds.Rcl/Services/BatchEditorService.cs
-  for the Batch Editor tab) extends BatchEditingBase<PKM, BatchInfo> and
-  reflects over the 18 concrete PKM types listed below, caching their
-  PropertyInfo for batch property-name lookups. Under TrimMode=full the
-  trimmer otherwise strips PKM members it doesn't see static references
-  to, causing batch editor property lookups to silently return null.
+  Two reflection paths in PKHeX.Core depend on all PKM members surviving
+  the linker, both annotated [RequiresUnreferencedCode] (PKHeX ≥ 26.5.x):
 
-  PKHeX.Core has no [DynamicDependency] annotations on this reflection
-  path because the BatchEditingBase API surface is annotated
-  [RequiresUnreferencedCode]; the caller (us) is responsible for
-  rooting the reflected-over types.
+  1. EntityBatchEditor (Pkmds.Rcl/Services/BatchEditorService.cs) —
+     extends BatchEditingBase<PKM, BatchInfo> and reflects over the types
+     below, caching their PropertyInfo for batch property-name lookups.
+     Without rooting, the trimmer strips PKM members it doesn't see static
+     references to, causing lookups to silently return null.
+
+  2. RibbonInfo.GetRibbonInfo (Pkmds.Rcl/RibbonHelper.cs and
+     Pkmds.Rcl/Services/PkmDiffer.cs) — walks every property starting with
+     "Ribbon" on the actual PKM subtype via reflection. Call sites carry
+     [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026")] because
+     this rooting makes those reflective lookups safe.
+
+  PKHeX.Core has no [DynamicDependency] annotations on either path;
+  the caller (us) is responsible for rooting the reflected-over types.
 
   Source: EntityBatchEditor.EntityTypes in PKHeX.Core. Keep this list
   in sync if PKHeX adds a new PKM subclass to that array.


### PR DESCRIPTION
…im annotations

PKHeX.Core commit f0a9c33 (≥ 26.5.x) adds [RequiresUnreferencedCode] to RibbonInfo.GetRibbonInfo and several ReflectUtil methods. PreservePkmTypes.xml already roots all PKM types with preserve="all", making these reflection paths safe; the suppressions document that explicitly so the trimmer doesn't warn on publish once the NuGet version including those annotations is consumed.

Also updates the PreservePkmTypes.xml comment to cover both reflection paths (batch editor and ribbon info) that the rooting protects.