### PR TITLE
ci: fix CodeQL code scanning (C# extraction, ECB suppression, JS fixes, +Actions/Python, workflow perms)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,16 @@
+name: "PKMDS CodeQL config"
+
+# Uses the default query suite for each analyzed language (no override),
+# with the filter below applied on top.
+query-filters:
+  # AES-ECB is mandated by the Pokémon save-file / entity format that
+  # PKHeX.Core reads and writes. The games themselves encrypt save blocks
+  # and Pokémon data with AES in ECB mode, so this is a wire-format
+  # requirement, not a security design choice — switching to CBC (or any
+  # other mode) would make the app unable to read or write real save files.
+  # The only ECB usage in this repository is the PKHeX crypto bridge in
+  # Pkmds.Web/Services/BlazorAesProvider.cs (mirrored by the crypto-js bridge
+  # in Pkmds.Rcl/wwwroot/js/crypto.js), so excluding this rule does not hide
+  # any genuinely avoidable insecure encryption.
+  - exclude:
+      id: cs/ecb-encryption

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -16,6 +16,10 @@ on:
     branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]  # Also run when PR is marked ready for review
 
+# Least-privilege GITHUB_TOKEN: this workflow only checks out and builds/tests.
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build and Test

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,14 +51,18 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
+        config-file: ./.github/codeql/codeql-config.yml
 
     - name: Dotnet Restore
       if: matrix.build-mode == 'manual' && matrix.language == 'csharp'
       run: dotnet restore Pkmds.Web/Pkmds.Web.csproj
 
+    # Build in Release: Debug builds set TreatWarningsAsErrors (see
+    # Directory.Build.props), so a single warning would fail the build and
+    # leave CodeQL's manual build-mode extractor with no C# to analyze.
     - name: Dotnet Build
       if: matrix.build-mode == 'manual' && matrix.language == 'csharp'
-      run: dotnet build Pkmds.Web/Pkmds.Web.csproj
+      run: dotnet build Pkmds.Web/Pkmds.Web.csproj -c Release
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,17 +32,24 @@ jobs:
           build-mode: manual
         - language: javascript-typescript
           build-mode: none
+        - language: actions
+          build-mode: none
+        - language: python
+          build-mode: none
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6.0.2
 
-      # sets up .NET SDK
+      # .NET SDK + WASM workload are only needed for the csharp manual build;
+      # the buildless analyses (js, actions, python) skip them.
     - name: Setup .NET Core SDK
+      if: matrix.language == 'csharp'
       uses: actions/setup-dotnet@v5.2.0
       with:
         global-json-file: ./global.json
 
     - name: Install WASM workload
+      if: matrix.language == 'csharp'
       run: dotnet workload install wasm-tools
 
     # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,6 +95,9 @@ jobs:
   deploy_functions:
     name: Deploy Azure Functions
     runs-on: ubuntu-latest
+    # Least-privilege: deploys via the AZURE_CREDENTIALS secret, not GITHUB_TOKEN.
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/uat.yml
+++ b/.github/workflows/uat.yml
@@ -23,6 +23,11 @@ jobs:
   build_and_deploy:
     name: Build and Deploy UAT
     runs-on: ubuntu-latest
+    # contents: read for checkout; pull-requests: write so the Static Web Apps
+    # action can post/update the preview-URL comment on the PR via GITHUB_TOKEN.
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v6.0.2
@@ -63,6 +68,9 @@ jobs:
   deploy_functions:
     name: Deploy Azure Functions
     runs-on: ubuntu-latest
+    # Least-privilege: deploys via the AZURE_CREDENTIALS secret, not GITHUB_TOKEN.
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6.0.2

--- a/tools/bench/run-bench.mjs
+++ b/tools/bench/run-bench.mjs
@@ -79,8 +79,12 @@ const server = createServer(async (req, res) => {
         res.writeHead(200, { 'content-type': mime, 'cache-control': 'no-store' });
         res.end(data);
     } catch (err) {
+        // Log full detail (incl. stack) to the console, but return a generic
+        // message to the client so a stack trace isn't exposed in the HTTP
+        // response (CodeQL js/stack-trace-exposure).
+        console.error(err);
         res.writeHead(500, { 'content-type': 'text/plain' });
-        res.end(String(err));
+        res.end('Internal server error');
     }
 });
 

--- a/tools/bench/serve.mjs
+++ b/tools/bench/serve.mjs
@@ -62,8 +62,12 @@ const server = createServer(async (req, res) => {
         res.writeHead(200, { 'content-type': mime, 'cache-control': 'no-store' });
         res.end(data);
     } catch (err) {
+        // Log full detail (incl. stack) to the console, but return a generic
+        // message to the client so a stack trace isn't exposed in the HTTP
+        // response (CodeQL js/stack-trace-exposure).
+        console.error(err);
         res.writeHead(500, { 'content-type': 'text/plain' });
-        res.end(String(err));
+        res.end('Internal server error');
     }
 });
 

