### PR TITLE
Bump dependencies (combined #972, #973, #974)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.3
-      - uses: anthropics/claude-code-action@v1.0.137
+      - uses: anthropics/claude-code-action@v1.0.142
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--model claude-opus-4-7"
@@ -42,7 +42,7 @@ jobs:
   #     issues: write
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - uses: anthropics/claude-code-action@v1.0.137
+  #     - uses: anthropics/claude-code-action@v1.0.142
   #       with:
   #         claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
   #         settings: |
@@ -98,7 +98,7 @@ jobs:
       - uses: actions/checkout@v6.0.3
         with:
           fetch-depth: 0
-      - uses: anthropics/claude-code-action@v1.0.137
+      - uses: anthropics/claude-code-action@v1.0.142
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           settings: |

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,8 +15,8 @@
     <PackageVersion Include="FluentAssertions" Version="8.10.0" />
     <PackageVersion Include="Humanizer" Version="3.0.10" />
     <PackageVersion Include="KristofferStrube.Blazor.FileSystemAccess" Version="4.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.9" />
     <PackageVersion Include="Microsoft.JSInterop" Version="10.0.3" />
     <PackageVersion Include="Microsoft.JSInterop.WebAssembly" Version="10.0.3" />
     <!-- Windows Shell preview-handler PoC only (tools/windows-preview-poc). -->


### PR DESCRIPTION
@
Combines the three open Dependabot PRs into one:

- **#973** — `Microsoft.AspNetCore.Components.WebAssembly` 10.0.8 → 10.0.9
- **#974** — `Microsoft.AspNetCore.Components.WebAssembly.DevServer` 10.0.8 → 10.0.9
- **#972** — `anthropics/claude-code-action` 1.0.137 → 1.0.142

Both NuGet bumps are applied centrally in `Directory.Packages.props`. The GitHub Action bump updates all three references in `.github/workflows/claude.yml` (including the commented-out triage job).

Note: Dependabots #973 also added a spurious `VersionOverride` `PackageReference` to `Pkmds.Rcl.csproj` (which does not reference that package — its only consumed by `Pkmds.Web`). That addition was intentionally omitted as unnecessary.

Verified locally with `dotnet build Pkmds.Web/Pkmds.Web.csproj -c Debug` (0 warnings, 0 errors).

Closes #972
Closes #973
Closes #974

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@