### PR TITLE
chore(deps): bump actions/checkout to 6.0.3 and claude-code-action to 1.0.134

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       # uses GitHub's checkout action to checkout code form the release branch
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
 
       # sets up .NET SDK
       - name: Setup .NET

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,8 +25,8 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: anthropics/claude-code-action@v1.0.133
+      - uses: actions/checkout@v6.0.3
+      - uses: anthropics/claude-code-action@v1.0.134
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--model claude-opus-4-7"
@@ -42,7 +42,7 @@ jobs:
   #     issues: write
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - uses: anthropics/claude-code-action@v1.0.133
+  #     - uses: anthropics/claude-code-action@v1.0.134
   #       with:
   #         claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
   #         settings: |
@@ -95,10 +95,10 @@ jobs:
       discussions: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6.0.3
         with:
           fetch-depth: 0
-      - uses: anthropics/claude-code-action@v1.0.133
+      - uses: anthropics/claude-code-action@v1.0.134
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           settings: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,7 @@ jobs:
           build-mode: none
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6.0.2
+      uses: actions/checkout@v6.0.3
 
       # .NET SDK + WASM workload are only needed for the csharp manual build;
       # the buildless analyses (js, actions, python) skip them.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       # accepted when main contains commits that modify `.github/workflows/*`
       # (the default GITHUB_TOKEN cannot be granted the `workflows` scope).
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
         with:
           persist-credentials: true
           token: ${{ secrets.RELEASE_PAT }}
@@ -105,7 +105,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5.3.0

--- a/.github/workflows/uat.yml
+++ b/.github/workflows/uat.yml
@@ -30,7 +30,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5.3.0
@@ -73,7 +73,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5.3.0


### PR DESCRIPTION
Combines the two open Dependabot PRs into a single PR.

## Changes
- **actions/checkout**: `v6.0.2` → `v6.0.3` — supersedes #963 (applied across `buildandtest.yml`, `claude.yml`, `codeql.yml`, `main.yml`, `uat.yml`)
- **anthropics/claude-code-action**: `v1.0.133` → `v1.0.134` — supersedes #962 (in `claude.yml`)

Both PRs touched `claude.yml`, so they're merged here to avoid a conflict.

Closes #963
Closes #962

🤖 Generated with [Claude Code](https://claude.com/claude-code)