### PR TITLE
feat(ios-ql): add iOS QLThumbnailProvider extension

### DIFF
--- a/tools/ios-quicklook-poc/PkmdsQuickLook/Info.plist
+++ b/tools/ios-quicklook-poc/PkmdsQuickLook/Info.plist
@@ -20,6 +20,7 @@
             <array>
                 <string>com.bondcodes.pkmds.pkm-file</string>
                 <string>com.bondcodes.pkmds.save-file</string>
+                <string>com.bondcodes.pkmds.save-file-restricted</string>
                 <string>com.bondcodes.pkmds.wonder-card</string>
             </array>
             <key>QLSupportsSearchableItems</key>

--- a/tools/ios-quicklook-poc/PkmdsQuickLookThumbnail/Info.plist
+++ b/tools/ios-quicklook-poc/PkmdsQuickLookThumbnail/Info.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleDisplayName</key>
+    <string>PKMDS Thumbnails</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundlePackageType</key>
+    <string>XPC!</string>
+    <key>MinimumOSVersion</key>
+    <string>16.0</string>
+    <key>NSExtension</key>
+    <dict>
+        <key>NSExtensionAttributes</key>
+        <dict>
+            <key>QLSupportedContentTypes</key>
+            <array>
+                <string>com.bondcodes.pkmds.pkm-file</string>
+                <string>com.bondcodes.pkmds.save-file</string>
+                <string>com.bondcodes.pkmds.wonder-card</string>
+            </array>
+            <key>QLSupportsSearchableItems</key>
+            <false/>
+        </dict>
+        <key>NSExtensionPointIdentifier</key>
+        <string>com.apple.quicklook.thumbnail</string>
+        <key>NSExtensionPrincipalClass</key>
+        <string>ThumbnailProvider</string>
+    </dict>
+</dict>
+</plist>

--- a/tools/ios-quicklook-poc/PkmdsQuickLookThumbnail/Info.plist
+++ b/tools/ios-quicklook-poc/PkmdsQuickLookThumbnail/Info.plist
@@ -20,7 +20,6 @@
             <array>
                 <string>com.bondcodes.pkmds.pkm-file</string>
                 <string>com.bondcodes.pkmds.save-file</string>
-                <string>com.bondcodes.pkmds.save-file-restricted</string>
                 <string>com.bondcodes.pkmds.wonder-card</string>
             </array>
             <key>QLSupportsSearchableItems</key>

--- a/tools/ios-quicklook-poc/PkmdsQuickLookThumbnail/Info.plist
+++ b/tools/ios-quicklook-poc/PkmdsQuickLookThumbnail/Info.plist
@@ -20,6 +20,7 @@
             <array>
                 <string>com.bondcodes.pkmds.pkm-file</string>
                 <string>com.bondcodes.pkmds.save-file</string>
+                <string>com.bondcodes.pkmds.save-file-restricted</string>
                 <string>com.bondcodes.pkmds.wonder-card</string>
             </array>
             <key>QLSupportsSearchableItems</key>

--- a/tools/ios-quicklook-poc/PkmdsQuickLookThumbnail/PkmdsQuickLookThumbnail.csproj
+++ b/tools/ios-quicklook-poc/PkmdsQuickLookThumbnail/PkmdsQuickLookThumbnail.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Library</OutputType>
+        <IsAppExtension>true</IsAppExtension>
+        <TargetFramework>net10.0-ios</TargetFramework>
+        <SupportedOSPlatformVersion>16.0</SupportedOSPlatformVersion>
+        <RootNamespace>Pkmds.QuickLookThumbnail</RootNamespace>
+        <AssemblyName>PkmdsQuickLookThumbnail</AssemblyName>
+        <ApplicationId>com.bondcodes.pkmds.host.ios.quicklook.thumbnail</ApplicationId>
+        <ApplicationTitle>PKMDS Thumbnails</ApplicationTitle>
+        <ApplicationDisplayVersion>0.0.1</ApplicationDisplayVersion>
+        <ApplicationVersion>1</ApplicationVersion>
+        <PublishAot>true</PublishAot>
+        <InvariantGlobalization>true</InvariantGlobalization>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+        <IsPackable>false</IsPackable>
+        <ValidateXcodeVersion>false</ValidateXcodeVersion>
+        <EnableCodeSigning>false</EnableCodeSigning>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\preview-shared\Pkmds.Preview.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/tools/ios-quicklook-poc/PkmdsQuickLookThumbnail/SaveCard.cs
+++ b/tools/ios-quicklook-poc/PkmdsQuickLookThumbnail/SaveCard.cs
@@ -1,0 +1,217 @@
+using CoreGraphics;
+using CoreText;
+using Foundation;
+using PKHeX.Core;
+using UIKit;
+
+namespace Pkmds.QuickLookThumbnail;
+
+internal static class SaveCard
+{
+    internal sealed record Info(string Version, string Ot, int Tid, int Sid, int Hours, int Minutes);
+
+    internal static Info? TryParseSave(byte[] data)
+    {
+        if (!SaveUtil.TryGetSaveFile(data, out var sav))
+            return null;
+        return new Info(
+            Version: sav.Version.ToString(),
+            Ot:      sav.OT ?? string.Empty,
+            Tid:     sav.TID16,
+            Sid:     sav.SID16,
+            Hours:   sav.PlayedHours,
+            Minutes: sav.PlayedMinutes);
+    }
+
+    // Draws a trainer card into the QL CGContext.
+    // iOS QL context origin: top-left, y-down — same as UIKit's drawing coordinate system
+    // when entered via UIGraphics.PushContext. All y offsets are measured from the top.
+    internal static void Draw(CGContext ctx, CGSize size, Info info)
+    {
+        var margin   = (nfloat)(size.Width * 0.05);
+        var cardRect = new CGRect(margin, margin,
+                                  size.Width  - 2 * margin,
+                                  size.Height - 2 * margin);
+        var radius      = (nfloat)(size.Width * 0.10);
+        var borderWidth = (nfloat)Math.Max(2.0, size.Width * 0.014);
+
+        var (accent, accent2) = AccentColors(info.Version);
+
+        // Card background — use CGContext directly since UIBezierPath fills go through
+        // UIGraphics.GetCurrentContext(), which is set by PushContext.
+        var cardPath = UIBezierPath.FromRoundedRect(cardRect, radius);
+        UIColor.White.SetFill();
+        cardPath.Fill();
+        cardPath.LineWidth = borderWidth;
+        accent.SetStroke();
+        cardPath.Stroke();
+
+        // Version code — large, at the top of the card (y = margin + 5% padding).
+        var codeH    = (nfloat)(size.Height * 0.34);
+        var codeY    = margin + (nfloat)(size.Height * 0.05);
+        var codeRect = new CGRect(cardRect.X, codeY, cardRect.Width, codeH);
+        if (accent2 is { } a2)
+            DrawFittedGradientText(info.Version, codeRect, (nfloat)(size.Height * 0.40), bold: true, a1: accent, a2: a2);
+        else
+            DrawFittedText(info.Version, codeRect, (nfloat)(size.Height * 0.40), bold: true, color: accent);
+
+        // OT name
+        var otH    = (nfloat)(size.Height * 0.15);
+        var otY    = margin + (nfloat)(size.Height * 0.43);
+        var otPad  = (nfloat)(cardRect.Width * 0.05);
+        DrawFittedText(info.Ot.Length > 0 ? info.Ot : "Trainer",
+                       new CGRect(cardRect.X + otPad, otY, cardRect.Width - 2 * otPad, otH),
+                       (nfloat)(size.Height * 0.135), bold: true,
+                       color: UIColor.FromRGB(33, 33, 33));
+
+        // TID/SID
+        var idsH = (nfloat)(size.Height * 0.12);
+        var idsY = margin + (nfloat)(size.Height * 0.60);
+        DrawFittedText($"{info.Tid}/{info.Sid}",
+                       new CGRect(cardRect.X, idsY, cardRect.Width, idsH),
+                       (nfloat)(size.Height * 0.10), bold: false,
+                       color: UIColor.FromRGB(102, 102, 102));
+
+        // Playtime
+        var playH = (nfloat)(size.Height * 0.12);
+        var playY = margin + (nfloat)(size.Height * 0.73);
+        DrawFittedText(string.Format("{0}:{1:00}", info.Hours, info.Minutes),
+                       new CGRect(cardRect.X, playY, cardRect.Width, playH),
+                       (nfloat)(size.Height * 0.10), bold: false,
+                       color: UIColor.FromRGB(102, 102, 102));
+    }
+
+    // Shrinks the font until text fits inside rect, then draws it horizontally centred.
+    private static void DrawFittedText(string text, CGRect rect, nfloat maxEm, bool bold, UIColor color)
+    {
+        var style = new NSMutableParagraphStyle { Alignment = UITextAlignment.Center };
+        var em = maxEm;
+        while (em > 6)
+        {
+            var attrs = MakeAttrs(em, bold, color, style);
+            var sz    = MeasureText(text, rect.Width, attrs);
+            if (sz.Width <= rect.Width && sz.Height <= rect.Height)
+            {
+                DrawText(text, VertCentred(sz, rect), attrs);
+                return;
+            }
+            em -= 1;
+        }
+        var fallbackAttrs = MakeAttrs(6, bold, color, style);
+        var fallbackSz    = MeasureText(text, rect.Width, fallbackAttrs);
+        DrawText(text, VertCentred(fallbackSz, rect), fallbackAttrs);
+    }
+
+    // Per-character gradient text for the ambiguous RB / GS groups.
+    private static void DrawFittedGradientText(string text, CGRect rect, nfloat maxEm,
+                                               bool bold, UIColor a1, UIColor a2)
+    {
+        if (text.Length == 0) return;
+        var chars = text.ToCharArray();
+        var em    = maxEm;
+        while (em > 6)
+        {
+            var attrs = MakeAttrs(em, bold, a1, style: null);
+            var sz    = MeasureText(text, rect.Width, attrs);
+            if (sz.Width <= rect.Width && sz.Height <= rect.Height) break;
+            em -= 1;
+        }
+
+        var baseAttrs = MakeAttrs(em, bold, a1, style: null);
+        var totalW    = MeasureText(text, rect.Width, baseAttrs).Width;
+        var curX      = (nfloat)(rect.MidX - totalW / 2);
+
+        for (var i = 0; i < chars.Length; i++)
+        {
+            var t     = chars.Length > 1 ? (nfloat)i / (chars.Length - 1) : (nfloat)0;
+            var color = Interpolate(a1, a2, t);
+            var attrs = MakeAttrs(em, bold, color, style: null);
+            var ch    = chars[i].ToString();
+            var sz    = MeasureText(ch, rect.Width, attrs);
+            DrawText(ch, new CGRect(curX, rect.MidY - sz.Height / 2, sz.Width, sz.Height), attrs);
+            curX += sz.Width;
+        }
+    }
+
+    private static NSDictionary MakeAttrs(nfloat em, bool bold, UIColor color, NSParagraphStyle? style)
+    {
+        var font = bold ? UIFont.BoldSystemFontOfSize(em) : UIFont.SystemFontOfSize(em);
+        var keys   = new NSObject[] { UIStringAttributeKey.Font, UIStringAttributeKey.ForegroundColor };
+        var values = new NSObject[] { font, color };
+        if (style is not null)
+        {
+            keys   = [.. keys,   UIStringAttributeKey.ParagraphStyle];
+            values = [.. values, style];
+        }
+        return NSDictionary.FromObjectsAndKeys(values, keys);
+    }
+
+    private static CGSize MeasureText(string text, nfloat maxWidth, NSDictionary attrs)
+    {
+        var ns  = new NSString(text);
+        var opt = NSStringDrawingOptions.UsesLineFragmentOrigin;
+        return ns.GetBoundingRect(new CGSize(maxWidth, nfloat.MaxValue), opt, attrs, null).Size;
+    }
+
+    private static void DrawText(string text, CGRect rect, NSDictionary attrs)
+    {
+        var ns = new NSString(text);
+        ns.DrawString(rect, attrs);
+    }
+
+    private static CGRect VertCentred(CGSize sz, CGRect rect) =>
+        new(rect.X, rect.MidY - sz.Height / 2, rect.Width, sz.Height);
+
+    // ── Accent colours — mirrors macOS ThumbnailProvider.swift accentColors ──────────────────────
+
+    private static (UIColor accent, UIColor? accent2) AccentColors(string version) => version switch
+    {
+        "RB" => (Hex(0xC0392B), Hex(0x2980B9)),
+        "GS" => (Hex(0xD4860B), Hex(0x7F8C9A)),
+        _    => (AccentColor(version), null),
+    };
+
+    private static UIColor AccentColor(string version) => version switch
+    {
+        "RD" or "R" or "FR" or "OR"    => Hex(0xC0392B),
+        "SL"                            => Hex(0xD0432A),
+        "GN" or "LG"                   => Hex(0x27AE60),
+        "E"                             => Hex(0x1E9E6A),
+        "BU" or "S" or "AS" or "X"    => Hex(0x2980B9),
+        "D" or "BD"                    => Hex(0x4A78B0),
+        "P" or "SP"                    => Hex(0xC56AA0),
+        "Pt"                            => Hex(0x7A6FA0),
+        "YW" or "GP"                   => Hex(0xC79100),
+        "GE"                            => Hex(0x8B5A2B),
+        "GD" or "HG"                   => Hex(0xD4860B),
+        "SI" or "SS"                   => Hex(0x7F8C9A),
+        "C"                             => Hex(0x16A0A0),
+        "B" or "B2"                    => Hex(0x333333),
+        "W" or "W2"                    => Hex(0x8A8A8A),
+        "SN" or "US"                   => Hex(0xE07B2A),
+        "MN" or "UM"                   => Hex(0x5B4B8A),
+        "SW"                            => Hex(0x1F9BC2),
+        "SH"                            => Hex(0xC0306A),
+        "PLA"                           => Hex(0x2FA37A),
+        "VL"                            => Hex(0x7A3FA0),
+        "Y"                             => Hex(0xC0392B),
+        _                               => Hex(0x3B6EA5),
+    };
+
+    private static UIColor Hex(int rgb) =>
+        UIColor.FromRGB(
+            (byte)((rgb >> 16) & 0xFF),
+            (byte)((rgb >>  8) & 0xFF),
+            (byte)( rgb        & 0xFF));
+
+    private static UIColor Interpolate(UIColor a, UIColor b, nfloat t)
+    {
+        a.GetRGBA(out var ar, out var ag, out var ab, out _);
+        b.GetRGBA(out var br, out var bg, out var bb, out _);
+        return UIColor.FromRGBA(
+            (nfloat)(ar + (br - ar) * t),
+            (nfloat)(ag + (bg - ag) * t),
+            (nfloat)(ab + (bb - ab) * t),
+            1);
+    }
+}

