### PR TITLE
feat(bug-report): structured categories, fields, and per-category labels (#955)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,11 @@ jobs:
     name: Deploy to GitHub Pages
     # use ubuntu-latest image to run steps on
     runs-on: ubuntu-latest
+    # Deploy the Azure Function first and gate the front-end on its success. The function is
+    # backward-compatible with older (cached PWA) front-ends, but an old function is NOT forward-
+    # compatible with a new front-end — so the new front-end must never go live ahead of the
+    # function it depends on. If the function deploy fails, the front-end is held back too.
+    needs: deploy_functions
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/Pkmds.Functions/Functions/SubmitBugReport.cs
+++ b/Pkmds.Functions/Functions/SubmitBugReport.cs
@@ -28,25 +28,46 @@ public class SubmitBugReport(IGitHubService gitHubService, IBlobService blobServ
 
         var name = form["name"].ToString().Trim();
         var email = form["email"].ToString().Trim();
-        var description = form["description"].ToString().Trim();
+        var category = form["category"].ToString().Trim();
         var appVersion = form["appVersion"].ToString().Trim();
         var pkhexVersion = form["pkhexVersion"].ToString().Trim();
         var userAgent = form["userAgent"].ToString().Trim();
+        // Bug-category structured fields.
+        var actual = form["actual"].ToString().Trim();
+        var steps = form["steps"].ToString().Trim();
+        var expected = form["expected"].ToString().Trim();
+        var reportedSaveSource = form["reportedSaveSource"].ToString().Trim();
+        // Feature / Feedback free-text field.
+        var details = form["details"].ToString().Trim();
         var saveGameName = form["saveGameName"].ToString().Trim();
         var saveRevision = form["saveRevision"].ToString().Trim();
         var saveFileName = form["saveFileName"].ToString().Trim();
         var saveFileSource = form["saveFileSource"].ToString().Trim();
         var saveFileType = form["saveFileType"].ToString().Trim();
 
-        if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(email) || string.IsNullOrWhiteSpace(description))
+        // The primary text is the bug's "what happened" or the feature/feedback details, depending
+        // on category. Older clients (pre-structured) sent a single "description" field — fall back
+        // to it so the endpoint stays backward compatible.
+        var primaryText = category.Equals("Bug", StringComparison.OrdinalIgnoreCase) || string.IsNullOrWhiteSpace(category)
+            ? FirstNonEmpty(actual, form["description"].ToString().Trim())
+            : details;
+
+        if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(email) || string.IsNullOrWhiteSpace(primaryText))
         {
-            return new BadRequestObjectResult(new { error = "name, email, and description are required." });
+            return new BadRequestObjectResult(new { error = "name, email, and a description are required." });
         }
 
-        var shortTitle = description.Length > 72
-            ? $"{description[..72]}…"
-            : description;
-        var issueTitle = $"[Bug] {shortTitle}";
+        var (titlePrefix, issueLabel) = category.ToLowerInvariant() switch
+        {
+            "feature" => ("[Feature]", "enhancement"),
+            "feedback" => ("[Feedback]", "feedback"),
+            _ => ("[Bug]", "bug"),
+        };
+
+        var shortTitle = primaryText.Length > 72
+            ? $"{primaryText[..72]}…"
+            : primaryText;
+        var issueTitle = $"{titlePrefix} {shortTitle}";
 
         var saveFileSection = new StringBuilder();
         if (!string.IsNullOrWhiteSpace(saveGameName) ||
@@ -81,6 +102,32 @@ public class SubmitBugReport(IGitHubService gitHubService, IBlobService blobServ
             }
         }
 
