### PR TITLE
fix: support WB8 mystery gift import for BDSP saves

### DIFF
--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
@@ -953,14 +953,14 @@ public partial class MainLayout : IDisposable
 
             if (albumImportSuccessful)
             {
-                Logger.LogInformation("Mystery Gift card imported to album successfully");
-                Snackbar.Add("Mystery Gift card added to Wonder Cards album.", Severity.Success);
+                Logger.LogInformation("Mystery Gift imported successfully: {Message}", albumImportMessage);
+                Snackbar.Add(albumImportMessage, Severity.Success);
                 // Notify subscribers (e.g. the Wonder Cards tab) that save state changed.
                 RefreshService.Refresh();
             }
             else
             {
-                Logger.LogWarning("Mystery Gift album import: {Message}", albumImportMessage);
+                Logger.LogWarning("Mystery Gift import failed: {Message}", albumImportMessage);
                 Snackbar.Add(albumImportMessage, Severity.Warning);
             }
 

--- a/Pkmds.Rcl/Services/AppService.cs
+++ b/Pkmds.Rcl/Services/AppService.cs
@@ -628,6 +628,17 @@ public class AppService(IAppState appState, IRefreshService refreshService, ILeg
                 return Task.CompletedTask;
             }
 
+            // SAV8BS (BDSP) does not implement IMysteryGiftStorageProvider — its mystery gift
+            // history lives in MysteryBlock8b (RecvData8b slots + received flags), which is
+            // structurally different from the Gen 4–7 wonder-card album.
+            // WB8 Pokemon gifts are already handled by the entity flow in the caller; here we
+            // handle item gifts (add directly to bag) and other types (populate a RecvData8b
+            // slot so the in-game Pokémon Delivery Man can grant the gift).
+            if (saveFile is SAV8BS sav8bs && gift is WB8 wb8)
+            {
+                return ImportWB8ToBDSP(sav8bs, wb8, out isSuccessful, out resultsMessage);
+            }
+
             var cards = GetMysteryGiftProvider(saveFile);
             var album = LoadMysteryGifts(saveFile, cards);
             var flags = cards as IMysteryGiftFlags;
@@ -793,6 +804,69 @@ public class AppService(IAppState appState, IRefreshService refreshService, ILeg
             if (cards is MysteryBlock5 s5)
             {
                 s5.EndAccess(); // need to encrypt the at-rest data with the seed.
+            }
+        }
+    }
+
+    private static Task ImportWB8ToBDSP(SAV8BS saveFile, WB8 gift, out bool isSuccessful, out string resultsMessage)
+    {
+        switch (gift.CardType)
+        {
+            case WB8.GiftType.Pokemon:
+                // Pokemon gifts are handled by the entity flow in the caller (LoadMysteryGiftFile).
+                // ConvertToPKM produces the Pokémon — nothing extra to store in the save here.
+                isSuccessful = true;
+                resultsMessage = "The Mystery Gift has been successfully received.";
+                return Task.CompletedTask;
+
+            case WB8.GiftType.Item:
+            {
+                var items = saveFile.Items;
+                var addedAny = false;
+                for (var i = 0; i < 7; i++)
+                {
+                    var itemId = (ushort)gift.GetItem(i);
+                    var quantity = gift.GetQuantity(i);
+                    if (itemId == 0)
+                        break;
+                    items.SetItemQuantity(itemId, items.GetItemQuantity(itemId) + quantity);
+                    addedAny = true;
+                }
+                isSuccessful = addedAny;
+                resultsMessage = addedAny
+                    ? "The Mystery Gift items have been added to your bag."
+                    : "No items found in this Mystery Gift.";
+                return Task.CompletedTask;
+            }
+
+            default:
+            {
+                // For Clothing, Money, BP, etc.: populate a RecvData8b slot in MysteryBlock8b.
+                // The in-game Pokémon Delivery Man reads these slots to grant gifts.
+                var records = saveFile.MysteryRecords;
+                var emptySlot = -1;
+                for (var i = 0; i < MysteryBlock8b.RecvDataMax; i++)
+                {
+                    if (records.GetReceived(i).Ticks == 0)
+                    {
+                        emptySlot = i;
+                        break;
+                    }
+                }
+                if (emptySlot == -1)
+                {
+                    isSuccessful = false;
+                    resultsMessage = "No empty Mystery Gift slots available in the save file.";
+                    return Task.CompletedTask;
+                }
+                var slot = records.GetReceived(emptySlot);
+                slot.Timestamp = DateTime.UtcNow;
+                slot.DeliveryID = (ushort)gift.CardID;
+                slot.DataType = (byte)gift.CardType;
+                slot.TextID = (ushort)gift.CardTitleIndex;
+                isSuccessful = true;
+                resultsMessage = "The Mystery Gift has been queued. Visit the Pokémon Delivery Man to claim it.";
+                return Task.CompletedTask;
             }
         }
     }


### PR DESCRIPTION
## Summary

- `SAV8BS` (Brilliant Diamond/Shining Pearl) does not implement `IMysteryGiftStorageProvider`, causing all non-Pokémon WB8 gift imports to throw "does not support Mystery Gifts" with no fallback
- Added `ImportWB8ToBDSP` to handle the three WB8 gift types: item gifts are added directly to the player's bag, Pokémon gifts signal success so the existing entity flow places the PKM, and clothing/other gifts populate a `RecvData8b` slot in `MysteryBlock8b` for the in-game Pokémon Delivery Man
- Fixed the file-drop success snackbar to use the returned `resultsMessage` instead of the hardcoded "Wonder Cards album" string

Fixes #920.

## Test plan

- [ ] Load a BDSP save (Brilliant Diamond or Shining Pearl, any revision)
- [ ] Drop an Oak's Letter `.wb8` file — item 452 should appear in the bag
- [ ] Drop a Membership Pass `.wb8` file — item 454 should appear in the bag
- [ ] Drop a Platinum outfit `.wb8` file — success toast should appear; visit the Pokémon Delivery Man in-game to claim
- [ ] Drop a Manaphy Egg `.wb8` file — Manaphy should be placed in a box slot as before
- [ ] Confirm non-BDSP saves (e.g. Gen 4, Sword/Shield, Scarlet/Violet) still import mystery gifts normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)