### PR TITLE
chore(deps): Combined Dependabot updates (MudBlazor, Azure.Storage.Blobs, setup-dotnet, claude-code-action)

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -34,7 +34,7 @@ jobs:
 
       # sets up .NET SDK
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5.3.0
+        uses: actions/setup-dotnet@v5.4.0
         with:
           global-json-file: ./global.json
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7.0.0
-      - uses: anthropics/claude-code-action@v1.0.154
+      - uses: anthropics/claude-code-action@v1.0.162
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--model claude-opus-4-7"
@@ -42,7 +42,7 @@ jobs:
   #     issues: write
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - uses: anthropics/claude-code-action@v1.0.154
+  #     - uses: anthropics/claude-code-action@v1.0.162
   #       with:
   #         claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
   #         settings: |
@@ -98,7 +98,7 @@ jobs:
       - uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
-      - uses: anthropics/claude-code-action@v1.0.154
+      - uses: anthropics/claude-code-action@v1.0.162
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           settings: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,7 +44,7 @@ jobs:
       # the buildless analyses (js, actions, python) skip them.
     - name: Setup .NET Core SDK
       if: matrix.language == 'csharp'
-      uses: actions/setup-dotnet@v5.3.0
+      uses: actions/setup-dotnet@v5.4.0
       with:
         global-json-file: ./global.json
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
 
       # sets up .NET SDK
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5.3.0
+        uses: actions/setup-dotnet@v5.4.0
         with:
           global-json-file: ./global.json
 
@@ -108,7 +108,7 @@ jobs:
         uses: actions/checkout@v7.0.0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5.3.0
+        uses: actions/setup-dotnet@v5.4.0
         with:
           global-json-file: ./global.json
 

--- a/.github/workflows/uat.yml
+++ b/.github/workflows/uat.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v7.0.0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5.3.0
+        uses: actions/setup-dotnet@v5.4.0
         with:
           global-json-file: ./global.json
 
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@v7.0.0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5.3.0
+        uses: actions/setup-dotnet@v5.4.0
         with:
           global-json-file: ./global.json
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,7 @@
     <PackageVersion Include="Microsoft.JSInterop.WebAssembly" Version="10.0.3" />
     <!-- Windows Shell preview-handler PoC only (tools/windows-preview-poc). -->
     <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.3967.48" />
-    <PackageVersion Include="MudBlazor" Version="9.5.0" />
+    <PackageVersion Include="MudBlazor" Version="9.6.0" />
     <PackageVersion Include="PKHeX.Core" Version="26.5.5" />
     <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageVersion Include="Serilog.Sinks.BrowserConsole" Version="8.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Azure.Storage.Blobs" Version="12.29.0" />
+    <PackageVersion Include="Azure.Storage.Blobs" Version="12.29.1" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />


### PR DESCRIPTION
Combines the four open Dependabot dependency updates into a single PR.

## Updates

| Dependency | From | To | Original PR |
|---|---|---|---|
| anthropics/claude-code-action | 1.0.154 | 1.0.162 | #1032 |
| MudBlazor | 9.5.0 | 9.6.0 | #1029 |
| actions/setup-dotnet | 5.3.0 | 5.4.0 | #1025 |
| Azure.Storage.Blobs | 12.29.0 | 12.29.1 | #1020 |

Each Dependabot commit was cherry-picked as-is (authorship preserved). Closes #1032, #1029, #1025, #1020.

## Verification

- `dotnet build Pkmds.slnx -c Debug` — succeeds, 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