+        var detailsSection = new StringBuilder();
+        if (category.Equals("Feature", StringComparison.OrdinalIgnoreCase) ||
+            category.Equals("Feedback", StringComparison.OrdinalIgnoreCase))
+        {
+            detailsSection.Append($"\n\n## Details\n\n{primaryText}");
+        }
+        else
+        {
+            // Bug: assemble the structured sections, omitting any the reporter left blank.
+            detailsSection.Append($"\n\n## What happened\n\n{primaryText}");
+            if (!string.IsNullOrWhiteSpace(steps))
+            {
+                detailsSection.Append($"\n\n## Steps\n\n{steps}");
+            }
+
+            if (!string.IsNullOrWhiteSpace(expected))
+            {
+                detailsSection.Append($"\n\n## Expected\n\n{expected}");
+            }
+
+            if (!string.IsNullOrWhiteSpace(reportedSaveSource))
+            {
+                detailsSection.Append($"\n\n## Where the save came from\n\n{reportedSaveSource}");
+            }
+        }
+
         var issueBody =
             $"**Reporter:** {name} ({email})\n" +
             $"**App version:** {appVersion}\n" +
@@ -89,13 +136,13 @@ public class SubmitBugReport(IGitHubService gitHubService, IBlobService blobServ
                 : $"**PKHeX.Core version:** {pkhexVersion}\n") +
             $"**User agent:** {userAgent}" +
             saveFileSection +
-            $"\n\n## Description\n\n{description}";
+            detailsSection;
 
         int issueNumber;
         string issueUrl;
         try
         {
-            (issueNumber, issueUrl) = await gitHubService.CreateIssueAsync(issueTitle, issueBody);
+            (issueNumber, issueUrl) = await gitHubService.CreateIssueAsync(issueTitle, issueBody, issueLabel);
             logger.LogInformation("Created GitHub issue #{IssueNumber} for bug report from {Email}", issueNumber, email);
         }
         catch (Exception ex)
@@ -140,6 +187,9 @@ public class SubmitBugReport(IGitHubService gitHubService, IBlobService blobServ
 
         return new ObjectResult(new { issueNumber, issueUrl }) { StatusCode = StatusCodes.Status201Created };
     }
