### PR TITLE
fix: prevent TradePane crash when box selection is out of range for current save

### DIFF
--- a/Pkmds.Rcl/Components/MainTabPages/TradePane.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TradePane.razor
@@ -33,7 +33,9 @@
         @* Box selector — Let's Go saves only have a single 1000-slot storage; gate behind BoxCount > 0 *@
         @if (saveFile.BoxCount > 0)
         {
-            var currentBox = SelectedBox ?? saveFile.CurrentBox;
+            // Clamp to [0, BoxCount-1] so a stale SelectedBox from a previous save
+            // with more boxes (or a corrupted CurrentBox byte) cannot crash GetBoxSlotAtIndex.
+            var currentBox = Math.Clamp(SelectedBox ?? saveFile.CurrentBox, 0, saveFile.BoxCount - 1);
             <div class="flex items-center gap-1">
                 <MudIconButton OnClick="@(() => SelectBox((currentBox - 1 + saveFile.BoxCount) % saveFile.BoxCount))"
                                title="Previous Box"

--- a/Pkmds.Web/AppState.cs
+++ b/Pkmds.Web/AppState.cs
@@ -43,6 +43,12 @@ public record AppState : IAppState
                 ManicEmuSaveContext = null;
             }
 
+            // Clear slot-A selections so a stale SelectedBoxNumber from a previous
+            // save with more boxes cannot cause ArgumentOutOfRangeException in TradePane
+            // when the new save has fewer boxes.
+            SelectedBoxNumber = null;
+            SelectedBoxSlotNumber = null;
+            SelectedPartySlotNumber = null;
             PinnedBoxNumber = null;
         }
     }


### PR DESCRIPTION
## Summary

- `AppState.SelectedBoxNumber` was never reset when a new primary save loaded, so a stale box index from a previous save with more boxes (e.g. USUM box 31) could crash `GetBoxSlotAtIndex` in TradePane when the new save has fewer boxes (e.g. XY valid range 0–30)
- Added `Math.Clamp` on `currentBox` in `TradePane.razor` as belt-and-suspenders against both the stale-state scenario and a corrupted `saveFile.CurrentBox` byte

## Test plan

- [ ] Load a USUM save as primary, navigate to box 31 in the Trade tab, then load an XY save — Trade tab should render without crashing
- [ ] Load any save and open the Trade tab — box rendering works normally
- [ ] Load a second save in Trade slot B — Slot B pane renders correctly

Fixes #925.

🤖 Generated with [Claude Code](https://claude.com/claude-code)