--- a/tools/ios-quicklook-poc/PkmdsQuickLookThumbnail/SaveCard.cs
+++ b/tools/ios-quicklook-poc/PkmdsQuickLookThumbnail/SaveCard.cs
@@ -1,5 +1,4 @@
 using CoreGraphics;
-using CoreText;
 using Foundation;
 using PKHeX.Core;
 using UIKit;
@@ -24,8 +23,8 @@ internal static class SaveCard
     }
 
     // Draws a trainer card into the QL CGContext.
-    // iOS QL context origin: top-left, y-down — same as UIKit's drawing coordinate system
-    // when entered via UIGraphics.PushContext. All y offsets are measured from the top.
+    // iOS QL context origin: top-left, y-down — same as UIKit drawing when entered via
+    // UIGraphics.PushContext. All y offsets are measured from the top.
     internal static void Draw(CGContext ctx, CGSize size, Info info)
     {
         var margin   = (nfloat)(size.Width * 0.05);
@@ -37,8 +36,6 @@ internal static class SaveCard
 
         var (accent, accent2) = AccentColors(info.Version);
 
-        // Card background — use CGContext directly since UIBezierPath fills go through
-        // UIGraphics.GetCurrentContext(), which is set by PushContext.
         var cardPath = UIBezierPath.FromRoundedRect(cardRect, radius);
         UIColor.White.SetFill();
         cardPath.Fill();
@@ -56,9 +53,9 @@ internal static class SaveCard
             DrawFittedText(info.Version, codeRect, (nfloat)(size.Height * 0.40), bold: true, color: accent);
 
         // OT name
-        var otH    = (nfloat)(size.Height * 0.15);
-        var otY    = margin + (nfloat)(size.Height * 0.43);
-        var otPad  = (nfloat)(cardRect.Width * 0.05);
+        var otH   = (nfloat)(size.Height * 0.15);
+        var otY   = margin + (nfloat)(size.Height * 0.43);
+        var otPad = (nfloat)(cardRect.Width * 0.05);
         DrawFittedText(info.Ot.Length > 0 ? info.Ot : "Trainer",
                        new CGRect(cardRect.X + otPad, otY, cardRect.Width - 2 * otPad, otH),
                        (nfloat)(size.Height * 0.135), bold: true,
@@ -84,22 +81,20 @@ internal static class SaveCard
     // Shrinks the font until text fits inside rect, then draws it horizontally centred.
     private static void DrawFittedText(string text, CGRect rect, nfloat maxEm, bool bold, UIColor color)
     {
-        var style = new NSMutableParagraphStyle { Alignment = UITextAlignment.Center };
         var em = maxEm;
         while (em > 6)
         {
-            var attrs = MakeAttrs(em, bold, color, style);
-            var sz    = MeasureText(text, rect.Width, attrs);
+            var attrStr = MakeAttrStr(text, em, bold, color, centerAligned: true);
+            var sz      = Measure(attrStr, rect.Width);
             if (sz.Width <= rect.Width && sz.Height <= rect.Height)
             {
-                DrawText(text, VertCentred(sz, rect), attrs);
+                attrStr.DrawString(VertCentred(sz, rect));
                 return;
             }
             em -= 1;
         }
-        var fallbackAttrs = MakeAttrs(6, bold, color, style);
-        var fallbackSz    = MeasureText(text, rect.Width, fallbackAttrs);
-        DrawText(text, VertCentred(fallbackSz, rect), fallbackAttrs);
+        var fallback = MakeAttrStr(text, 6, bold, color, centerAligned: true);
+        fallback.DrawString(VertCentred(Measure(fallback, rect.Width), rect));
     }
 
     // Per-character gradient text for the ambiguous RB / GS groups.
@@ -111,56 +106,47 @@ internal static class SaveCard
         var em    = maxEm;
         while (em > 6)
         {
-            var attrs = MakeAttrs(em, bold, a1, style: null);
-            var sz    = MeasureText(text, rect.Width, attrs);
+            var sz = Measure(MakeAttrStr(text, em, bold, a1, centerAligned: false), rect.Width);
             if (sz.Width <= rect.Width && sz.Height <= rect.Height) break;
             em -= 1;
         }
 
-        var baseAttrs = MakeAttrs(em, bold, a1, style: null);
-        var totalW    = MeasureText(text, rect.Width, baseAttrs).Width;
-        var curX      = (nfloat)(rect.MidX - totalW / 2);
+        var totalW = Measure(MakeAttrStr(text, em, bold, a1, centerAligned: false), rect.Width).Width;
+        // rect.X + rect.Width / 2 = horizontal centre of rect (MidX)
+        var curX = rect.X + rect.Width / 2 - totalW / 2;
+        // rect.Y + rect.Height / 2 = vertical centre (MidY)
+        var midY = rect.Y + rect.Height / 2;
 
         for (var i = 0; i < chars.Length; i++)
         {
             var t     = chars.Length > 1 ? (nfloat)i / (chars.Length - 1) : (nfloat)0;
             var color = Interpolate(a1, a2, t);
-            var attrs = MakeAttrs(em, bold, color, style: null);
-            var ch    = chars[i].ToString();
-            var sz    = MeasureText(ch, rect.Width, attrs);
-            DrawText(ch, new CGRect(curX, rect.MidY - sz.Height / 2, sz.Width, sz.Height), attrs);
+            var attrStr = MakeAttrStr(chars[i].ToString(), em, bold, color, centerAligned: false);
+            var sz      = Measure(attrStr, rect.Width);
+            attrStr.DrawString(new CGRect(curX, midY - sz.Height / 2, sz.Width, sz.Height));
             curX += sz.Width;
         }
     }
 
-    private static NSDictionary MakeAttrs(nfloat em, bool bold, UIColor color, NSParagraphStyle? style)
+    private static NSAttributedString MakeAttrStr(string text, nfloat em, bool bold,
+                                                   UIColor color, bool centerAligned)
     {
-        var font = bold ? UIFont.BoldSystemFontOfSize(em) : UIFont.SystemFontOfSize(em);
-        var keys   = new NSObject[] { UIStringAttributeKey.Font, UIStringAttributeKey.ForegroundColor };
-        var values = new NSObject[] { font, color };
-        if (style is not null)
-        {
-            keys   = [.. keys,   UIStringAttributeKey.ParagraphStyle];
-            values = [.. values, style];
-        }
-        return NSDictionary.FromObjectsAndKeys(values, keys);
+        var font  = bold ? UIFont.BoldSystemFontOfSize(em) : UIFont.SystemFontOfSize(em);
+        var attrs = new UIStringAttributes { Font = font, ForegroundColor = color };
+        if (centerAligned)
+            attrs.ParagraphStyle = new NSMutableParagraphStyle { Alignment = UITextAlignment.Center };
+        return new NSAttributedString(text, attrs.Dictionary);
     }
 
-    private static CGSize MeasureText(string text, nfloat maxWidth, NSDictionary attrs)
-    {
-        var ns  = new NSString(text);
-        var opt = NSStringDrawingOptions.UsesLineFragmentOrigin;
-        return ns.GetBoundingRect(new CGSize(maxWidth, nfloat.MaxValue), opt, attrs, null).Size;
-    }
+    private static CGSize Measure(NSAttributedString attrStr, nfloat maxWidth) =>
+        attrStr.GetBoundingRect(
+            new CGSize(maxWidth, nfloat.MaxValue),
+            NSStringDrawingOptions.UsesLineFragmentOrigin,
+            null).Size;
 
-    private static void DrawText(string text, CGRect rect, NSDictionary attrs)
-    {
-        var ns = new NSString(text);
-        ns.DrawString(rect, attrs);
-    }
-
+    // rect.Y + rect.Height / 2 - sz.Height / 2 = vertically centred inside rect (MidY - half height)
     private static CGRect VertCentred(CGSize sz, CGRect rect) =>
-        new(rect.X, rect.MidY - sz.Height / 2, rect.Width, sz.Height);
+        new(rect.X, rect.Y + rect.Height / 2 - sz.Height / 2, rect.Width, sz.Height);
 
     // ── Accent colours — mirrors macOS ThumbnailProvider.swift accentColors ──────────────────────
 

--- a/tools/ios-quicklook-poc/PkmdsQuickLookThumbnail/SpriteDrawer.cs
+++ b/tools/ios-quicklook-poc/PkmdsQuickLookThumbnail/SpriteDrawer.cs
@@ -1,0 +1,120 @@
+using CoreGraphics;
+using Foundation;
+using UIKit;
+
+namespace Pkmds.QuickLookThumbnail;
+
+internal static class SpriteDrawer
+{
+    // Sprites are copied into Resources/sprites/ by build-extension.sh after dotnet build.
+    internal static UIImage? LoadBundledSprite(string relativePath)
+    {
+        var resourcePath = NSBundle.MainBundle.ResourcePath;
+        if (resourcePath is null) return null;
+
+        var segments = relativePath.Split('/');
+        var path     = Path.Combine(resourcePath, "sprites", Path.Combine(segments));
+        return File.Exists(path) ? UIImage.FromFile(path) : null;
+    }
+
+    // Returns the tight bounding box (in UIImage pixel coordinates) of non-transparent pixels.
+    // Falls back to the full image bounds when pixel data cannot be read.
+    internal static CGRect OpaqueSourceRect(UIImage image)
+    {
+        var cgImg = image.CGImage;
+        if (cgImg is null)
+            return new CGRect(CGPoint.Empty, image.Size);
+
+        var pw = cgImg.Width;
+        var ph = cgImg.Height;
+        if (pw == 0 || ph == 0)
+            return new CGRect(CGPoint.Empty, image.Size);
+
+        var full   = new CGRect(0, 0, pw, ph);
+        var stride = pw * 4;
+
+        // BGRA / premultipliedFirst — alpha at byte +3, native ARM layout.
+        var ctx = CGBitmapContext.Create(
+            IntPtr.Zero, pw, ph, 8, stride,
+            CGColorSpace.CreateDeviceRGB(),
+            CGBitmapFlags.ByteOrder32Little | CGBitmapFlags.PremultipliedFirst);
+        if (ctx is null) return full;
+
+        // CGBitmapContext row 0 = visual top (raster order), y-down.
+        ctx.DrawImage(new CGRect(0, 0, pw, ph), cgImg);
+        var rawData = ctx.Data;
+        if (rawData == IntPtr.Zero) return full;
+
+        unsafe
+        {
+            var bytes = (byte*)rawData.ToPointer();
+            int left = pw, right = -1, top = ph, bottom = -1;
+            for (var row = 0; row < ph; row++)
+            {
+                for (var col = 0; col < pw; col++)
+                {
+                    // Alpha byte is at offset +3 in BGRA layout.
+                    if (bytes[row * stride + col * 4 + 3] > 10)
+                    {
+                        if (col  < left)   left   = col;
+                        if (col  > right)  right  = col;
+                        if (row  < top)    top    = row;
+                        if (row  > bottom) bottom = row;
+                    }
+                }
+            }
+            if (right < left || bottom < top) return full;
+
+            // CGBitmapContext row 0 is the visual top (y-down), so pixel row maps directly to
+            // y in the CGImage coordinate system (which is also y-down in raster storage).
+            // UIImage.Size is in points; scale pixel coords to points for the return value.
+            var sx = (nfloat)image.Size.Width  / pw;
+            var sy = (nfloat)image.Size.Height / ph;
+            return new CGRect(
+                (nfloat)left              * sx,
+                (nfloat)top               * sy,
+                (nfloat)(right - left + 1) * sx,
+                (nfloat)(bottom - top + 1) * sy);
+        }
+    }
+
+    // Draws cgImg centred in the QL context, scaled so the opaque region fills 90% of the frame.
+    // CGContext.DrawImage has bottom-left origin (y-up), so a vertical flip is required so the
+    // sprite appears right-side up in the iOS QL context (which is y-down / top-left origin).
+    internal static void DrawCentered(CGContext ctx, CGSize ctxSize, CGImage cgImg, CGRect srcRect)
+    {
+        const double fill = 0.90;
+        var scale = Math.Min(ctxSize.Width  * fill / srcRect.Width,
+                             ctxSize.Height * fill / srcRect.Height);
+        var drawW = srcRect.Width  * scale;
+        var drawH = srcRect.Height * scale;
+        var destX = (ctxSize.Width  - drawW) / 2;
+        var destY = (ctxSize.Height - drawH) / 2;
+
+        // Clip to the opaque source region.
+        var srcRectPixels = new CGRect(
+            srcRect.X / (cgImg.Width  > 0 ? cgImg.Width  : 1),
+            srcRect.Y / (cgImg.Height > 0 ? cgImg.Height : 1),
+            srcRect.Width  / (cgImg.Width  > 0 ? cgImg.Width  : 1),
+            srcRect.Height / (cgImg.Height > 0 ? cgImg.Height : 1));
+
+        // Flip vertically around the draw rect's centre so CGContext.DrawImage renders upright.
+        ctx.SaveState();
+        ctx.TranslateCTM((nfloat)(destX + drawW / 2), (nfloat)(destY + drawH / 2));
+        ctx.ScaleCTM(1, -1);
+
+        // Crop to the opaque sub-region before drawing.
+        var croppedImg = cgImg.WithImageInRect(new CGRect(
+            (nfloat)(srcRect.X),
+            (nfloat)(srcRect.Y),
+            (nfloat)(srcRect.Width),
+            (nfloat)(srcRect.Height)));
+
+        ctx.DrawImage(new CGRect(
+            (nfloat)(-drawW / 2), (nfloat)(-drawH / 2),
+            (nfloat)drawW, (nfloat)drawH),
+            croppedImg ?? cgImg);
+
+        ctx.RestoreState();
+    }
+}

--- a/tools/ios-quicklook-poc/PkmdsQuickLookThumbnail/SpriteDrawer.cs
+++ b/tools/ios-quicklook-poc/PkmdsQuickLookThumbnail/SpriteDrawer.cs
@@ -17,104 +17,75 @@ internal static class SpriteDrawer
         return File.Exists(path) ? UIImage.FromFile(path) : null;
     }
 
