### PR TITLE
Gen 2 fixes: Kanto badge toggle, GS Ball wording, RTC clock reset

### DIFF
--- a/Pkmds.Rcl/Components/MainTabPages/BadgesComponent.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/BadgesComponent.razor.cs
@@ -70,7 +70,9 @@ public partial class BadgesComponent : IDisposable
                 break;
 
             case EntityContext.Gen4 when saveFile is SAV4HGSS sav4hgss:
-                badgeFlagInt = sav4hgss.Badges;
+                // HGSS stores 16 badges across two bytes: Johto in Badges (bits 0-7),
+                // Kanto in Badges16 (read into bits 8-15). Mirrors PKHeX SAV_SimpleTrainer.
+                badgeFlagInt = sav4hgss.Badges | (sav4hgss.Badges16 << 8);
                 badgeTotal = 16;
                 break;
 
@@ -155,7 +157,11 @@ public partial class BadgesComponent : IDisposable
                 break;
 
             case EntityContext.Gen4 when saveFile is SAV4HGSS sav4hgss:
-                sav4hgss.Badges = (byte)ToggleBadge(sav4hgss.Badges, badgeIndex);
+                // HGSS stores 16 badges across two bytes: Johto in Badges, Kanto in
+                // Badges16. Toggle on the combined 16-bit value, then split back out.
+                var hgssBadges = ToggleBadge(sav4hgss.Badges | (sav4hgss.Badges16 << 8), badgeIndex);
+                sav4hgss.Badges = (byte)(hgssBadges & 0xFF);
+                sav4hgss.Badges16 = (hgssBadges >> 8) & 0xFF;
                 break;
 
             case EntityContext.Gen5 when saveFile is SAV5BW sav5bw:
@@ -194,7 +200,11 @@ public partial class BadgesComponent : IDisposable
                 break;
         }
 
+        // No (byte) cast on the mask: Kanto badges (indices 8-15 in GSC/HGSS) need
+        // bits 8-15, and (byte)(1 << 8) truncates to 0 — the cause of issue: Kanto
+        // badge toggles silently doing nothing. The caller assigns into the correct
+        // width (SAV2.Badges is a 16-bit int; HGSS splits the result across two bytes).
         static int ToggleBadge(int badges, int badgeIndex) =>
-            badges ^ (byte)(1 << badgeIndex);
+            badges ^ (1 << badgeIndex);
     }
 }

--- a/Pkmds.Rcl/Components/MainTabPages/Trainer/TrainerInfoSav2Section.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/Trainer/TrainerInfoSav2Section.razor
@@ -1,21 +1,36 @@
 @inherits BasePkmdsComponent
 
 @* Gen 2 (GSC) trainer misc/events. Renders inside the parent .form-grid; sub-sections
-   are separated by full-width .form-section-header rows. Mirrors PKHeX WinForms SAV_Misc2.
-   The parent only renders this for Crystal today (the GS Ball event is Crystal-exclusive).
-   When GSC-wide features (#341) are added, widen the parent gate to all SAV2 and gate any
-   Crystal-only sub-sections here. *@
+   are separated by full-width .form-section-header rows. Mirrors PKHeX WinForms SAV_Misc2
+   and the SAVEditor RTC reset prompt. The RTC clock reset applies to all GSC; the GS Ball
+   event is Crystal-exclusive, so its sub-section is gated to Crystal below. *@
 
-<div class="form-section-header">Events</div>
+<div class="form-section-header">Clock</div>
 
 <div class="form-field">
-    <MudTooltip Text="Unlocks the Crystal GS Ball event: collect the GS Ball at a Pokémon Center, then place it on the Ilex Forest shrine to encounter Celebi.">
+    <MudTooltip Text="Flags the in-game clock (RTC) as needing to be set. The game will prompt you to set the time the next time you load this save. On non-Japanese saves the reset password is shown first.">
         <MudButton Variant="@Variant.Filled"
                    Color="@Color.Primary"
-                   StartIcon="@Icons.Material.Filled.CardGiftcard"
-                   Disabled="@SaveFile.IsEnabledGSBallMobileEvent"
-                   OnClick="@EnableGSBallEvent">
-            @(SaveFile.IsEnabledGSBallMobileEvent ? "GS Ball Event Enabled" : "Enable GS Ball Event")
+                   StartIcon="@Icons.Material.Filled.Schedule"
+                   OnClick="@ResetRtc">
+            Reset Clock (RTC)
         </MudButton>
     </MudTooltip>
 </div>
+
+@if (SaveFile.Version is GameVersion.C)
+{
+    <div class="form-section-header">Events</div>
+
+    <div class="form-field">
+        <MudTooltip Text="Unlocks the Crystal GS Ball event: collect the GS Ball from the woman at the Goldenrod City Pokémon Center, take it to Kurt in Azalea Town, then place it on the Ilex Forest shrine to encounter Celebi.">
+            <MudButton Variant="@Variant.Filled"
+                       Color="@Color.Primary"
+                       StartIcon="@Icons.Material.Filled.CardGiftcard"
+                       Disabled="@SaveFile.IsEnabledGSBallMobileEvent"
+                       OnClick="@EnableGSBallEvent">
+                @(SaveFile.IsEnabledGSBallMobileEvent ? "GS Ball Event Enabled" : "Enable GS Ball Event")
+            </MudButton>
+        </MudTooltip>
+    </div>
+}

--- a/Pkmds.Rcl/Components/MainTabPages/Trainer/TrainerInfoSav2Section.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/Trainer/TrainerInfoSav2Section.razor.cs
@@ -6,6 +6,36 @@ public partial class TrainerInfoSav2Section
     [EditorRequired]
     public SAV2 SaveFile { get; set; } = null!;
 
+    private async Task ResetRtc()
+    {
+        // Mirrors PKHeX's SAVEditor Gen 2 RTC reset prompt: show the reset password
+        // (non-Japanese saves only — Japanese GSC don't surface one) then confirm.
+        var message = SaveFile.Japanese
+            ? "Would you like to reset the in-game clock (RTC)?"
+            : $"RTC Reset Password: {SaveFile.ResetKey:00000}{Environment.NewLine}{Environment.NewLine}" +
+              "Would you like to reset the in-game clock (RTC)?";
+
+        var confirmed = await DialogService.ShowMessageBoxAsync(
+            "Reset Clock",
+            message,
+            yesText: "Reset",
+            cancelText: "Cancel");
+
+        if (confirmed is not true)
+        {
+            return;
+        }
+
+        // Sets the "Time Not Set" flag directly (no property setter), so mark the save
+        // edited explicitly. The game re-prompts for the clock on next boot.
+        SaveFile.ResetRTC();
+        SaveFile.State.Edited = true;
+
+        Snackbar.Add(
+            "The in-game clock has been flagged for reset. The game will prompt you to set the time the next time you load this save.",
+            Severity.Success);
+    }
+
     private void EnableGSBallEvent()
     {
         if (SaveFile.IsEnabledGSBallMobileEvent)
@@ -20,7 +50,8 @@ public partial class TrainerInfoSav2Section
         SaveFile.State.Edited = true;
 
         Snackbar.Add(
-            "GS Ball event enabled. Collect the GS Ball at any Pokémon Center, then place it on the Ilex Forest shrine to encounter Celebi.",
+            "GS Ball event enabled. Collect the GS Ball from the woman at the Goldenrod City Pokémon Center, " +
+            "take it to Kurt in Azalea Town, then place it on the Ilex Forest shrine to encounter Celebi.",
             Severity.Success);
     }
 }

