### PR TITLE
Fix crash loading ROM-hack saves; block them at import (#1003)

### DIFF
--- a/Pkmds.Core/Extensions/SaveFileExtensions.cs
+++ b/Pkmds.Core/Extensions/SaveFileExtensions.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Pkmds.Core.Extensions;
 
 /// <summary>
@@ -6,6 +8,41 @@ namespace Pkmds.Core.Extensions;
 public static class SaveFileExtensions
 {
     private const int PartySize = 6;
+
+    /// <summary>
+    /// Validates that a freshly parsed save satisfies the core invariants the editor relies on,
+    /// returning <see langword="false"/> with a user-facing <paramref name="reason"/> for saves that
+    /// parse structurally but are unsafe to edit. This catches two cases the bare
+    /// <see cref="SaveState.Exportable"/> flag misses:
+    /// <list type="bullet">
+    /// <item>Unsupported / unexportable formats (the existing <see cref="SaveState.Exportable"/> check).</item>
+    /// <item>ROM hacks that reuse a vanilla save layout but corrupt fixed-size invariants. The
+    /// SAV3-based Pokémon Unbound, for example, is detected as a valid <c>SAV3E</c>
+    /// (<see cref="SaveState.Exportable"/> is <see langword="true"/>) yet writes an out-of-range value
+    /// into the single-byte party-count field; reading the phantom party slots throws and crashes
+    /// the editor (issue #1003).</item>
+    /// </list>
+    /// </summary>
+    public static bool IsSupportedForEditing(this SaveFile sav, [NotNullWhen(false)] out string? reason)
+    {
+        if (!sav.State.Exportable)
+        {
+            reason = "This save file cannot be loaded — it may be from an unsupported ROM hack or format.";
+            return false;
+        }
+
+        // A legitimate party can never exceed the 6-slot physical maximum (vanilla saves store the
+        // count in a field whose value is always 0–6). A larger value means the save isn't laid out
+        // the way the editor expects — in practice a ROM hack — and every read past slot 6 throws.
+        if (sav.PartyCount > PartySize)
+        {
+            reason = "This save file appears to be from an unsupported ROM hack — its party data is not in the expected format, so it can't be edited safely.";
+            return false;
+        }
+
+        reason = null;
+        return true;
+    }
 
     /// <summary>
     /// Rewrites the party so all non-blank members are contiguous at indices 0..N-1, with the

--- a/Pkmds.Core/Extensions/SaveFileExtensions.cs
+++ b/Pkmds.Core/Extensions/SaveFileExtensions.cs
@@ -76,21 +76,25 @@ public static class SaveFileExtensions
     }
 
     /// <summary>
-    /// The number of leading party slots that can actually be read without throwing. For most
-    /// saves this equals <see cref="SaveFile.PartyCount"/>. For LGPE (SAV7b) the stored count can
-    /// exceed the number of populated pointers, so this walks the reported slots and stops at the
-    /// first one that is unreadable or empty.
+    /// The number of leading party slots that can actually be read without throwing. The stored
+    /// party count is never trusted as-is: it is clamped to the 6-slot physical maximum first.
+    /// On mainline saves the count cannot legitimately exceed 6, but ROM hacks (e.g. SAV3-based
+    /// Pokémon Unbound) write garbage into the single-byte party-count field, which would otherwise
+    /// drive <see cref="SaveFile.GetPartySlotAtIndex"/> past the party buffer and throw
+    /// <see cref="ArgumentOutOfRangeException"/> (issue #1003). For LGPE (SAV7b) the stored count can
+    /// also exceed the number of populated pointers, so there this additionally walks the reported
+    /// slots and stops at the first one that is unreadable or empty (issues #942–#948).
     /// </summary>
     public static int GetSafePartyCount(this SaveFile sav)
     {
-        var reported = sav.PartyCount;
+        var reported = Math.Min(sav.PartyCount, PartySize);
         if (sav is not SAV7b)
         {
             return reported;
         }
 
         var count = 0;
-        for (var i = 0; i < reported && i < PartySize; i++)
+        for (var i = 0; i < reported; i++)
         {
             if (sav.TryGetPartySlot(i) is not { Species: > 0 })
             {

--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
@@ -435,11 +435,10 @@ public partial class MainLayout : IDisposable
 
             if (SaveFileLoader.TryLoad(data, fileName, out var saveFile, out var manicContext))
             {
-                if (!saveFile.State.Exportable)
+                if (!saveFile.IsSupportedForEditing(out var unsupportedReason))
                 {
-                    Logger.LogWarning("Backup save file is not exportable (unsupported format/ROM hack): {FileName}", fileName);
-                    await DialogService.ShowMessageBoxAsync("Unsupported save file",
-                        "This backup cannot be restored — it may be from an unsupported ROM hack or format.");
+                    Logger.LogWarning("Backup save file rejected (unsupported format/ROM hack): {FileName}", fileName);
+                    await DialogService.ShowMessageBoxAsync("Unsupported save file", unsupportedReason);
                     AppState.ShowProgressIndicator = false;
                     return;
                 }
@@ -563,11 +562,10 @@ public partial class MainLayout : IDisposable
             // raw bytes that Manic EMU rejects on re-import (see issue #750).
             if (SaveFileLoader.TryLoad(data, selectedFile.Name, out var saveFile, out var manicContext))
             {
-                if (!saveFile.State.Exportable)
+                if (!saveFile.IsSupportedForEditing(out var unsupportedReason))
                 {
-                    Logger.LogWarning("Save file is not exportable (unsupported format/ROM hack): {FileName}", selectedFile.Name);
-                    await DialogService.ShowMessageBoxAsync("Unsupported save file",
-                        "This save file cannot be loaded — it may be from an unsupported ROM hack or format.");
+                    Logger.LogWarning("Save file rejected (unsupported format/ROM hack): {FileName}", selectedFile.Name);
+                    await DialogService.ShowMessageBoxAsync("Unsupported save file", unsupportedReason);
                     AppState.ShowProgressIndicator = false;
                     return;
                 }

--- a/Pkmds.Rcl/Components/PokemonStorageComponent.razor.cs
+++ b/Pkmds.Rcl/Components/PokemonStorageComponent.razor.cs
@@ -136,9 +136,13 @@ public partial class PokemonStorageComponent : RefreshAwareComponent
             return false;
         }
 
-        for (var i = 0; i < sav.PartyCount; i++)
+        // Don't trust the reported party count: ROM hacks (e.g. SAV3-based Pokémon Unbound) write
+        // garbage into the single-byte party-count field, which drives GetPartySlotAtIndex past the
+        // party buffer and throws (issue #1003). GetSafePartyCount clamps to the 6-slot maximum.
+        var partyCount = sav.GetSafePartyCount();
+        for (var i = 0; i < partyCount; i++)
         {
-            if (sav.GetPartySlotAtIndex(i).Species != 0)
+            if (sav.TryGetPartySlot(i) is { Species: > 0 })
             {
                 return true;
             }

--- a/Pkmds.Rcl/Services/EmbeddedHostBridge.cs
+++ b/Pkmds.Rcl/Services/EmbeddedHostBridge.cs
@@ -96,9 +96,9 @@ public sealed partial class EmbeddedHostBridge
                 return false;
             }
 
-            if (!saveFile.State.Exportable)
+            if (!saveFile.IsSupportedForEditing(out var unsupportedReason))
             {
-                _logger.LogWarning("Host save load rejected: not exportable ({FileName})", fileName);
+                _logger.LogWarning("Host save load rejected ({FileName}): {Reason}", fileName, unsupportedReason);
                 return false;
             }
 

--- a/Pkmds.Tests/RomHackSaveSafetyTests.cs
+++ b/Pkmds.Tests/RomHackSaveSafetyTests.cs
@@ -1,0 +1,72 @@
+namespace Pkmds.Tests;
+
+/// <summary>
+/// Regression tests for ROM-hack saves that reuse a vanilla layout but corrupt fixed-size
+/// invariants. The SAV3-based Pokémon Unbound is detected as a valid <c>SAV3E</c>
+/// (<see cref="SaveState.Exportable"/> is <see langword="true"/>) yet writes an out-of-range value
+/// into the single-byte party-count field at <c>0x234</c>. The party buffer only holds 6 slots, so
+/// reading any reported slot past the sixth throws <see cref="ArgumentOutOfRangeException"/> — which
+/// crashed the storage component on load (issue #1003). The save must be rejected at import, and the
+/// safe helpers must tolerate the over-reported count if they are reached anyway.
+/// </summary>
+public class RomHackSaveSafetyTests
+{
+    // The real Pokémon Unbound save from issue #1003 reported a party count of 187.
+    private const int OverReportedPartyCount = 187;
+
+    private static SAV3E CreateEmeraldWithOverReportedParty(int reportedCount)
+    {
+        var sav = new SAV3E();
+        sav.LargeBlock.PartyCount = (byte)reportedCount;
+        return sav;
+    }
+
+    [Fact]
+    public void RawGetPartySlotAtIndex_PastBuffer_Throws()
+    {
+        // Documents the underlying PKHeX behavior the import guard and safe helpers shield against.
+        var sav = CreateEmeraldWithOverReportedParty(OverReportedPartyCount);
+
+        Action act = () => sav.GetPartySlotAtIndex(6);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void IsSupportedForEditing_OverReportedParty_RejectsWithReason()
+    {
+        var sav = CreateEmeraldWithOverReportedParty(OverReportedPartyCount);
+
+        var supported = sav.IsSupportedForEditing(out var reason);
+
+        supported.Should().BeFalse();
+        reason.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void IsSupportedForEditing_VanillaSave_IsSupported()
+    {
+        var sav = new SAV3E();
+
+        var supported = sav.IsSupportedForEditing(out var reason);
+
+        supported.Should().BeTrue();
+        reason.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetSafePartyCount_OverReportedParty_ClampsToMax()
+    {
+        var sav = CreateEmeraldWithOverReportedParty(OverReportedPartyCount);
+
+        sav.GetSafePartyCount().Should().Be(6);
+    }
+
+    [Fact]
+    public void GetSafePartyCount_VanillaSave_EqualsPartyCount()
+    {
+        var sav = new SAV3E();
+
+        sav.GetSafePartyCount().Should().Be(sav.PartyCount);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1003 — a startup crash when loading a Pokémon Unbound (Emerald ROM hack) save.

The save parses as a structurally-valid `SAV3E` with `State.Exportable = true`, so it slipped past the existing import guard. But it writes a garbage party count (`187`) into the single-byte field at `0x234` while the party buffer holds exactly 6 slots, so `HasAnyExportablePokemon` threw `ArgumentOutOfRangeException` during render — crashing the app on load. Same class of bug as the LGPE party-count issues (#942–#948), different root cause.

## Changes

**Stop the crash (defense in depth)**
- Hardened `GetSafePartyCount` to clamp the reported count to the 6-slot maximum for all saves (previously trusted non-LGPE counts verbatim).
- Switched `HasAnyExportablePokemon` to the safe count + `TryGetPartySlot`.

**Block unsupported ROM-hack saves at import**
- Added `SaveFile.IsSupportedForEditing(out reason)`, folding in the existing `Exportable` check and additionally rejecting saves whose party count exceeds 6 — an invariant that's impossible in a legitimate save, so vanilla games are unaffected.
- Wired it into all three import paths (file load, backup restore, embedded host), surfacing a ROM-hack-specific "Unsupported save file" message instead of crashing.

**Tests**
- Added `RomHackSaveSafetyTests` covering the over-reported party count, the import guard, and `GetSafePartyCount` clamping.

## Notes

There's no general, false-positive-free way to detect arbitrary ROM hacks (PKHeX doesn't attempt it either), so the guard keys off the violated invariant that actually causes the crash. A hack that keeps a valid party count but corrupts data elsewhere could still load, but won't crash on this path; the check can be extended if more reports come in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
