### PR TITLE
Retry boot resources on transient network failure (closes #978)

### DIFF
--- a/Pkmds.Web/wwwroot/index.html
+++ b/Pkmds.Web/wwwroot/index.html
@@ -156,9 +156,13 @@
                     : {cache: 'no-cache'};
                 return fetch(defaultUri, init).then(function (response) {
                     // Retry transient server-side failures; let other statuses
-                    // (incl. 4xx and the SW's synthetic 504) flow through.
+                    // flow through, including 4xx and the SW's synthetic 504.
+                    // 504 is excluded deliberately: service-worker.published.js
+                    // returns it precisely when the network is already down, so
+                    // retrying can't recover and only adds startup delay.
                     if (!response.ok && n < maxAttempts
-                        && (response.status >= 500 || response.status === 429)) {
+                        && ((response.status >= 500 && response.status !== 504)
+                            || response.status === 429)) {
                         return backoffThenRetry(n);
                     }
                     return response;

--- a/Pkmds.Web/wwwroot/index.html
+++ b/Pkmds.Web/wwwroot/index.html
@@ -139,7 +139,57 @@
     })();
 
     if (webassemblySupported) {
-        Blazor.start({});
+        // Retry boot-resource fetches with exponential backoff. Blazor does not
+        // retry boot resources by default, so a single transient network blip
+        // during startup (common on mobile connections, especially first load
+        // before the service worker controls the page) kills the whole
+        // bootstrap and surfaces as `TypeError: Failed to fetch` (issue #978).
+        // Retrying turns that one-off failure into a brief stall instead.
+        function retryFetchBootResource(defaultUri, integrity) {
+            var maxAttempts = 3;
+            var baseDelayMs = 500;
+            function attempt(n) {
+                // Mirror Blazor's default boot fetch: revalidate via no-cache and
+                // enforce SRI when an integrity hash is supplied.
+                var init = integrity
+                    ? {cache: 'no-cache', integrity: integrity}
+                    : {cache: 'no-cache'};
+                return fetch(defaultUri, init).then(function (response) {
+                    // Retry transient server-side failures; let other statuses
+                    // (incl. 4xx and the SW's synthetic 504) flow through.
+                    if (!response.ok && n < maxAttempts
+                        && (response.status >= 500 || response.status === 429)) {
+                        return backoffThenRetry(n);
+                    }
+                    return response;
+                }).catch(function (err) {
+                    // Network-layer rejection ("Failed to fetch") — retry.
+                    if (n >= maxAttempts) throw err;
+                    return backoffThenRetry(n);
+                });
+            }
+            function backoffThenRetry(n) {
+                var delay = baseDelayMs * Math.pow(2, n - 1);
+                return new Promise(function (resolve) {
+                    setTimeout(resolve, delay);
+                }).then(function () {
+                    return attempt(n + 1);
+                });
+            }
+            return attempt(1);
+        }
+
+        Blazor.start({
+            loadBootResource: function (type, name, defaultUri, integrity) {
+                // The 'dotnetjs' module is imported as a script and must be
+                // returned as a URL string, not a Response — leave it to the
+                // default loader.
+                if (type === 'dotnetjs') {
+                    return undefined;
+                }
+                return retryFetchBootResource(defaultUri, integrity);
+            }
+        });
     } else {
         // Resolve against document.baseURI so the redirect lands on the
         // fallback regardless of the current path / query / hash. Coercing


### PR DESCRIPTION
## What

Adds retry-with-backoff to `Blazor.start({ loadBootResource })` in `Pkmds.Web/wwwroot/index.html` so a transient network failure during startup retries instead of crashing the bootstrap.

## Why

Issue #978 is an auto-filed startup crash: `TypeError: Failed to fetch`, Android Chrome, with the stack trace entirely inside the .NET runtime''s `dotnet.<hash>.js` (`fetch_like` → boot). That is a **network-layer rejection of the runtime''s own boot-resource fetch** — a transient mobile-network drop during initial boot, before the service worker controls the page.

This is **distinct from the #915/#916 service-worker bug** (already fixed): that one''s stack was inside the service worker. Because the SW now always resolves `respondWith` (synthetic 504 on failure), a request routed through it can no longer surface as "Failed to fetch" — so #978''s failure happened at the network layer, outside the SW. Blazor does not retry boot resources by default, so one blip kills the whole bootstrap.

## How

- 3 attempts, 500 ms base delay, exponential backoff.
- Retries network-layer rejections plus `5xx`/`429`; lets `4xx` and the SW''s synthetic `504` flow through unchanged.
- Guards `type === ''dotnetjs''` → returns `undefined` (default loader) because that module is imported as a script and must be a URL string, not a `Response`.
- Mirrors Blazor''s default boot fetch (`cache: ''no-cache''` + `integrity` when supplied), so SRI and caching semantics are unchanged.

## Notes / limitations

- Turns a one-off transient boot failure into a brief stall. It cannot fix a fully-offline first load — that is inherent to the network, not something retry can resolve.
- Static HTML/JS change; `dotnet build Pkmds.Web -c Debug` passes clean (0 warnings / 0 errors).

Closes #978.

🤖 Generated with [Claude Code](https://claude.com/claude-code)