--- a/tools/embedded-host-poc/mock-host.js
+++ b/tools/embedded-host-poc/mock-host.js
@@ -22,7 +22,6 @@ if (pkmdsParam) {
         // Ignore an unparseable override and keep the default origin.
     }
 }
-document.getElementById('pkmds-frame').src = pkmdsOrigin + '/?host=poc';
 
 // ── DOM references ─────────────────────────────────────────────────────────
 
@@ -34,6 +33,9 @@ var fileInput = document.getElementById('file-input');
 var statusEl  = document.getElementById('status');
 var logEl     = document.getElementById('log-entries');
 var logClear  = document.getElementById('log-clear');
+
+// Point the embedded PKMDS frame at the (validated) origin computed above.
+frame.src = pkmdsOrigin + '/?host=poc';
 
 // ── State ──────────────────────────────────────────────────────────────────
 

--- a/tools/embedded-host-poc/mock-host.js
+++ b/tools/embedded-host-poc/mock-host.js
@@ -7,8 +7,21 @@
 // perfectly. When opened directly as a local file (file://), default to the
 // standard dev-server address. Override either case with ?pkmds=<url>.
 var pkmdsParam = new URLSearchParams(location.search).get('pkmds');
-var pkmdsOrigin = pkmdsParam ||
-    (location.protocol !== 'file:' ? location.origin : 'http://localhost:5283');
+var pkmdsOrigin = location.protocol !== 'file:' ? location.origin : 'http://localhost:5283';
+if (pkmdsParam) {
+    // Validate the override before it reaches the iframe src: only accept an
+    // http(s) URL and use just its origin, so a crafted value like
+    // ?pkmds=javascript:… can't be injected (CodeQL js/xss,
+    // js/client-side-unvalidated-url-redirection).
+    try {
+        var overrideUrl = new URL(pkmdsParam, location.href);
+        if (overrideUrl.protocol === 'http:' || overrideUrl.protocol === 'https:') {
+            pkmdsOrigin = overrideUrl.origin;
+        }
+    } catch (e) {
+        // Ignore an unparseable override and keep the default origin.
+    }
+}
 document.getElementById('pkmds-frame').src = pkmdsOrigin + '/?host=poc';
 
 // ── DOM references ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Code scanning had stalled: CodeQL hadn't produced a fresh analysis since **2024-11-22**, the advanced workflow was **disabled** (0 runs ever), and the dashboard showed *"CodeQL is reporting errors"* plus 2 open ECB alerts. This restores a healthy, comprehensive CodeQL setup.

### Root cause of the broken C# analysis
The workflow built `Pkmds.Web` with a bare `dotnet build`, which defaults to **Debug**. Debug sets `TreatWarningsAsErrors` (see `Directory.Build.props`), so any warning failed the build — and with `build-mode: manual`, a failed build leaves the C# extractor with nothing to analyze. Now builds **Release** (matching the other CI workflows).

### Changes
- **`.github/codeql/codeql-config.yml`** (new): excludes `cs/ecb-encryption`. AES-ECB is mandated by the Pokémon save-file/entity format that PKHeX.Core reads and writes — a wire-format requirement, not a fixable vulnerability, and the only ECB usage in the repo. The 2 existing ECB alerts are also dismissed.
- **`codeql.yml`**: build Release + wire in the config; add **`actions`** and **`python`** buildless analyses to the matrix; gate the .NET SDK/WASM steps to the `csharp` job.
- **`tools/embedded-host-poc/mock-host.js`**: validate the `?pkmds=` override (require http/https, use only the parsed origin) before assigning the iframe `src` — closes `js/xss` + `js/client-side-unvalidated-url-redirection`.
- **`tools/bench/serve.mjs`, `run-bench.mjs`**: log errors to console + return a generic 500 body instead of `String(err)` — closes `js/stack-trace-exposure`.
- **`buildandtest.yml`, `main.yml`, `uat.yml`**: explicit least-privilege `permissions:` blocks — closes `actions/missing-workflow-permissions`.

### Validation
Dispatched the workflow on this branch repeatedly while iterating. Final state: all jobs **green**, every language analysis **0 results, no extractor errors** (csharp, javascript-typescript, actions, python).

### Not covered (deliberate)
- **Swift** (`tools/*-poc` Xcode) and **C/C++** (`tools/windows-preview-poc` shim) — need macOS/MSVC builds and cover local-only POC tooling; left unscanned.
- **HTML/CSS/Razor markup/PowerShell** — no CodeQL analyzer exists for these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)