+
+    private static string FirstNonEmpty(params string[] values) =>
+        Array.Find(values, v => !string.IsNullOrWhiteSpace(v)) ?? string.Empty;
 
     private static string SanitizeFileName(string fileName)
     {

--- a/Pkmds.Functions/Services/GitHubService.cs
+++ b/Pkmds.Functions/Services/GitHubService.cs
@@ -16,10 +16,11 @@ public class GitHubService(IConfiguration configuration) : IGitHubService
 
     public async Task<(int IssueNumber, string IssueUrl)> CreateIssueAsync(
         string title,
-        string body)
+        string body,
+        string label)
     {
         var newIssue = new NewIssue(title) { Body = body };
-        newIssue.Labels.Add("bug");
+        newIssue.Labels.Add(label);
 
         var issue = await client.Issue.Create(owner, repo, newIssue);
         return (issue.Number, issue.HtmlUrl);

--- a/Pkmds.Functions/Services/IGitHubService.cs
+++ b/Pkmds.Functions/Services/IGitHubService.cs
@@ -4,7 +4,8 @@ public interface IGitHubService
 {
     Task<(int IssueNumber, string IssueUrl)> CreateIssueAsync(
         string title,
-        string body);
+        string body,
+        string label);
 
     Task AddCommentAsync(
         int issueNumber,

--- a/Pkmds.Rcl/Components/Dialogs/BugReportDialog.razor
+++ b/Pkmds.Rcl/Components/Dialogs/BugReportDialog.razor
@@ -25,6 +25,7 @@
             else
             {
                 <MudSelect @bind-Value="@category"
+                           @bind-Value:after="OnCategoryChanged"
                            Label="What kind of report is this?"
                            Variant="@Variant.Outlined"
                            Dense="true">

--- a/Pkmds.Rcl/Components/Dialogs/BugReportDialog.razor
+++ b/Pkmds.Rcl/Components/Dialogs/BugReportDialog.razor
@@ -8,7 +8,7 @@
                      Style="vertical-align: middle;"/>
             @(CapturedException is not null
                 ? "Report this crash"
-                : "Report a Bug")
+                : "Send a Report")
         </MudText>
     </TitleContent>
     <DialogContent>
@@ -22,29 +22,76 @@
                     email, and any additional context about what you were doing before the crash.
                 </MudAlert>
             }
-            else if (!HasSaveFile)
+            else
             {
-                <MudAlert Severity="@Severity.Info"
-                          Dense="true">
-                    If your issue is that a file failed to load, make sure you are uploading a
-                    <strong>save file</strong> (.sav, .dsv, .bin, etc.) — not a save state (.state)
-                    or ROM file. Save states are emulator snapshots and cannot be edited here.
-                </MudAlert>
+                <MudSelect @bind-Value="@category"
+                           Label="What kind of report is this?"
+                           Variant="@Variant.Outlined"
+                           Dense="true">
+                    <MudSelectItem Value="@BugReportCategory.Bug">Bug — something isn't working</MudSelectItem>
+                    <MudSelectItem Value="@BugReportCategory.Feature">Feature request</MudSelectItem>
+                    <MudSelectItem Value="@BugReportCategory.Feedback">Feedback / other</MudSelectItem>
+                </MudSelect>
             }
-            <MudTextField @bind-Value="@description"
-                          Label="What went wrong?"
-                          Lines="@(CapturedException is not null
-                                     ? 10
-                                     : 5)"
-                          Required="@(CapturedException is null)"
-                          Placeholder="Describe the issue in detail. Include: what you were doing, what happened, and what you expected to happen. Mention the game title and any specific Pokémon or field involved."
-                          HelperText="@(CapturedException is null
-                                          ? $"Minimum {MinDescriptionLength} characters. {description.Length} entered."
-                                          : "Crash details pre-filled. Add any extra context below the divider.")"
-                          Validation="@((string v) => CapturedException is not null || (v?.Length ?? 0) >= MinDescriptionLength
-                                          ? null
-                                          : $"Please provide at least {MinDescriptionLength} characters of detail.")"
-                          Variant="@Variant.Outlined"/>
+
+            @if (CapturedException is not null)
+            {
+                <MudTextField @bind-Value="@actual"
+                              Label="Crash details &amp; what you were doing"
+                              Lines="10"
+                              HelperText="Crash details pre-filled. Add any extra context below the divider."
+                              Variant="@Variant.Outlined"/>
+            }
+            else if (category == BugReportCategory.Bug)
+            {
+                @if (!HasSaveFile)
+                {
+                    <MudAlert Severity="@Severity.Info"
+                              Dense="true">
+                        If your issue is that a file failed to load, make sure you are uploading a
+                        <strong>save file</strong> (.sav, .dsv, .bin, etc.) — not a save state (.state)
+                        or ROM file. Save states are emulator snapshots and cannot be edited here.
+                    </MudAlert>
+                }
+                <MudTextField @bind-Value="@actual"
+                              Label="What actually happened?"
+                              Lines="3"
+                              Required
+                              Placeholder="Describe what went wrong. Include the game title and any specific Pokémon or field involved."
+                              HelperText="@($"Minimum {MinPrimaryLength} characters. {actual.Length} entered.")"
+                              Validation="@PrimaryValidation"
+                              Variant="@Variant.Outlined"/>
+                <MudTextField @bind-Value="@steps"
+                              Label="What did you do? (optional)"
+                              Lines="2"
+                              Placeholder="The steps that led to the problem, so we can reproduce it."
+                              Variant="@Variant.Outlined"/>
+                <MudTextField @bind-Value="@expected"
+                              Label="What did you expect to happen? (optional)"
+                              Lines="2"
+                              Variant="@Variant.Outlined"/>
+                <MudTextField @bind-Value="@reportedSaveSource"
+                              Label="Where did the save come from? (optional)"
+                              Lines="2"
+                              Placeholder="e.g. exported from an emulator (which one?), a real cartridge, or a download — plus the filename and extension."
+                              Variant="@Variant.Outlined"/>
+            }
+            else
+            {
+                <MudTextField @bind-Value="@details"
+                              Label="@(category == BugReportCategory.Feature
+                                         ? "Describe the feature you'd like"
+                                         : "Your feedback")"
+                              Lines="5"
+                              Required
+                              Placeholder="@(category == BugReportCategory.Feature
+                                              ? "What would you like the app to do, and why would it help?"
+                                              : "Tell us what's on your mind.")"
+                              HelperText="@($"Minimum {MinPrimaryLength} characters. {details.Length} entered.")"
+                              Validation="@PrimaryValidation"
+                              Variant="@Variant.Outlined"/>
+            }
+
             <MudTextField @bind-Value="@email"
                           Label="Email"
                           InputType="@InputType.Email"