-    // Returns the tight bounding box (in UIImage pixel coordinates) of non-transparent pixels.
-    // Falls back to the full image bounds when pixel data cannot be read.
+    // Returns the tight bounding box (in CGImage pixel coordinates) of non-transparent pixels.
+    // Falls back to the full image pixel bounds when pixel data cannot be read.
     internal static CGRect OpaqueSourceRect(UIImage image)
     {
         var cgImg = image.CGImage;
         if (cgImg is null)
-            return new CGRect(CGPoint.Empty, image.Size);
+            return new CGRect(0, 0, (int)image.Size.Width, (int)image.Size.Height);
 
-        var pw = cgImg.Width;
-        var ph = cgImg.Height;
-        if (pw == 0 || ph == 0)
-            return new CGRect(CGPoint.Empty, image.Size);
+        var pw = (int)cgImg.Width;
+        var ph = (int)cgImg.Height;
+        if (pw == 0 || ph == 0) return new CGRect(0, 0, pw, ph);
 
         var full   = new CGRect(0, 0, pw, ph);
         var stride = pw * 4;
 
-        // BGRA / premultipliedFirst — alpha at byte +3, native ARM layout.
-        var ctx = CGBitmapContext.Create(
+        // BGRA / premultipliedFirst — alpha at byte offset +3, native ARM layout.
+        // Use the constructor directly; CGBitmapContext.Create matches an adaptive overload
+        // (with callback parameters) when passed IntPtr.Zero as the data argument.
+        var bmpCtx = new CGBitmapContext(
             IntPtr.Zero, pw, ph, 8, stride,
             CGColorSpace.CreateDeviceRGB(),
             CGBitmapFlags.ByteOrder32Little | CGBitmapFlags.PremultipliedFirst);
-        if (ctx is null) return full;
+        if (bmpCtx is null) return full;
 
-        // CGBitmapContext row 0 = visual top (raster order), y-down.
-        ctx.DrawImage(new CGRect(0, 0, pw, ph), cgImg);
-        var rawData = ctx.Data;
+        // CGBitmapContext row 0 = visual top (raster order, y-down).
+        bmpCtx.DrawImage(new CGRect(0, 0, pw, ph), cgImg);
+        var rawData = bmpCtx.Data;
         if (rawData == IntPtr.Zero) return full;
 
         unsafe
         {
-            var bytes = (byte*)rawData.ToPointer();
-            int left = pw, right = -1, top = ph, bottom = -1;
+            var bytes  = (byte*)rawData.ToPointer();
+            int left   = pw, right = -1, top = ph, bottom = -1;
             for (var row = 0; row < ph; row++)
             {
                 for (var col = 0; col < pw; col++)
                 {
-                    // Alpha byte is at offset +3 in BGRA layout.
                     if (bytes[row * stride + col * 4 + 3] > 10)
                     {
-                        if (col  < left)   left   = col;
-                        if (col  > right)  right  = col;
-                        if (row  < top)    top    = row;
-                        if (row  > bottom) bottom = row;
+                        if (col < left)   left   = col;
+                        if (col > right)  right  = col;
+                        if (row < top)    top    = row;
+                        if (row > bottom) bottom = row;
                     }
                 }
             }
             if (right < left || bottom < top) return full;
 
-            // CGBitmapContext row 0 is the visual top (y-down), so pixel row maps directly to
-            // y in the CGImage coordinate system (which is also y-down in raster storage).
-            // UIImage.Size is in points; scale pixel coords to points for the return value.
-            var sx = (nfloat)image.Size.Width  / pw;
-            var sy = (nfloat)image.Size.Height / ph;
-            return new CGRect(
-                (nfloat)left              * sx,
-                (nfloat)top               * sy,
-                (nfloat)(right - left + 1) * sx,
-                (nfloat)(bottom - top + 1) * sy);
+            // Return pixel coordinates — used by DrawCentered to crop the CGImage.
+            return new CGRect(left, top, right - left + 1, bottom - top + 1);
         }
     }
 
-    // Draws cgImg centred in the QL context, scaled so the opaque region fills 90% of the frame.
-    // CGContext.DrawImage has bottom-left origin (y-up), so a vertical flip is required so the
-    // sprite appears right-side up in the iOS QL context (which is y-down / top-left origin).
-    internal static void DrawCentered(CGContext ctx, CGSize ctxSize, CGImage cgImg, CGRect srcRect)
+    // Draws sprite centred in the QL context, scaled so the opaque region fills 90% of the frame.
+    // Crops the CGImage to the opaque pixel bounding box, then draws via UIImage.Draw(CGRect),
+    // which handles the CG coordinate flip (bottom-left origin) internally — no manual flip needed.
+    internal static void DrawCentered(CGContext ctx, CGSize ctxSize, UIImage sprite, CGRect srcPixels)
     {
         const double fill = 0.90;
-        var scale = Math.Min(ctxSize.Width  * fill / srcRect.Width,
-                             ctxSize.Height * fill / srcRect.Height);
-        var drawW = srcRect.Width  * scale;
-        var drawH = srcRect.Height * scale;
+        var scale = Math.Min(ctxSize.Width  * fill / srcPixels.Width,
+                             ctxSize.Height * fill / srcPixels.Height);
+        var drawW = srcPixels.Width  * scale;
+        var drawH = srcPixels.Height * scale;
         var destX = (ctxSize.Width  - drawW) / 2;
         var destY = (ctxSize.Height - drawH) / 2;
 
-        // Clip to the opaque source region.
-        var srcRectPixels = new CGRect(
-            srcRect.X / (cgImg.Width  > 0 ? cgImg.Width  : 1),
-            srcRect.Y / (cgImg.Height > 0 ? cgImg.Height : 1),
-            srcRect.Width  / (cgImg.Width  > 0 ? cgImg.Width  : 1),
-            srcRect.Height / (cgImg.Height > 0 ? cgImg.Height : 1));
-
-        // Flip vertically around the draw rect's centre so CGContext.DrawImage renders upright.
-        ctx.SaveState();
-        ctx.TranslateCTM((nfloat)(destX + drawW / 2), (nfloat)(destY + drawH / 2));
-        ctx.ScaleCTM(1, -1);
-
-        // Crop to the opaque sub-region before drawing.
-        var croppedImg = cgImg.WithImageInRect(new CGRect(
-            (nfloat)(srcRect.X),
-            (nfloat)(srcRect.Y),
-            (nfloat)(srcRect.Width),
-            (nfloat)(srcRect.Height)));
-
-        ctx.DrawImage(new CGRect(
-            (nfloat)(-drawW / 2), (nfloat)(-drawH / 2),
-            (nfloat)drawW, (nfloat)drawH),
-            croppedImg ?? cgImg);
-
-        ctx.RestoreState();
+        // Crop to the opaque bounding box, then wrap in a UIImage for drawing.
+        var croppedCg = sprite.CGImage?.WithImageInRect(srcPixels);
+        var toDraw    = croppedCg is not null ? new UIImage(croppedCg) : sprite;
+        toDraw.Draw(new CGRect((nfloat)destX, (nfloat)destY, (nfloat)drawW, (nfloat)drawH));
     }
 }

