### PR TITLE
Add TSV (Trainer Shiny Value) readout to Trainer Info tab (closes #41)

### DIFF
--- a/PKHEX_PARITY_ROADMAP.md
+++ b/PKHEX_PARITY_ROADMAP.md
@@ -1132,7 +1132,7 @@ Three parallel tracks — wiki content authoring, in-app help links (code), and 
 - [x] Gen 6 Trainer Card Sayings viewer — read-only display (free-form text is view-only to avoid abuse vectors)
 - [x] Gen 3 Game Corner Joyful Records editor — closes #870
 - [x] Gen 4 HGSS NSparkle (National Park Sparkle) flag
-- [x] TSV (Trainer Shiny Value) read-only readout — Gen 3+; mirrors PKHeX's `TrainerID.GetTSV` (`(SID16 ^ TID16) >> 3` for Gen 1–5, `>> 4` for Gen 6+)
+- [x] TSV (Trainer Shiny Value) read-only readout — Gen 3+; mirrors PKHeX's `TrainerID.GetTSV` (`(SID16 ^ TID16) >> 3` for Gen 3–5, `>> 4` for Gen 6+)
 - [ ] Add trainer memo/notes
 
 ### 6.2 Box Viewer Enhancements

--- a/PKHEX_PARITY_ROADMAP.md
+++ b/PKHEX_PARITY_ROADMAP.md
@@ -1132,6 +1132,7 @@ Three parallel tracks — wiki content authoring, in-app help links (code), and 
 - [x] Gen 6 Trainer Card Sayings viewer — read-only display (free-form text is view-only to avoid abuse vectors)
 - [x] Gen 3 Game Corner Joyful Records editor — closes #870
 - [x] Gen 4 HGSS NSparkle (National Park Sparkle) flag
+- [x] TSV (Trainer Shiny Value) read-only readout — Gen 3+; mirrors PKHeX's `TrainerID.GetTSV` (`(SID16 ^ TID16) >> 3` for Gen 1–5, `>> 4` for Gen 6+)
 - [ ] Add trainer memo/notes
 
 ### 6.2 Box Viewer Enhancements

--- a/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor
@@ -85,6 +85,17 @@
                 break;
         }
 
+        @if (saveGeneration >= 3 && GetTrainerShinyValue(saveFile) is { } tsv)
+        {
+            <div class="form-field">
+                <MudTextField Label="TSV (Shiny Value)"
+                              Variant="@Variant.Outlined"
+                              Value="@($"{tsv:D4}")"
+                              ReadOnly="true"
+                              HelperText="Trainer Shiny Value (read-only)"/>
+            </div>
+        }
+
         @if (saveGeneration >= 2)
         {
             <div class="form-field">

--- a/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor.cs
@@ -369,7 +369,9 @@ public partial class TrainerInfoTab : IDisposable
     /// Trainer Shiny Value — the read-only value PKHeX surfaces on its TID/SID control.
     /// Only meaningful for Gen 3+, where a Secret ID exists; returns <see langword="null" />
     /// otherwise. Mirrors PKHeX's <c>TrainerID.GetTSV</c>: the xor of the 16-bit IDs shifted
-    /// right by 3 for Gen 1–5 (8-value shiny range) and by 4 for Gen 6+ (16-value range).
+    /// right by 3 for Gen 3–5 (8-value shiny range) and by 4 for Gen 6+ (16-value range).
+    /// (PKHeX's <c>GetTSV</c> uses the same shift for all of Gen 1–5, but the Gen 1–2 case
+    /// is unreachable here because of the early return above.)
     /// </summary>
     private static uint? GetTrainerShinyValue(SaveFile saveFile)
     {

--- a/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TrainerInfoTab.razor.cs
@@ -365,6 +365,23 @@ public partial class TrainerInfoTab : IDisposable
         // Gen 3 does not store OT gender on the PKM, so skip the gender check for those.
         (pkm.Format <= 3 || pkm.OriginalTrainerGender == gender);
 
+    /// <summary>
+    /// Trainer Shiny Value — the read-only value PKHeX surfaces on its TID/SID control.
+    /// Only meaningful for Gen 3+, where a Secret ID exists; returns <see langword="null" />
+    /// otherwise. Mirrors PKHeX's <c>TrainerID.GetTSV</c>: the xor of the 16-bit IDs shifted
+    /// right by 3 for Gen 1–5 (8-value shiny range) and by 4 for Gen 6+ (16-value range).
+    /// </summary>
+    private static uint? GetTrainerShinyValue(SaveFile saveFile)
+    {
+        if (saveFile.Generation < 3)
+        {
+            return null;
+        }
+
+        var xor = (uint)(saveFile.SID16 ^ saveFile.TID16);
+        return saveFile.Generation <= 5 ? xor >> 3 : xor >> 4;
+    }
+
     private static string FormatPlaytime(SaveFile saveFile) =>
         $"{saveFile.PlayedHours}:{saveFile.PlayedMinutes:D2}:{saveFile.PlayedSeconds:D2}";
 


### PR DESCRIPTION
## Summary

Adds the final missing piece of the issue #41 trainer-info implementation plan: a **read-only TSV (Trainer Shiny Value) readout** on the Trainer Info tab, displayed next to the TID/SID fields.

The rest of #41's plan (name, gender, playtime, language, TID/SID format handling, adventure-start, Game Sync ID, per-gen currencies, rival names, trainer card dialogs, etc.) already shipped across earlier PRs (#570, #574, #584, #587, #872). This closes out the umbrella request.

## Details

- New `GetTrainerShinyValue(SaveFile)` helper in `TrainerInfoTab.razor.cs`, mirroring PKHeX's `TrainerID.GetTSV`:
  - `(SID16 ^ TID16) >> 3` for Gen 1–5 (8-value shiny range)
  - `(SID16 ^ TID16) >> 4` for Gen 6+ (16-value range)
- Gated to **Gen 3+** (where a Secret ID exists); returns `null` and the field is hidden otherwise.
- Read-only `MudTextField` labeled "TSV (Shiny Value)", shown as a 4-digit value. Recomputes on each render, so it updates live as TID/SID change.

## Verification

- `dotnet format --verify-no-changes` — clean
- `dotnet build Pkmds.Web -c Debug` — 0 warnings, 0 errors (Debug treats warnings as errors)

## Notes

The broader **trainer appearance / avatar editor** remains tracked separately in #873 (v1 spec already written there). The only other open §6.1 item is an unscoped "trainer memo/notes" idea.

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)
