### PR TITLE
Retry dotnetjs boot resource; add reload hint for network startup errors

### DIFF
--- a/Pkmds.Web/wwwroot/index.html
+++ b/Pkmds.Web/wwwroot/index.html
@@ -185,11 +185,15 @@
 
         Blazor.start({
             loadBootResource: function (type, name, defaultUri, integrity) {
-                // The 'dotnetjs' module is imported as a script and must be
-                // returned as a URL string, not a Response — leave it to the
-                // default loader.
                 if (type === 'dotnetjs') {
-                    return undefined;
+                    // dotnetjs must be returned as a URL string (or Promise<string>),
+                    // not a Response. Pre-fetch with retry to give transient failures
+                    // a chance to recover; discard the Response and return the URL
+                    // for Blazor's script import. If all retries fail the rejected
+                    // Promise propagates to Blazor's bootstrap (issue #991).
+                    return retryFetchBootResource(defaultUri, null).then(function () {
+                        return defaultUri;
+                    });
                 }
                 return retryFetchBootResource(defaultUri, integrity);
             }

--- a/Pkmds.Web/wwwroot/index.html
+++ b/Pkmds.Web/wwwroot/index.html
@@ -187,11 +187,15 @@
             loadBootResource: function (type, name, defaultUri, integrity) {
                 if (type === 'dotnetjs') {
                     // dotnetjs must be returned as a URL string (or Promise<string>),
-                    // not a Response. Pre-fetch with retry to give transient failures
-                    // a chance to recover; discard the Response and return the URL
-                    // for Blazor's script import. If all retries fail the rejected
-                    // Promise propagates to Blazor's bootstrap (issue #991).
-                    return retryFetchBootResource(defaultUri, null).then(function () {
+                    // not a Response. Pre-fetch with retry (and SRI when integrity is
+                    // supplied) so a transient failure gets multiple attempts; reject
+                    // explicitly on non-OK so bootstrap fails with a clear error rather
+                    // than silently returning the URL and letting the script import fail
+                    // generically later (issue #991).
+                    return retryFetchBootResource(defaultUri, integrity).then(function (response) {
+                        if (!response.ok) {
+                            throw new TypeError('dotnetjs load failed: HTTP ' + response.status);
+                        }
                         return defaultUri;
                     });
                 }

--- a/Pkmds.Web/wwwroot/js/error-reporting.js
+++ b/Pkmds.Web/wwwroot/js/error-reporting.js
@@ -82,6 +82,21 @@
             ui.insertBefore(details, msgEl.nextSibling);
         }
 
+        // For network-layer startup failures, add a reload hint before the
+        // button row so users know what to try before filing a bug.
+        var isNetworkError = (
+            message === 'Load failed' ||
+            message.indexOf('Failed to fetch') !== -1 ||
+            message.indexOf('NetworkError') !== -1
+        );
+        if (isNetworkError) {
+            var hint = document.createElement('p');
+            hint.style.cssText = 'margin: 0.4rem 0 0; font-size: 0.8rem; color: #555;';
+            hint.textContent = 'This is usually a temporary network problem or an app update in progress — reloading typically fixes it.';
+            var insertHintAfter = stack ? details : msgEl;
+            ui.insertBefore(hint, insertHintAfter.nextSibling);
+        }
+
         // Button row.
         var row = document.createElement('div');
         row.style.cssText = 'margin-top: 0.5rem; display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center;';

--- a/Pkmds.Web/wwwroot/js/error-reporting.js
+++ b/Pkmds.Web/wwwroot/js/error-reporting.js
@@ -93,11 +93,10 @@
             var hint = document.createElement('p');
             hint.style.cssText = 'margin: 0.4rem 0 0; font-size: 0.8rem; color: #555;';
             hint.textContent = 'This is usually a temporary network problem or an app update in progress — reloading typically fixes it.';
-            var insertHintAfter = stack ? details : msgEl;
-            ui.insertBefore(hint, insertHintAfter.nextSibling);
+            ui.insertBefore(hint, (stack ? details : msgEl).nextSibling);
         }
 
-        // Button row.
+        // Button row — anchor after hint when present (var-hoisted as undefined otherwise).
         var row = document.createElement('div');
         row.style.cssText = 'margin-top: 0.5rem; display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center;';
 
@@ -135,7 +134,7 @@
         row.appendChild(copyBtn);
         row.appendChild(reportLink);
 
-        var insertAfter = stack ? details : msgEl;
+        var insertAfter = hint || (stack ? details : msgEl);
         ui.insertBefore(row, insertAfter.nextSibling);
     }
 


### PR DESCRIPTION
## Summary

- **`index.html`**: `loadBootResource` now pre-fetches `dotnetjs` with the same 3-attempt exponential-backoff retry used for all other boot resources. It returns `Promise<string>` so Blazor uses the URL once the fetch succeeds. Previously this type returned `undefined` (Blazor default — no retry), so a single network hiccup loading `dotnet.*.js` would permanently crash startup with no recovery.
- **`error-reporting.js`**: When the startup error message is `Load failed`, `Failed to fetch`, or `NetworkError`, the error bar now shows a brief "reloading typically fixes it" hint before the bug-report button, reducing alarmed reports from users hit by transient failures.

## Background

A cluster of startup-failure reports (#978, #989, #990, #991) arrived after five production deployments landed on June 10–11. The retry-with-backoff added in #979 covered most boot resources but explicitly excluded `dotnetjs`, leaving the runtime script itself with zero retry. On iOS Safari, a failed script load surfaces as `TypeError: Load failed` with no stack trace — exactly what #991 observed (fail on load, fail on reload, succeed on fresh navigation after the SW settled).

## Closes

Closes #991. See also #990.

## Test plan

- [ ] Build passes (`dotnet build Pkmds.slnx -c Debug`)
- [ ] Throttle network to "Slow 3G" in DevTools, reload pkmds.app — app still boots (retries kick in and succeed once throttle is released mid-boot)
- [ ] Simulate a startup fetch failure and confirm the error bar shows the "reloading typically fixes it" hint for `Load failed` / `Failed to fetch` messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)