--- a/tools/ios-quicklook-poc/PkmdsQuickLookThumbnail/ThumbnailProvider.cs
+++ b/tools/ios-quicklook-poc/PkmdsQuickLookThumbnail/ThumbnailProvider.cs
@@ -1,0 +1,73 @@
+using CoreGraphics;
+using Foundation;
+using PKHeX.Core;
+using Pkmds.Preview;
+using QuickLookThumbnailing;
+using UIKit;
+
+namespace Pkmds.QuickLookThumbnail;
+
+[Register("ThumbnailProvider")]
+public sealed class ThumbnailProvider : QLThumbnailProvider
+{
+    public override void ProvideThumbnail(QLFileThumbnailRequest request,
+                                          Action<QLThumbnailReply?, NSError?> handler)
+    {
+        var fileUrl = request.FileURL;
+        var maxSize = request.MaximumSize;
+        var scale   = request.Scale;
+
+        DispatchQueue.GetGlobalQueue(DispatchQueuePriority.UserInitiated).DispatchAsync(() =>
+        {
+            using var nsData = NSData.FromUrl(fileUrl, NSDataReadingOptions.Mapped, out var error);
+            if (nsData is null)
+            {
+                handler(null, error);
+                return;
+            }
+
+            var fileData = nsData.ToArray();
+            var ext      = fileUrl.PathExtension?.ToLowerInvariant() ?? string.Empty;
+
+            // All PKHeX.Core work happens here on the background queue, before the
+            // drawing closure so the QL context thread has no managed dependencies.
+            var saveInfo = SaveCard.TryParseSave(fileData);
+
+            UIImage? sprite  = null;
+            CGRect   srcRect = CGRect.Empty;
+            if (saveInfo is null)
+            {
+                var rel = FileSprite.GetRelativeSpritePath(fileData, ext);
+                sprite  = SpriteDrawer.LoadBundledSprite(rel);
+                if (sprite is not null)
+                    srcRect = SpriteDrawer.OpaqueSourceRect(sprite);
+            }
+
+            // QLThumbnailReply(contextSize:drawing:) — system provides a pre-configured CGContext.
+            // UIGraphics.PushContext / PopContext are the iOS equivalent of NSGraphicsContext.current.
+            var contextSize = new CGSize(maxSize.Width * scale, maxSize.Height * scale);
+            var reply = new QLThumbnailReply(contextSize, ctx =>
+            {
+                UIGraphics.PushContext(ctx);
+                try
+                {
+                    if (saveInfo is not null)
+                    {
+                        SaveCard.Draw(ctx, contextSize, saveInfo);
+                    }
+                    else if (sprite?.CGImage is { } cgImg && srcRect.Width > 0)
+                    {
+                        SpriteDrawer.DrawCentered(ctx, contextSize, cgImg, srcRect);
+                    }
+                }
+                finally
+                {
+                    UIGraphics.PopContext();
+                }
+                return true;
+            });
+
+            handler(reply, null);
+        });
+    }
+}