@@ -57,10 +104,41 @@
                           Label="Name"
                           Required
                           Variant="@Variant.Outlined"/>
-            <MudSwitch @bind-Value="@attachSaveFile"
-                       Label="Attach current save file"
-                       Disabled="@(!HasSaveFile)"
-                       Color="@Color.Primary"/>
+
+            @if (ShowSaveAttach)
+            {
+                <MudSwitch @bind-Value="@attachSaveFile"
+                           Label="Attach current save file"
+                           Disabled="@(!HasSaveFile || uploadedBytes is not null)"
+                           Color="@Color.Primary"/>
+                <MudFileUpload T="IBrowserFile"
+                               Accept=".sav,.dsv,.bin,.dat,.srm,.3ds.sav,.3ds.save"
+                               @bind-Files="uploadedFile"
+                               @bind-Files:after="OnUploadFileChangedAsync">
+                    <CustomContent>
+                        <MudButton Variant="@Variant.Outlined"
+                                   StartIcon="@Icons.Material.Filled.AttachFile"
+                                   OnClick="@context.OpenFilePickerAsync">
+                            Attach a save file manually
+                        </MudButton>
+                    </CustomContent>
+                </MudFileUpload>
+                @if (uploadedFileName is not null)
+                {
+                    <MudStack Row="true"
+                              AlignItems="@AlignItems.Center"
+                              Spacing="1">
+                        <MudIcon Icon="@Icons.Material.Filled.AttachFile"
+                                 Size="@Size.Small"/>
+                        <MudText Typo="@Typo.body2">@uploadedFileName</MudText>
+                        <MudIconButton Icon="@Icons.Material.Filled.Close"
+                                       Size="@Size.Small"
+                                       OnClick="@ClearUploadedFile"
+                                       aria-label="Remove attached file"/>
+                    </MudStack>
+                }
+            }
+
             @if (submitError is not null)
             {
                 <MudAlert Severity="@Severity.Error"
@@ -71,7 +149,7 @@
             <MudText Typo="@Typo.caption"
                      Color="@Color.Secondary">
                 Reports are submitted as GitHub issues to help improve the app.
-                @if (HasSaveFile)
+                @if (ShowSaveAttach && HasSaveFile)
                 {
                     @:Your current save file can be attached to help diagnose the issue.
                 }
@@ -88,7 +166,7 @@
         <MudButton OnClick="@Submit"
                    Color="@Color.Primary"
                    Variant="@Variant.Filled"
-                   Disabled="@(isSubmitting || CapturedException is null && description.Length < MinDescriptionLength || !IsEmailValid || string.IsNullOrWhiteSpace(name))">
+                   Disabled="@(isSubmitting || !IsFormValid)">
             @if (isSubmitting)
             {
                 <MudProgressCircular Size="@Size.Small"

--- a/Pkmds.Rcl/Components/Dialogs/BugReportDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/BugReportDialog.razor.cs
@@ -4,18 +4,52 @@ namespace Pkmds.Rcl.Components.Dialogs;
 
 public partial class BugReportDialog
 {
-    private const int MinDescriptionLength = 30;
+    private const int MinPrimaryLength = 20;
+
+    // Match the Azure Function's MaxSaveFileSizeBytes so we reject oversized attachments up front
+    // instead of silently filing an issue whose save never uploads.
+    private const long MaxAttachmentBytes = 8 * 1024 * 1024;
+
     private static readonly EmailAddressAttribute EmailValidator = new();
+
+    private BugReportCategory category = BugReportCategory.Bug;
     private bool attachSaveFile;
 
-    private string description = string.Empty;
-    private string email = string.Empty;
-    private bool isSubmitting;
-    private string name = string.Empty;
+    // Bug-category fields.
+    private string actual = string.Empty;
+    private string steps = string.Empty;
+    private string expected = string.Empty;
+    private string reportedSaveSource = string.Empty;
 
+    // Feature / Feedback field.
+    private string details = string.Empty;
+
+    private string email = string.Empty;
+    private string name = string.Empty;
+    private bool isSubmitting;
     private string? submitError;
 
+    // Manually-attached file (for the load-failure case where no save is loaded).
+    private IBrowserFile? uploadedFile;
+    private byte[]? uploadedBytes;
+    private string? uploadedFileName;
+
     private bool IsEmailValid => !string.IsNullOrWhiteSpace(email) && EmailValidator.IsValid(email);
+
+    // Save attachment only makes sense for bug reports; feature/feedback don't need a save.
+    private bool ShowSaveAttach => CapturedException is not null || category == BugReportCategory.Bug;
+
+    private string PrimaryText => category == BugReportCategory.Bug ? actual : details;
+
+    private bool IsPrimaryValid =>
+        CapturedException is not null || PrimaryText.Trim().Length >= MinPrimaryLength;
+
+    private bool IsFormValid => IsPrimaryValid && IsEmailValid && !string.IsNullOrWhiteSpace(name);
+
+    private static Func<string, string?> PrimaryValidation => v =>
+        (v?.Trim().Length ?? 0) >= MinPrimaryLength
+            ? null
+            : $"Please provide at least {MinPrimaryLength} characters of detail.";
 
     [CascadingParameter]
     private IMudDialogInstance MudDialog { get; set; } = null!;
@@ -38,20 +72,70 @@ public partial class BugReportDialog
 
         if (CapturedException is not null)
         {
-            description =
+            // Crashes are always bugs, and the structured split doesn't fit a stack dump — route
+            // the pre-filled details through the single "actual" field.
+            category = BugReportCategory.Bug;
+            actual =
                 $"[Crash] {CapturedException.GetType().Name}: {CapturedException.Message}" +
                 $"\n\nStack trace:\n{CapturedException.StackTrace}" +
                 "\n\n--- Additional details ---\nPlease describe what you were doing when this crash occurred:\n\n";
         }
     }
 
+    private async Task OnUploadFileChangedAsync()
+    {
+        if (uploadedFile is null)
+        {
+            return;
+        }
+
+        submitError = null;
+
+        if (uploadedFile.Size > MaxAttachmentBytes)
+        {
+            submitError = "That file is larger than the 8 MB attachment limit and can't be attached.";
+            uploadedFile = null;
+            uploadedBytes = null;
+            uploadedFileName = null;
+            return;
+        }
+
+        try
+        {
+            // Read the bytes immediately — IBrowserFile is only valid while the picker is mounted,
+            // and any later re-render can invalidate the handle.
+            await using var stream = uploadedFile.OpenReadStream(MaxAttachmentBytes);
+            using var ms = new MemoryStream();
+            await stream.CopyToAsync(ms);
+            uploadedBytes = ms.ToArray();
+            uploadedFileName = uploadedFile.Name;
+            // A manual attachment supersedes the current-save toggle.
+            attachSaveFile = false;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Failed to read manually-attached bug report file");
+            submitError = "Couldn't read that file. Please try attaching it again.";
+            uploadedFile = null;
+            uploadedBytes = null;
+            uploadedFileName = null;
+        }
+    }
+
+    private void ClearUploadedFile()
+    {
+        uploadedFile = null;
+        uploadedBytes = null;
+        uploadedFileName = null;
+    }
+
     private void Cancel() => MudDialog.Close(DialogResult.Cancel());
 
     private async Task Submit()
     {
-        if (CapturedException is null && description.Length < MinDescriptionLength)
+        if (!IsPrimaryValid)
         {
-            submitError = $"Please provide a more detailed description (at least {MinDescriptionLength} characters).";
+            submitError = $"Please provide at least {MinPrimaryLength} characters of detail.";
             return;
         }
 
@@ -73,7 +157,9 @@ public partial class BugReportDialog
             string? saveRevision = null;
             string? saveFileSource = null;
             string? saveFileType = null;
-            if (AppState.SaveFile is { } sf)
+
+            // Save diagnostics + attachment only apply to bug reports (and crashes).
+            if (ShowSaveAttach && AppState.SaveFile is { } sf)
             {
                 saveGameName = SaveFileNameDisplay.FriendlyGameName(sf.Version);
                 saveRevision = (sf as ISaveFileRevision)?.SaveRevisionString;
@@ -82,44 +168,58 @@ public partial class BugReportDialog
                 // out of attaching the save bytes, since legality rules diverge between them.
                 saveFileSource = SaveSourceDetector.Detect(sf, AppState.SaveFileName, AppState.ManicEmuSaveContext is not null);
                 saveFileType = sf.GetType().Name;
-                if (attachSaveFile)
+            }
+
+            // A manually-attached file takes precedence; it covers the load-failure case where no
+            // save is loaded at all (the whole reason the user is reporting).
+            if (uploadedBytes is { Length: > 0 })
+            {
+                saveBytes = uploadedBytes;
+                saveFileName = uploadedFileName ?? "save.bin";
+            }
+            else if (ShowSaveAttach && attachSaveFile && AppState.SaveFile is { } currentSave)
+            {
+                var rawBytes = currentSave.Write().ToArray();
+                // If the current save was loaded from a Manic EMU .3ds.sav ZIP, rebuild the
+                // archive so the bug report preserves the wrapper. Without this the submitted
+                // bytes are the bare inner save and we can never diagnose ZIP round-trip
+                // issues from user reports (see issue #750). The attachment name must carry
+                // the compound extension so triagers can see at a glance the payload is a ZIP
+                // and not a bare .sav — a generic save.bin fallback would mask that.
+                //
+                // RebuildZip can throw (InvalidDataException on oversized non-save entries,
+                // corrupt archives, etc.). Getting the report through matters more than the
+                // wrapper, so on failure we fall back to the bare save — the submission
+                // itself must not be blocked by an attach-side issue.
+                if (AppState.ManicEmuSaveContext is { } ctx)
                 {
-                    var rawBytes = sf.Write().ToArray();
-                    // If the current save was loaded from a Manic EMU .3ds.sav ZIP, rebuild the
-                    // archive so the bug report preserves the wrapper. Without this the submitted
-                    // bytes are the bare inner save and we can never diagnose ZIP round-trip
-                    // issues from user reports (see issue #750). The attachment name must carry
-                    // the compound extension so triagers can see at a glance the payload is a ZIP
-                    // and not a bare .sav — a generic save.bin fallback would mask that.
-                    //
-                    // RebuildZip can throw (InvalidDataException on oversized non-save entries,
-                    // corrupt archives, etc.). Getting the report through matters more than the
-                    // wrapper, so on failure we fall back to the bare save — the submission
-                    // itself must not be blocked by an attach-side issue.
-                    if (AppState.ManicEmuSaveContext is { } ctx)
+                    try
                     {
-                        try
-                        {
-                            saveBytes = ManicEmuSaveHelper.RebuildZip(ctx, rawBytes);
-                            saveFileName = ManicEmuSaveHelper.GetExportFileName(AppState.SaveFileName).ExportName;
-                        }
-                        catch (Exception ex)
-                        {
-                            Logger.LogWarning(ex, "Failed to rebuild Manic EMU ZIP for bug report attachment; falling back to bare save");
-                            saveBytes = rawBytes;
-                            saveFileName = AppState.SaveFileName ?? "save.bin";
-                        }
+                        saveBytes = ManicEmuSaveHelper.RebuildZip(ctx, rawBytes);
+                        saveFileName = ManicEmuSaveHelper.GetExportFileName(AppState.SaveFileName).ExportName;
                     }
-                    else
+                    catch (Exception ex)
                     {
+                        Logger.LogWarning(ex, "Failed to rebuild Manic EMU ZIP for bug report attachment; falling back to bare save");
                         saveBytes = rawBytes;
                         saveFileName = AppState.SaveFileName ?? "save.bin";
                     }
                 }
+                else
+                {
+                    saveBytes = rawBytes;
+                    saveFileName = AppState.SaveFileName ?? "save.bin";
+                }
             }
 
             var userAgent = await JSRuntime.InvokeAsync<string>("eval", "navigator.userAgent");
-            var request = new BugReportRequest(name, email, description, AppVersion, userAgent,
+            var isBug = category == BugReportCategory.Bug;
+            var request = new BugReportRequest(name, email, category, AppVersion, userAgent,
+                Actual: isBug ? actual : null,
+                Steps: isBug && !string.IsNullOrWhiteSpace(steps) ? steps : null,
+                Expected: isBug && !string.IsNullOrWhiteSpace(expected) ? expected : null,
+                ReportedSaveSource: isBug && !string.IsNullOrWhiteSpace(reportedSaveSource) ? reportedSaveSource : null,
+                Details: isBug ? null : details,
                 PkhexVersion: IAppState.PkhexVersion,
                 SaveFileBytes: saveBytes, SaveFileName: saveFileName, SaveGameName: saveGameName,
                 SaveRevision: saveRevision, SaveFileSource: saveFileSource,

--- a/Pkmds.Rcl/Components/Dialogs/BugReportDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/BugReportDialog.razor.cs
@@ -41,8 +41,10 @@ public partial class BugReportDialog
 
     private string PrimaryText => category == BugReportCategory.Bug ? actual : details;
 
-    private bool IsPrimaryValid =>
-        CapturedException is not null || PrimaryText.Trim().Length >= MinPrimaryLength;
+    // No crash short-circuit: the crash path pre-fills `actual` with a template well over the
+    // minimum, so crash reports start valid — but if the user clears it, Submit must disable
+    // rather than POST whitespace that the function would reject as missing primary text.
+    private bool IsPrimaryValid => PrimaryText.Trim().Length >= MinPrimaryLength;
 
     private bool IsFormValid => IsPrimaryValid && IsEmailValid && !string.IsNullOrWhiteSpace(name);
 
@@ -129,6 +131,18 @@ public partial class BugReportDialog
         uploadedFileName = null;
     }
 
+    private void OnCategoryChanged()
+    {
+        // Save attachment only applies to bug reports. When the user switches to a category that
+        // hides the attach controls, drop any attached file so it can't be silently uploaded on a
+        // non-bug report (and isn't stranded in the UI with no way to remove it).
+        if (!ShowSaveAttach)
+        {
+            ClearUploadedFile();
+            attachSaveFile = false;
+        }
+    }
+
     private void Cancel() => MudDialog.Close(DialogResult.Cancel());
 
     private async Task Submit()
@@ -171,8 +185,10 @@ public partial class BugReportDialog
             }
 
             // A manually-attached file takes precedence; it covers the load-failure case where no
-            // save is loaded at all (the whole reason the user is reporting).
-            if (uploadedBytes is { Length: > 0 })
+            // save is loaded at all (the whole reason the user is reporting). Gated on
+            // ShowSaveAttach so a file attached as a Bug can't ride along after switching to a
+            // Feature/Feedback report (where the attach controls are hidden).
+            if (ShowSaveAttach && uploadedBytes is { Length: > 0 })
             {
                 saveBytes = uploadedBytes;
                 saveFileName = uploadedFileName ?? "save.bin";

--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor
@@ -94,7 +94,7 @@
                     }
                     <MudMenuItem Icon="@Icons.Material.Filled.BugReport"
                                  OnClick="@ShowBugReportDialog">
-                        Report a Bug
+                        Report a Bug or Feedback
                     </MudMenuItem>
                     <MudMenuItem Icon="@Icons.Material.Filled.Info"
                                  OnClick="@ShowAboutDialog">
@@ -224,7 +224,7 @@
                 <MudDivider/>
                 <MudMenuItem Icon="@Icons.Material.Filled.BugReport"
                              OnClick="@ShowBugReportDialog">
-                    Report a Bug
+                    Report a Bug or Feedback
                 </MudMenuItem>
             </MudMenu>
         }

--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
@@ -302,7 +302,7 @@ public partial class MainLayout : IDisposable
     {
         var parameters = new DialogParameters { { nameof(BugReportDialog.HasSaveFile), AppState.SaveFile is not null }, { nameof(BugReportDialog.AppVersion), AppState.AppVersion ?? string.Empty } };
         var options = await DialogOptionsHelper.BuildAsync(MaxWidth.Small);
-        var dialog = await DialogService.ShowAsync<BugReportDialog>("Report a Bug", parameters, options);
+        var dialog = await DialogService.ShowAsync<BugReportDialog>("Send a Report", parameters, options);
         var result = await dialog.Result;
         if (result is { Data: string issueUrl })
         {

--- a/Pkmds.Rcl/Services/IBugReportService.cs
+++ b/Pkmds.Rcl/Services/IBugReportService.cs
@@ -1,11 +1,26 @@
 namespace Pkmds.Rcl.Services;
 
+public enum BugReportCategory
+{
+    Bug,
+    Feature,
+    Feedback,
+}
+
 public sealed record BugReportRequest(
     string Name,
     string Email,
-    string Description,
+    BugReportCategory Category,
     string AppVersion,
     string UserAgent,
+    // Bug category — structured fields. Actual is the one required field (and also carries the
+    // pre-filled dump on the crash path); the rest are optional context.
+    string? Actual = null,
+    string? Steps = null,
+    string? Expected = null,
+    string? ReportedSaveSource = null,
+    // Feature / Feedback categories — single free-text field.
+    string? Details = null,
     string? PkhexVersion = null,
     byte[]? SaveFileBytes = null,
     string? SaveFileName = null,

--- a/Pkmds.Web/Services/BugReportService.cs
+++ b/Pkmds.Web/Services/BugReportService.cs
@@ -19,9 +19,34 @@ public class BugReportService(IConfiguration configuration, HttpClient httpClien
             using var content = new MultipartFormDataContent();
             content.Add(new StringContent(request.Name), "name");
             content.Add(new StringContent(request.Email), "email");
-            content.Add(new StringContent(request.Description), "description");
+            content.Add(new StringContent(request.Category.ToString()), "category");
             content.Add(new StringContent(request.AppVersion), "appVersion");
             content.Add(new StringContent(request.UserAgent), "userAgent");
+
+            if (!string.IsNullOrWhiteSpace(request.Actual))
+            {
+                content.Add(new StringContent(request.Actual), "actual");
+            }
+
+            if (!string.IsNullOrWhiteSpace(request.Steps))
+            {
+                content.Add(new StringContent(request.Steps), "steps");
+            }
+
+            if (!string.IsNullOrWhiteSpace(request.Expected))
+            {
+                content.Add(new StringContent(request.Expected), "expected");
+            }
+
+            if (!string.IsNullOrWhiteSpace(request.ReportedSaveSource))
+            {
+                content.Add(new StringContent(request.ReportedSaveSource), "reportedSaveSource");
+            }
+
+            if (!string.IsNullOrWhiteSpace(request.Details))
+            {
+                content.Add(new StringContent(request.Details), "details");
+            }
 
             if (!string.IsNullOrWhiteSpace(request.PkhexVersion))
             {


### PR DESCRIPTION
Closes #955.

## What

Replaces the single free-text bug report box with a **category selector** and category-specific fields, and files each report under a matching label instead of always `bug`.

| Category | Title prefix | Label |
|---|---|---|
| Bug | `[Bug]` | `bug` |
| Feature request | `[Feature]` | `enhancement` |
| Feedback / other | `[Feedback]` | `feedback` (created) |

**Bug** reports collect a required *What actually happened?* (min 20 chars) plus optional *steps*, *expected*, and *where the save came from*. **Feature/Feedback** use a single required details box. The Azure Function assembles the issue Markdown from these discrete fields and picks the prefix + label.

## Motivation — #954

#954 ("None of my save files are working") is the poster child: the old placeholder already *asked* for "what you were doing / what happened / what you expected", but one box let the reporter skip all of it, so we hand-wrote five follow-up questions. Separate fields force those specifics. #954 also exposed that there was **no way to attach a save when none ever loaded** — so this adds a manual `MudFileUpload` (bytes read on selection per the `IBrowserFile` lifetime gotcha; oversized files rejected client-side to match the function''s 8 MB cap).

## Backward compatibility

The endpoint still accepts the legacy `description` field and defaults to the Bug category/label, so an old deployed front-end keeps working against the new function.

## Notes
- Crash path keeps its pre-filled single-field behavior, routed as a Bug.
- `feedback` label created on the repo.
- Menu entry renamed "Report a Bug" → "Report a Bug or Feedback".

## Verification
`dotnet format` + `dotnet build -c Debug` clean (0 warnings). Tests left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)