--- a/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor
@@ -372,11 +372,11 @@
             <TrainerInfoSav9ZaSection SaveFile="@za9Gen9"/>
         }
 
-        @* Crystal-only for now (the only Gen 2 feature here, the GS Ball event, is
-           Crystal-exclusive). When GSC-wide features are added, widen this to `is SAV2`. *@
-        @if (saveFile is SAV2 { Version: GameVersion.C } sav2Crystal)
+        @* All Gen 2 (GSC): the RTC clock reset applies to every GSC save. The GS Ball
+           event sub-section inside is gated to Crystal, where it is exclusive. *@
+        @if (saveFile is SAV2 sav2Misc)
         {
-            <TrainerInfoSav2Section SaveFile="@sav2Crystal"/>
+            <TrainerInfoSav2Section SaveFile="@sav2Misc"/>
         }
 
         @if (saveFile is SAV6 sav6Sayings)

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "allowPrerelease": false,
     "rollForward": "latestMinor",
-    "version": "10.0.300"
+    "version": "10.0.301"
   }
 }


### PR DESCRIPTION
Bundles three Gen 2 (GSC) fixes/features. Verified in the UAT preview + browser.

## Changes

**Fix Kanto badge toggling (Gen 2 + HGSS)** — `Closes #984`
`BadgesComponent.ToggleBadge` masked with `(byte)(1 << badgeIndex)`; Kanto badges use bit indices 8-15 and `(byte)(1 << 8)` truncates to 0, so every Kanto toggle was a silent no-op. Dropped the cast. `SAV2.Badges` is a single 16-bit int (Johto low / Kanto high), so this is the whole fix for G/S/C. HGSS stores the 16 badges across two bytes (`Badges` + `Badges16`); the read/write now combines and splits them, matching PKHeX `SAV_SimpleTrainer`. Verified on a real Crystal save (write+reload preserves the Johto byte, checksums valid).

**Correct GS Ball event wording** — `Closes #982`
Tooltip and snackbar said the ball is collected at "a"/"any" Pokémon Center. It comes specifically from the woman at the **Goldenrod City** Pokémon Center; you then take it to **Kurt in Azalea Town** before the Ilex Forest shrine. Both strings corrected. (Confirmed against the pokecrystal disassembly: the event scripts gate on the `GS_BALL_AVAILABLE` mobile-event state, not on Hall of Fame / Elite Four.)

**Add Gen 2 clock (RTC) reset** — `Closes #983`
New "Reset Clock (RTC)" button for all GSC saves, mirroring PKHeX `SAVEditor`: shows the reset password (`SAV2.ResetKey`, non-Japanese saves only), confirms, then calls `SAV2.ResetRTC()`. Widened the Gen 2 trainer section from Crystal-only to all `SAV2`; the GS Ball sub-section stays gated to Crystal. (The #983 GS-Ball "instant vs wait" request needs no code — the existing button already produces the original wait-a-day event; PKHeX exposes no flag to skip Kurt.)

## UAT test checklist
- [x] **RTC reset**: load a GSC save → Trainer → "Reset Clock (RTC)" → password matches PKHeX `ResetKey`; reset flags the clock for re-prompt on next boot.
- [x] **Kanto badges**: G/S/C and HGSS — bottom-row (Kanto) badges now toggle and persist.
- [x] **GS Ball tooltip**: Crystal — corrected wording shown.

Closes #982
Closes #983
Closes #984

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>