--- a/tools/ios-quicklook-poc/PkmdsQuickLookThumbnail/ThumbnailProvider.cs
+++ b/tools/ios-quicklook-poc/PkmdsQuickLookThumbnail/ThumbnailProvider.cs
@@ -1,8 +1,12 @@
 using CoreGraphics;
 using Foundation;
+using ObjCRuntime;
 using PKHeX.Core;
 using Pkmds.Preview;
 using QuickLookThumbnailing;
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
 using UIKit;
 
 namespace Pkmds.QuickLookThumbnail;
@@ -10,27 +14,31 @@ namespace Pkmds.QuickLookThumbnail;
 [Register("ThumbnailProvider")]
 public sealed class ThumbnailProvider : QLThumbnailProvider
 {
+    // The net10.0-ios binding omits public constructors for QLThumbnailReply.
+    // Call the ObjC factory replyWithImageFileURL: directly via P/Invoke.
+    [DllImport(Constants.ObjectiveCLibrary, EntryPoint = "objc_msgSend")]
+    private static extern IntPtr ObjcMsgSend(IntPtr receiver, IntPtr selector, IntPtr arg1);
+
     public override void ProvideThumbnail(QLFileThumbnailRequest request,
-                                          Action<QLThumbnailReply?, NSError?> handler)
+                                          Action<QLThumbnailReply, NSError> handler)
     {
-        var fileUrl = request.FileURL;
+        var fileUrl = request.FileUrl;
         var maxSize = request.MaximumSize;
         var scale   = request.Scale;
 
-        DispatchQueue.GetGlobalQueue(DispatchQueuePriority.UserInitiated).DispatchAsync(() =>
+        Task.Run(() =>
         {
             using var nsData = NSData.FromUrl(fileUrl, NSDataReadingOptions.Mapped, out var error);
             if (nsData is null)
             {
-                handler(null, error);
+                handler(null!, error!);
                 return;
             }
 
             var fileData = nsData.ToArray();
             var ext      = fileUrl.PathExtension?.ToLowerInvariant() ?? string.Empty;
 
-            // All PKHeX.Core work happens here on the background queue, before the
-            // drawing closure so the QL context thread has no managed dependencies.
+            // All PKHeX.Core work on this background thread before drawing.
             var saveInfo = SaveCard.TryParseSave(fileData);
 
             UIImage? sprite  = null;
@@ -43,31 +51,33 @@ public sealed class ThumbnailProvider : QLThumbnailProvider
                     srcRect = SpriteDrawer.OpaqueSourceRect(sprite);
             }
 
-            // QLThumbnailReply(contextSize:drawing:) — system provides a pre-configured CGContext.
-            // UIGraphics.PushContext / PopContext are the iOS equivalent of NSGraphicsContext.current.
+            // UIGraphicsImageRenderer sets up a UIKit context so UIBezierPath /
+            // NSAttributedString drawing works without manually pushing a CGContext.
             var contextSize = new CGSize(maxSize.Width * scale, maxSize.Height * scale);
-            var reply = new QLThumbnailReply(contextSize, ctx =>
+            var renderer    = new UIGraphicsImageRenderer(contextSize);
+            var image       = renderer.CreateImage(rendCtx =>
             {
-                UIGraphics.PushContext(ctx);
-                try
-                {
-                    if (saveInfo is not null)
-                    {
-                        SaveCard.Draw(ctx, contextSize, saveInfo);
-                    }
-                    else if (sprite?.CGImage is { } cgImg && srcRect.Width > 0)
-                    {
-                        SpriteDrawer.DrawCentered(ctx, contextSize, cgImg, srcRect);
-                    }
-                }
-                finally
-                {
-                    UIGraphics.PopContext();
-                }
-                return true;
+                var ctx = rendCtx.CGContext;
+                if (saveInfo is not null)
+                    SaveCard.Draw(ctx, contextSize, saveInfo);
+                else if (sprite is not null && srcRect.Width > 0)
+                    SpriteDrawer.DrawCentered(ctx, contextSize, sprite, srcRect);
             });
 
-            handler(reply, null);
+            // Write to a temp PNG. The QL system reads this file when it consumes the
+            // reply; leave it in the temp directory for the OS to clean up.
+            var tmpPath = Path.Combine(Path.GetTempPath(),
+                                       Guid.NewGuid().ToString("N") + ".png");
+            using var pngData = image.AsPNG();
+            pngData!.Save(tmpPath, false, out _);
+
+            var tmpUrl    = NSUrl.FromFilename(tmpPath);
+            var clsHandle = Class.GetHandle("QLThumbnailReply");
+            var selHandle = Selector.GetHandle("replyWithImageFileURL:");
+            var handle    = ObjcMsgSend(clsHandle, selHandle, tmpUrl.Handle);
+            var reply     = Runtime.GetNSObject<QLThumbnailReply>(handle)!;
+
+            handler(reply, null!);
         });
     }
 }

--- a/tools/ios-quicklook-poc/PkmdsQuickLookThumbnail/ThumbnailProvider.cs
+++ b/tools/ios-quicklook-poc/PkmdsQuickLookThumbnail/ThumbnailProvider.cs
@@ -51,18 +51,31 @@ public sealed class ThumbnailProvider : QLThumbnailProvider
                     srcRect = SpriteDrawer.OpaqueSourceRect(sprite);
             }
 
-            // UIGraphicsImageRenderer sets up a UIKit context so UIBezierPath /
-            // NSAttributedString drawing works without manually pushing a CGContext.
             var contextSize = new CGSize(maxSize.Width * scale, maxSize.Height * scale);
