### PR TITLE
Fix startup crash: dotnetjs loader must return a string, not a Promise (#994)

### DIFF
--- a/Pkmds.Web/wwwroot/index.html
+++ b/Pkmds.Web/wwwroot/index.html
@@ -185,19 +185,15 @@
 
         Blazor.start({
             loadBootResource: function (type, name, defaultUri, integrity) {
+                // The 'dotnetjs' module is imported as a script and must be
+                // returned as a synchronous URI string — Blazor rejects a
+                // Promise here ("For a dotnetjs resource, custom loaders must
+                // supply a URI string"), which aborts startup entirely
+                // (issues #991, #994). Leave it to the default loader; the
+                // retry-on-transient-failure below still covers every other
+                // boot resource (.wasm/.dll/etc.).
                 if (type === 'dotnetjs') {
-                    // dotnetjs must be returned as a URL string (or Promise<string>),
-                    // not a Response. Pre-fetch with retry (and SRI when integrity is
-                    // supplied) so a transient failure gets multiple attempts; reject
-                    // explicitly on non-OK so bootstrap fails with a clear error rather
-                    // than silently returning the URL and letting the script import fail
-                    // generically later (issue #991).
-                    return retryFetchBootResource(defaultUri, integrity).then(function (response) {
-                        if (!response.ok) {
-                            throw new TypeError('dotnetjs load failed: HTTP ' + response.status);
-                        }
-                        return defaultUri;
-                    });
+                    return undefined;
                 }
                 return retryFetchBootResource(defaultUri, integrity);
             }


### PR DESCRIPTION
## Problem

PKMDS fails to load for **all users** (issue #994, Reddit reports). Console shows:

```
Failed to start platform. Reason: For a dotnetjs resource, custom loaders must supply a URI string.
Failed to load resource: 404 () /_framework/dotnet.js
```

## Root cause

PR #992 (issues #991/#990) changed the `dotnetjs` branch of `loadBootResource` to pre-fetch the resource and return a **`Promise<string>`**. Blazor does **not** accept a Promise for the `dotnetjs` resource type — it requires a synchronous URI string. The invalid return value aborts the platform start, and Blazor then falls back to the unfingerprinted `/_framework/dotnet.js`, which 404s.

This is a regression introduced today; before #991/#992 the `dotnetjs` branch returned `undefined` (default loader) and worked correctly.

## Fix

Restore the `dotnetjs` branch to `return undefined`. The retry-with-backoff logic still covers every other boot resource (`.wasm`/`.dll`/etc.), so the #978 transient-network-failure handling is preserved.

Closes #994.

🤖 Generated with [Claude Code](https://claude.com/claude-code)