### PR TITLE
fix(changelog): don't attribute native preview tools to the web app

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -131,6 +131,8 @@ jobs:
 
             Omit: dependency bumps, CI/CD changes, code formatting, internal refactors with no user-visible effect.
 
+            IMPORTANT — scope and attribution: "PKMDS" is the Blazor WebAssembly web app, and that is the product this changelog is about. The repo also contains separate native companion tools — the Windows Explorer preview/thumbnail handlers and the macOS/iOS Quick Look preview/thumbnail extensions. Those read PKHeX files from the filesystem and do NOT integrate with the web app. Do not describe their changes as features of PKMDS or imply they are part of the web app. If you mention them at all, clearly frame them as separate native/desktop companion tools (e.g. "Separately, the Windows file preview tool…"). When in doubt about whether a change affects the web app, leave it out.
+
             Use plain language. Avoid jargon. Group related changes if it helps readability. Keep it concise.
 
             Format the body as Markdown. Start with a brief intro line, then a bulleted list of changes.


### PR DESCRIPTION
## Summary

The weekly changelog generator in `.github/workflows/claude.yml` builds its discussion post from the raw `git log`, which includes commits for the **Windows Explorer preview/thumbnail handlers** and the **macOS/iOS Quick Look extensions**. Those are separate native companion tools that read PKHeX files from the filesystem and **do not integrate with the Blazor WebAssembly web app**.

A recent Change Log discussion post folded those native tools in as PKMDS features, which is misleading — "PKMDS" is the web app, and that is the product the changelog is about.

## Change

Adds a scope/attribution instruction to Step 4 of the changelog prompt so the generator:
- keeps "PKMDS" scoped to the web app,
- frames the native preview/thumbnail tools as separate companion tools (or omits them), and
- leaves out changes it can't tie to the web app.

No code or runtime behavior changes — prompt text only, within the existing `prompt: |` block scalar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