-            var renderer    = new UIGraphicsImageRenderer(contextSize);
-            var image       = renderer.CreateImage(rendCtx =>
+
+            // UIKit drawing (UIBezierPath, NSAttributedString, UIGraphicsImageRenderer)
+            // requires the main thread — UIGraphicsRendererContext.CGContext calls
+            // UIApplication.EnsureUIThread() and throws on background threads.
+            // InvokeOnMainThread dispatches synchronously to the extension's main run loop.
+            UIImage? image = null;
+            InvokeOnMainThread(() =>
             {
-                var ctx = rendCtx.CGContext;
-                if (saveInfo is not null)
-                    SaveCard.Draw(ctx, contextSize, saveInfo);
-                else if (sprite is not null && srcRect.Width > 0)
-                    SpriteDrawer.DrawCentered(ctx, contextSize, sprite, srcRect);
+                var renderer = new UIGraphicsImageRenderer(contextSize);
+                image = renderer.CreateImage(rendCtx =>
+                {
+                    var ctx = rendCtx.CGContext;
+                    if (saveInfo is not null)
+                        SaveCard.Draw(ctx, contextSize, saveInfo);
+                    else if (sprite is not null && srcRect.Width > 0)
+                        SpriteDrawer.DrawCentered(ctx, contextSize, sprite, srcRect);
+                });
             });
+
+            if (image is null)
+            {
+                handler(null!, null!);
+                return;
+            }
 
             // Write to a temp PNG. The QL system reads this file when it consumes the
             // reply; leave it in the temp directory for the OS to clean up.

--- a/tools/ios-quicklook-poc/build-extension.sh
+++ b/tools/ios-quicklook-poc/build-extension.sh
@@ -66,6 +66,12 @@ EOF
     exit 1
 fi
 
+# Delete the SDK's intermediate AppManifest.plist before each build so that
+# Info.plist-only changes (no .cs edits) are never skipped by incremental build.
+# Microsoft.iOS.Sdk caches the merged plist in obj/; cleaning bin/ alone is not enough.
+rm -f "${DOTNET_OUT_DIR/\/bin\//\/obj\/}/AppManifest.plist"
+rm -f "${THUMB_OUT_DIR/\/bin\//\/obj\/}/AppManifest.plist"
+
 echo "==> dotnet ${DOTNET_CMD[*]} (preview extension)"
 dotnet "${DOTNET_CMD[@]}" "$CSPROJ" --nologo
 

--- a/tools/ios-quicklook-poc/build-extension.sh
+++ b/tools/ios-quicklook-poc/build-extension.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Builds the C# Quick Look extension (.appex) and the SwiftUI host app, then
-# embeds the .appex into the host app's PlugIns/. Defaults to the iOS Simulator
+# Builds the C# Quick Look preview + thumbnail extensions (.appex) and the SwiftUI host app,
+# then embeds both .appex bundles into the host app's PlugIns/. Defaults to the iOS Simulator
 # (no signing required); use --device for an AOT'd ios-arm64 build.
 #
 #   ./build-extension.sh                          # iOS Simulator (Mono, no AOT)
@@ -9,6 +9,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_ROOT="$( cd "$SCRIPT_DIR/../.." && pwd )"
 
 # Ad-hoc signs every Mach-O inside an .appex (main binary + every embedded
 # .dylib), then signs the bundle itself. iOS extensions on the simulator
@@ -31,20 +32,24 @@ fi
 # build` (Microsoft.iOS.Sdk's Publish target rejects simulator RIDs); device
 # uses ios-arm64 + NativeAOT via `dotnet publish`.
 CSPROJ="$SCRIPT_DIR/PkmdsQuickLook/PkmdsQuickLook.csproj"
+THUMB_CSPROJ="$SCRIPT_DIR/PkmdsQuickLookThumbnail/PkmdsQuickLookThumbnail.csproj"
 if [[ "$TARGET_DEVICE" -eq 1 ]]; then
     DOTNET_CMD=(publish -c Release -r ios-arm64)
     DOTNET_OUT_DIR="$SCRIPT_DIR/PkmdsQuickLook/bin/Release/net10.0-ios/ios-arm64"
+    THUMB_OUT_DIR="$SCRIPT_DIR/PkmdsQuickLookThumbnail/bin/Release/net10.0-ios/ios-arm64"
     XCODE_DEST="generic/platform=iOS"
     XCODE_PRODUCTS_DIR="Release-iphoneos"
     XCODE_CONFIG="Release"
 else
     DOTNET_CMD=(build -c Debug -r iossimulator-arm64)
     DOTNET_OUT_DIR="$SCRIPT_DIR/PkmdsQuickLook/bin/Debug/net10.0-ios/iossimulator-arm64"
+    THUMB_OUT_DIR="$SCRIPT_DIR/PkmdsQuickLookThumbnail/bin/Debug/net10.0-ios/iossimulator-arm64"
     XCODE_PRODUCTS_DIR="Debug-iphonesimulator"
     XCODE_CONFIG="Debug"
 fi
 
 APPEX_SRC="$DOTNET_OUT_DIR/PkmdsQuickLook.appex"
+THUMB_APPEX_SRC="$THUMB_OUT_DIR/PkmdsQuickLookThumbnail.appex"
 
 XCODE_DIR="$SCRIPT_DIR/xcode"
 PROJECT="$XCODE_DIR/PkmdsHost.xcodeproj"
@@ -61,10 +66,15 @@ EOF
     exit 1
 fi
 
-echo "==> dotnet ${DOTNET_CMD[*]}"
+echo "==> dotnet ${DOTNET_CMD[*]} (preview extension)"
 dotnet "${DOTNET_CMD[@]}" "$CSPROJ" --nologo
 
 [[ -d "$APPEX_SRC" ]] || { echo "missing .appex at $APPEX_SRC" >&2; exit 1; }
+
+echo "==> dotnet ${DOTNET_CMD[*]} (thumbnail extension)"
+dotnet "${DOTNET_CMD[@]}" "$THUMB_CSPROJ" --nologo
+
+[[ -d "$THUMB_APPEX_SRC" ]] || { echo "missing thumbnail .appex at $THUMB_APPEX_SRC" >&2; exit 1; }
 
 echo "==> xcodegen generate"
 ( cd "$XCODE_DIR" && xcodegen generate --quiet )
@@ -83,21 +93,34 @@ if [[ "$TARGET_DEVICE" -eq 1 ]]; then
 
     [[ -d "$APP_PATH" ]] || { echo "missing host app at $APP_PATH" >&2; exit 1; }
 
-    echo "==> embed .appex into host app"
+    echo "==> embed .appex bundles into host app"
     mkdir -p "$APP_PATH/PlugIns"
     rm -rf "$APP_PATH/PlugIns/PkmdsQuickLook.appex"
     cp -R "$APPEX_SRC" "$APP_PATH/PlugIns/"
+    rm -rf "$APP_PATH/PlugIns/PkmdsQuickLookThumbnail.appex"
+    cp -R "$THUMB_APPEX_SRC" "$APP_PATH/PlugIns/"
+
+    # Copy bundled sprites into the thumbnail extension.
+    echo "==> bundle sprites into thumbnail extension"
+    SPRITES_SRC="$REPO_ROOT/Pkmds.Rcl/wwwroot/sprites"
+    SPRITES_DST="$APP_PATH/PlugIns/PkmdsQuickLookThumbnail.appex/sprites"
+    rm -rf "$SPRITES_DST"
+    mkdir -p "$SPRITES_DST"
+    cp -r "$SPRITES_SRC/a"  "$SPRITES_DST/"
+    cp -r "$SPRITES_SRC/ai" "$SPRITES_DST/"
+    cp -r "$SPRITES_SRC/bi" "$SPRITES_DST/"
 
     # Even on the simulator, iOS extensions must carry a valid code signature —
     # the host app gets a pass without one, but amfid SIGKILLs unsigned .appex
     # bundles on launch ("Code Signature Invalid" / dyld __LINKEDIT page fault).
     # Ad-hoc signing covers the simulator path; real-device deployment needs a
     # full Developer ID via Xcode.
-    echo "==> ad-hoc sign embedded .appex"
+    echo "==> ad-hoc sign embedded .appex bundles"
     sign_appex "$APP_PATH/PlugIns/PkmdsQuickLook.appex"
+    sign_appex "$APP_PATH/PlugIns/PkmdsQuickLookThumbnail.appex"
 
     echo
-    echo "Built unsigned host app with embedded extension: $APP_PATH"
+    echo "Built unsigned host app with embedded extensions: $APP_PATH"
     echo "Deploy to a real device by opening the project in Xcode, setting your"
     echo "Team / signing identity, and running on a connected device."
     exit 0
@@ -140,13 +163,25 @@ xcodebuild \
 
 [[ -d "$APP_PATH" ]] || { echo "missing host app at $APP_PATH" >&2; exit 1; }
 
-echo "==> embed .appex into host app"
+echo "==> embed .appex bundles into host app"
 mkdir -p "$APP_PATH/PlugIns"
 rm -rf "$APP_PATH/PlugIns/PkmdsQuickLook.appex"
 cp -R "$APPEX_SRC" "$APP_PATH/PlugIns/"
+rm -rf "$APP_PATH/PlugIns/PkmdsQuickLookThumbnail.appex"
+cp -R "$THUMB_APPEX_SRC" "$APP_PATH/PlugIns/"
 
-echo "==> ad-hoc sign embedded .appex"
+echo "==> bundle sprites into thumbnail extension"
+SPRITES_SRC="$REPO_ROOT/Pkmds.Rcl/wwwroot/sprites"
+SPRITES_DST="$APP_PATH/PlugIns/PkmdsQuickLookThumbnail.appex/sprites"
+rm -rf "$SPRITES_DST"
+mkdir -p "$SPRITES_DST"
+cp -r "$SPRITES_SRC/a"  "$SPRITES_DST/"
+cp -r "$SPRITES_SRC/ai" "$SPRITES_DST/"
+cp -r "$SPRITES_SRC/bi" "$SPRITES_DST/"
+
+echo "==> ad-hoc sign embedded .appex bundles"
 sign_appex "$APP_PATH/PlugIns/PkmdsQuickLook.appex"
+sign_appex "$APP_PATH/PlugIns/PkmdsQuickLookThumbnail.appex"
 
 echo "==> install + launch"
 xcrun simctl uninstall "$SIM_UUID" com.bondcodes.pkmds.host.ios 2>/dev/null || true
@@ -155,4 +190,6 @@ xcrun simctl launch "$SIM_UUID" com.bondcodes.pkmds.host.ios
 
 echo
 echo "Launched PkmdsHost on $SIM_NAME."
-echo "Drag a .pk*/.sav from Finder onto the Simulator window, then long-press the file in Files.app to preview."
+echo "Drag a .pk*/.sav from Finder onto the Simulator window, then:"
+echo "  - Long-press a file in Files.app → Quick Look → HTML preview."
+echo "  - Switch to grid/column view with large icons → thumbnail extension renders trainer cards + sprites."

--- a/tools/ios-quicklook-poc/xcode/PkmdsHost/Info.plist
+++ b/tools/ios-quicklook-poc/xcode/PkmdsHost/Info.plist
@@ -30,6 +30,7 @@
 			<key>LSItemContentTypes</key>
 			<array>
 				<string>com.bondcodes.pkmds.save-file</string>
+				<string>com.bondcodes.pkmds.save-file-restricted</string>
 			</array>
 		</dict>
 		<dict>
@@ -136,8 +137,26 @@
 					<string>gci</string>
 					<string>dsv</string>
 					<string>srm</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+				<string>public.composite-content</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Pokémon Save File (restricted extensions)</string>
+			<key>UTTypeIdentifier</key>
+			<string>com.bondcodes.pkmds.save-file-restricted</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
 					<string>dat</string>
 					<string>bin</string>
+					<string>fla</string>
 				</array>
 			</dict>
 		</dict>

--- a/tools/ios-quicklook-poc/xcode/PkmdsHost/Info.plist
+++ b/tools/ios-quicklook-poc/xcode/PkmdsHost/Info.plist
@@ -107,14 +107,8 @@
 					<string>pk8</string>
 					<string>pk9</string>
 					<string>pa8</string>
-					<string>pa9</string>
 					<string>pb7</string>
 					<string>pb8</string>
-					<string>sk2</string>
-					<string>ck3</string>
-					<string>xk3</string>
-					<string>bk4</string>
-					<string>rk4</string>
 				</array>
 			</dict>
 		</dict>
@@ -133,11 +127,6 @@
 				<key>public.filename-extension</key>
 				<array>
 					<string>sav</string>
-					<string>dat</string>
-					<string>gci</string>
-					<string>dsv</string>
-					<string>srm</string>
-					<string>fla</string>
 				</array>
 			</dict>
 		</dict>
@@ -155,25 +144,18 @@
 			<dict>
 				<key>public.filename-extension</key>
 				<array>
-					<string>pgt</string>
-					<string>pcd</string>
-					<string>wc3</string>
 					<string>wc4</string>
-					<string>pgf</string>
 					<string>wc5full</string>
 					<string>wc6</string>
 					<string>wc6full</string>
 					<string>wc7</string>
 					<string>wc7full</string>
-					<string>wr7</string>
-					<string>wb7</string>
-					<string>wb7full</string>
 					<string>wc8</string>
 					<string>wc8full</string>
-					<string>wb8</string>
-					<string>wa8</string>
 					<string>wc9</string>
-					<string>wa9</string>
+					<string>pcd</string>
+					<string>pgt</string>
+					<string>pgf</string>
 				</array>
 			</dict>
 		</dict>

--- a/tools/ios-quicklook-poc/xcode/PkmdsHost/Info.plist
+++ b/tools/ios-quicklook-poc/xcode/PkmdsHost/Info.plist
@@ -107,8 +107,14 @@
 					<string>pk8</string>
 					<string>pk9</string>
 					<string>pa8</string>
+					<string>pa9</string>
 					<string>pb7</string>
 					<string>pb8</string>
+					<string>sk2</string>
+					<string>ck3</string>
+					<string>xk3</string>
+					<string>bk4</string>
+					<string>rk4</string>
 				</array>
 			</dict>
 		</dict>
@@ -127,6 +133,11 @@
 				<key>public.filename-extension</key>
 				<array>
 					<string>sav</string>
+					<string>gci</string>
+					<string>dsv</string>
+					<string>srm</string>
+					<string>dat</string>
+					<string>bin</string>
 				</array>
 			</dict>
 		</dict>
@@ -144,15 +155,22 @@
 			<dict>
 				<key>public.filename-extension</key>
 				<array>
+					<string>wc3</string>
 					<string>wc4</string>
 					<string>wc5full</string>
 					<string>wc6</string>
 					<string>wc6full</string>
 					<string>wc7</string>
 					<string>wc7full</string>
+					<string>wr7</string>
+					<string>wb7</string>
+					<string>wb7full</string>
 					<string>wc8</string>
 					<string>wc8full</string>
+					<string>wb8</string>
+					<string>wa8</string>
 					<string>wc9</string>
+					<string>wa9</string>
 					<string>pcd</string>
 					<string>pgt</string>
 					<string>pgf</string>

--- a/tools/ios-quicklook-poc/xcode/PkmdsHost/PkmdsHostApp.swift
+++ b/tools/ios-quicklook-poc/xcode/PkmdsHost/PkmdsHostApp.swift
@@ -21,14 +21,15 @@ struct ContentView: View {
 
                 Divider()
 
-                Text("This host app exists so iOS will register the bundled Quick Look extension. Once installed, long-press a `.pk*` or `.sav` file in **Files** (or any other Quick Look surface — Mail attachments, AirDrop received files) to preview it.")
+                Text("This host app exists so iOS will register the bundled Quick Look extensions. Once installed, long-press any supported file in **Files** (or any other Quick Look surface — Mail attachments, AirDrop received files) to preview it. In grid or column view, supported files also show custom thumbnails.")
                     .fixedSize(horizontal: false, vertical: true)
 
                 Text("Supported types")
                     .font(.headline)
                     .padding(.top, 8)
-                Text("• `.pk1`–`.pk9`, `.pa8`, `.pb7`, `.pb8` — Pokémon entity files")
-                Text("• `.sav` — Pokémon save files")
+                Text("• `.pk1`–`.pk9`, `.pa8`, `.pa9`, `.pb7`, `.pb8`, `.sk2`, `.ck3`, `.xk3`, `.bk4`, `.rk4` — Pokémon entity files")
+                Text("• `.sav`, `.gci`, `.dsv`, `.srm`, `.dat`, `.bin`, `.fla` — Pokémon save files")
+                Text("• `.wc3`–`.wc9`, `.wa8`, `.wa9`, `.wb7`, `.wb8`, `.wr7`, `.pcd`, `.pgt`, `.pgf` — Wonder Cards / Mystery Gifts")
             }
             .padding(24)
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/tools/ios-quicklook-poc/xcode/project.yml
+++ b/tools/ios-quicklook-poc/xcode/project.yml
@@ -90,8 +90,20 @@ targets:
                 - gci
                 - dsv
                 - srm
+          # dat / bin / fla are common extensions that iOS resolves to system UTTypes
+          # (public.data, com.apple.macbinary-archive, etc.). Declaring them in the same
+          # UTType as sav/gci would poison the whole type and block QL dispatch for all
+          # of its extensions. Split them out — same fix as the macOS POC.
+          - UTTypeIdentifier: com.bondcodes.pkmds.save-file-restricted
+            UTTypeDescription: Pokémon Save File (restricted extensions)
+            UTTypeConformsTo:
+              - public.data
+              - public.composite-content
+            UTTypeTagSpecification:
+              public.filename-extension:
                 - dat
                 - bin
+                - fla
           - UTTypeIdentifier: com.bondcodes.pkmds.wonder-card
             UTTypeDescription: Pokémon Wonder Card
             UTTypeConformsTo:
@@ -128,6 +140,7 @@ targets:
             CFBundleTypeRole: Viewer
             LSItemContentTypes:
               - com.bondcodes.pkmds.save-file
+              - com.bondcodes.pkmds.save-file-restricted
             LSHandlerRank: Alternate
           - CFBundleTypeName: Pokémon Wonder Card
             CFBundleTypeRole: Viewer

--- a/tools/ios-quicklook-poc/xcode/project.yml
+++ b/tools/ios-quicklook-poc/xcode/project.yml
@@ -81,6 +81,25 @@ targets:
             UTTypeTagSpecification:
               public.filename-extension:
                 - sav
+          - UTTypeIdentifier: com.bondcodes.pkmds.wonder-card
+            UTTypeDescription: Pokémon Wonder Card
+            UTTypeConformsTo:
+              - public.data
+              - public.composite-content
+            UTTypeTagSpecification:
+              public.filename-extension:
+                - wc4
+                - wc5full
+                - wc6
+                - wc6full
+                - wc7
+                - wc7full
+                - wc8
+                - wc8full
+                - wc9
+                - pcd
+                - pgt
+                - pgf
         CFBundleDocumentTypes:
           - CFBundleTypeName: Pokémon Entity File
             CFBundleTypeRole: Viewer
@@ -91,4 +110,9 @@ targets:
             CFBundleTypeRole: Viewer
             LSItemContentTypes:
               - com.bondcodes.pkmds.save-file
+            LSHandlerRank: Alternate
+          - CFBundleTypeName: Pokémon Wonder Card
+            CFBundleTypeRole: Viewer
+            LSItemContentTypes:
+              - com.bondcodes.pkmds.wonder-card
             LSHandlerRank: Alternate

--- a/tools/ios-quicklook-poc/xcode/project.yml
+++ b/tools/ios-quicklook-poc/xcode/project.yml
@@ -71,8 +71,14 @@ targets:
                 - pk8
                 - pk9
                 - pa8
+                - pa9
                 - pb7
                 - pb8
+                - sk2
+                - ck3
+                - xk3
+                - bk4
+                - rk4
           - UTTypeIdentifier: com.bondcodes.pkmds.save-file
             UTTypeDescription: Pokémon Save File
             UTTypeConformsTo:
@@ -81,6 +87,11 @@ targets:
             UTTypeTagSpecification:
               public.filename-extension:
                 - sav
+                - gci
+                - dsv
+                - srm
+                - dat
+                - bin
           - UTTypeIdentifier: com.bondcodes.pkmds.wonder-card
             UTTypeDescription: Pokémon Wonder Card
             UTTypeConformsTo:
@@ -88,15 +99,22 @@ targets:
               - public.composite-content
             UTTypeTagSpecification:
               public.filename-extension:
+                - wc3
                 - wc4
                 - wc5full
                 - wc6
                 - wc6full
                 - wc7
                 - wc7full
+                - wr7
+                - wb7
+                - wb7full
                 - wc8
                 - wc8full
+                - wb8
+                - wa8
                 - wc9
+                - wa9
                 - pcd
                 - pgt
                 - pgf

--- a/tools/macos-quicklook-poc/xcode/PkmdsHost/PkmdsHostApp.swift
+++ b/tools/macos-quicklook-poc/xcode/PkmdsHost/PkmdsHostApp.swift
@@ -12,13 +12,23 @@ struct PkmdsHostApp: App {
 
 struct ContentView: View {
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("PKMDS Quick Look — Proof of Concept")
-                .font(.title2.bold())
-            Text("This host app exists so macOS will register the bundled Quick Look extension. Press Space on a `.pk*` or `.sav` file in Finder to preview.")
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("PKMDS Quick Look — Proof of Concept")
+                    .font(.title2.bold())
+                Text("This host app exists so macOS will register the bundled Quick Look extensions. Press Space on any supported file in Finder to preview it. Finder icon view also shows custom thumbnails.")
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Text("Supported types")
+                    .font(.headline)
+                    .padding(.top, 4)
+                Text("• `.pk1`–`.pk9`, `.pa8`, `.pa9`, `.pb7`, `.pb8`, `.sk2`, `.ck3`, `.xk3`, `.bk4`, `.rk4` — Pokémon entity files")
+                Text("• `.sav`, `.gci`, `.dsv`, `.srm`, `.dat`, `.bin`, `.fla` — Pokémon save files")
+                Text("• `.wc3`–`.wc9`, `.wa8`, `.wa9`, `.wb7`, `.wb8`, `.wr7`, `.pcd`, `.pgt`, `.pgf` — Wonder Cards / Mystery Gifts")
+            }
+            .padding(24)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding(24)
     }
 }

--- a/tools/preview-shared/PreviewFileTypes.cs
+++ b/tools/preview-shared/PreviewFileTypes.cs
@@ -25,7 +25,7 @@ public static class PreviewFileTypes
     /// <summary>Save files — UTType <c>com.bondcodes.pkmds.save-file</c>.</summary>
     public static readonly string[] SaveFiles =
     [
-        ".sav", ".dat", ".gci", ".dsv", ".srm", ".fla",
+        ".sav", ".dat", ".bin", ".gci", ".dsv", ".srm", ".fla",
     ];
 
     /// <summary>Wonder cards / mystery gifts — UTType <c>com.bondcodes.pkmds.wonder-card</c>.</summary>


### PR DESCRIPTION
## Summary

- Adds `PkmdsQuickLookThumbnail` — a C# `QLThumbnailProvider` that renders trainer cards (saves) and species sprites (entities / wonder cards) as iOS Quick Look thumbnails in Files.app.
- Expands UTType declarations for all supported file types: `.pk*`, `.pa*`, `.pb*`, `.sk2`, `.ck3`, `.xk3`, `.bk4`, `.rk4`, `.sav`, `.gci`, `.dsv`, `.srm`, `.wc3`–`.wc9` and variants, `.pcd`, `.pgt`, `.pgf`, `.wr7`, `.wb7`, `.wa8`.
- Splits `save-file` from `save-file-restricted` (`.dat`/`.bin`/`.fla`) to avoid iOS UTType poisoning.
- `build-extension.sh` updated to build, embed, sprite-bundle, sign both extensions, and invalidate `obj/.../AppManifest.plist` so Info.plist-only changes are always picked up.

## Bugs found and fixed during testing

1. **UIKit main-thread crash** — `UIGraphicsImageRenderer.CreateImage` (and all `UIBezierPath`/`NSAttributedString` drawing) calls `UIApplication.EnsureUIThread()` and SIGABRTs on background threads. Fixed by wrapping all UIKit rendering in `InvokeOnMainThread(...)`.

2. **Wonder card dispatch missing** — `com.bondcodes.pkmds.wonder-card` UTType was absent from `project.yml`; xcodegen regenerates `Info.plist` from `project.yml` on every build, silently dropping any hand-edited UTType. Fixed by adding the full wonder-card entry (identifier, conformances, all extensions) to `project.yml`.

3. **Prohibited extension poisons UTType** — Adding `.dat`/`.bin` to `save-file` caused iOS to block QL dispatch for ALL extensions in that UTType. Same fix as the macOS POC: split into `save-file` (safe extensions) + `save-file-restricted` (prohibited extensions).

4. **`ThumbnailsAgent` blacklists entire extension for prohibited extensions** — Including `save-file-restricted` in the thumbnail extension's `QLSupportedContentTypes` caused ThumbnailsAgent to log "trying to register for a prohibited filename extension: dat, bin, fla" and reject all dispatch for the extension — including `wonder-card` and `save-file`. Fix: remove `save-file-restricted` from the thumbnail extension only. The preview extension's dispatch path does not apply this prohibition, so `.dat`/`.bin`/`.fla` files still get QL preview.

5. **Incremental build skips Info.plist-only changes** — `Microsoft.iOS.Sdk` caches the merged plist in `obj/.../AppManifest.plist`. Deleting `bin/` output is insufficient; `build-extension.sh` now also deletes `AppManifest.plist` from `obj/` before each `dotnet build`.

## Result

| File type | Thumbnail | QL Preview |
|---|---|---|
| `.pk*`, `.pa*`, `.pb*`, etc. | ✅ species sprite | ✅ HTML |
| `.sav`, `.gci`, `.dsv`, `.srm` | ✅ trainer card | ✅ HTML |
| `.dat`, `.bin`, `.fla` | ❌ (iOS prohibits) | ✅ HTML |
| `.wc3`–`.wc9`, `.pcd`, `.pgt`, `.pgf` | ✅ species/item sprite | ✅ HTML |

## Test plan

- [x] `./build-extension.sh` (simulator) — both extensions build without error
- [x] `.pk*` / `.sav` / `.gci` files → thumbnail shows species sprite / trainer card
- [x] `.wc3`, `.wc6` files → thumbnail shows species/item placeholder sprite
- [x] Long-press any file → Quick Look → HTML preview works
- [x] `.dat`, `.bin` files → no thumbnail (expected), QL preview works

Closes #935

🤖 Generated with [Claude Code](https://claude.com/claude-code)