### PR TITLE
Serve sprites from our fork via jsDelivr; fix duplicate update-check snackbars

### DIFF
--- a/Pkmds.Core/Utilities/PokeApiSpriteUrls.cs
+++ b/Pkmds.Core/Utilities/PokeApiSpriteUrls.cs
@@ -3,7 +3,7 @@ using Pkmds.Core.Extensions;
 namespace Pkmds.Core.Utilities;
 
 /// <summary>
-/// Builds PokeAPI CDN URLs for Pokémon sprites — both the high-res HOME artwork and the
+/// Builds sprite URLs in the PokeAPI layout — both the high-res HOME artwork and the
 /// game-version-specific pixel-art sprites. Handles form variants, gender differences,
 /// shiny variants, Alcremie cream/sweet permutations, and Totem-form mapping.
 /// </summary>
@@ -11,14 +11,16 @@ namespace Pkmds.Core.Utilities;
 /// Lives in <c>Pkmds.Core</c> so AOT-clean consumers (the macOS / iOS Quick Look extensions,
 /// any future native host) can share the form-mapping data without taking a dependency on
 /// <c>Pkmds.Rcl</c> (MudBlazor + Blazor + Tailwind, none of which AOT-compile).
+/// The transport (which CDN / fork / branch the sprites come from) is centralized in
+/// <see cref="SpriteSource"/> — change it there, not here.
 /// </remarks>
 public static class PokeApiSpriteUrls
 {
-    private const string PokeApiHomeBaseUrl =
-        "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/";
+    // Local shorthands for the centralized transport in SpriteSource — the interpolations
+    // below stay readable. To change the CDN / fork / branch, edit SpriteSource, not these.
+    private const string PokeApiHomeBaseUrl = SpriteSource.HomeBaseUrl;
 
-    private const string PokeApiVersionsBaseUrl =
-        "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/";
+    private const string PokeApiVersionsBaseUrl = SpriteSource.VersionsBaseUrl;
 
     // Alcremie (869): 9 cream forms × 7 sweet decorations = 63 combinations.
     // PKHeX form (0-8) = cream type; GetFormArgument(0) (0-6) = sweet type.

--- a/Pkmds.Core/Utilities/SpriteSource.cs
+++ b/Pkmds.Core/Utilities/SpriteSource.cs
@@ -1,0 +1,44 @@
+namespace Pkmds.Core.Utilities;
+
+/// <summary>
+/// Single source of truth for where Pokémon sprite images are fetched from.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The app serves sprites from <c>codemonkey85/sprites</c> — our own fork of
+/// <c>PokeAPI/sprites</c> — over the jsDelivr CDN. Owning the fork means an upstream
+/// takedown or restructure of <c>PokeAPI/sprites</c> can't break the app; jsDelivr is a
+/// swappable speed layer on top (multi-CDN with edge caching). A scheduled GitHub Action
+/// in the fork keeps it synced with upstream so new-gen sprites keep arriving.
+/// </para>
+/// <para>
+/// <b>To change the sprite host, CDN, fork, or branch in the future, edit
+/// <see cref="RepoRoot"/> only.</b> Every sprite URL in the app — HOME artwork, game-version
+/// pixel art, and the placeholder — is composed from it. For example, to drop jsDelivr and go
+/// direct to GitHub raw, swap <see cref="RepoRoot"/> for
+/// <c>https://raw.githubusercontent.com/codemonkey85/sprites/master/sprites/pokemon/</c>.
+/// </para>
+/// </remarks>
+public static class SpriteSource
+{
+    // ── Transport: the ONE place to change CDN / fork / branch ───────────────
+    // Serving codemonkey85/sprites (our fork) via jsDelivr's GitHub gateway.
+    // Direct-from-GitHub alternative (no CDN):
+    //   "https://raw.githubusercontent.com/codemonkey85/sprites/master/sprites/pokemon/"
+    private const string RepoRoot =
+        "https://cdn.jsdelivr.net/gh/codemonkey85/sprites@master/sprites/pokemon/";
+
+    // ── Derived paths — composed from RepoRoot; do not hardcode elsewhere ─────
+
+    /// <summary>Base URL for high-res HOME artwork (<c>other/home/</c>).</summary>
+    public const string HomeBaseUrl = RepoRoot + "other/home/";
+
+    /// <summary>Base URL for game-version pixel-art sprites (<c>versions/</c>).</summary>
+    public const string VersionsBaseUrl = RepoRoot + "versions/";
+
+    /// <summary>
+    /// Placeholder sprite (species 0 / "egg-like" fallback) used when a real sprite URL
+    /// can't be built for a given Pokémon.
+    /// </summary>
+    public const string PlaceholderSpriteUrl = HomeBaseUrl + "0.png";
+}

--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
@@ -106,7 +106,15 @@ public partial class MainLayout : IDisposable
             switch (result)
             {
                 case "none":
-                    Snackbar.Add("You're up to date.", Severity.Success);
+                    // Belt-and-braces against the JS-side race (see checkForUpdates in app.js):
+                    // if the service worker's 'updateAvailable' event landed anyway — flipping
+                    // IsUpdateAvailable via ShowUpdateMessage — don't contradict it by also
+                    // claiming the app is up to date.
+                    if (!IsUpdateAvailable)
+                    {
+                        Snackbar.Add("You're up to date.", Severity.Success);
+                    }
+
                     break;
                 case "error":
                 case "no-sw":

--- a/Pkmds.Web/wwwroot/js/app.js
+++ b/Pkmds.Web/wwwroot/js/app.js
@@ -116,41 +116,71 @@ window.checkForUpdates = async () => {
         return 'found';
     }
 
-    let updated;
+    // Subscribe BEFORE calling update(): browsers populate registration.installing and fire
+    // 'updatefound' asynchronously, often a task or two AFTER the update() promise resolves —
+    // especially on slower mobile devices. Checking registration.installing immediately after
+    // update() can therefore miss a real update, making this function return 'none' ("You're
+    // up to date") moments before the global onupdatefound handler announces "An update is
+    // available" — two contradictory snackbars for the same check (issue seen mostly on mobile).
+    let signalUpdateFound;
+    const updateFoundPromise = new Promise(resolve => { signalUpdateFound = resolve; });
+    registration.addEventListener('updatefound', signalUpdateFound);
+
     try {
-        updated = await registration.update();
-    } catch (err) {
-        if (!(err.name === 'InvalidStateError' || (err.message && err.message.includes('newestWorker is null')))) {
-            console.warn('Manual update check failed:', err);
-        }
-        return 'error';
-    }
-
-    if (updated.waiting) {
-        window.dispatchEvent(new CustomEvent('updateAvailable'));
-        return 'found';
-    }
-
-    if (!updated.installing) {
-        return 'none';
-    }
-
-    // New SW is installing — wait for it to fully succeed or fail before returning.
-    // This prevents a silent no-feedback state when the install errors (e.g. SRI hash mismatch
-    // during a fresh deployment before CDN has fully propagated the new asset files).
-    const installing = updated.installing;
-    return new Promise((resolve) => {
-        const timeoutId = setTimeout(() => resolve('error'), 30000);
-        installing.addEventListener('statechange', function () {
-            if (installing.state === 'installed') {
-                clearTimeout(timeoutId);
-                window.dispatchEvent(new CustomEvent('updateAvailable'));
-                resolve('found');
-            } else if (installing.state === 'redundant') {
-                clearTimeout(timeoutId);
-                resolve('error');
+        try {
+            await registration.update();
+        } catch (err) {
+            if (!(err.name === 'InvalidStateError' || (err.message && err.message.includes('newestWorker is null')))) {
+                console.warn('Manual update check failed:', err);
             }
+            return 'error';
+        }
+
+        // No new worker visible yet — give the async 'updatefound' event a grace window
+        // before declaring "up to date". The persistent "Checking for updates…" snackbar
+        // covers this delay, so the up-to-date case just resolves ~1.5s later.
+        if (!registration.installing && !registration.waiting) {
+            await Promise.race([
+                updateFoundPromise,
+                new Promise(resolve => setTimeout(resolve, 1500)),
+            ]);
+        }
+
+        // A fast install may have already moved the new worker to the waiting slot.
+        if (registration.waiting) {
+            window.dispatchEvent(new CustomEvent('updateAvailable'));
+            return 'found';
+        }
+
+        const installing = registration.installing;
+        if (!installing) {
+            return 'none';
+        }
+
+        // New SW is installing — wait for it to fully succeed or fail before returning.
+        // This prevents a silent no-feedback state when the install errors (e.g. SRI hash mismatch
+        // during a fresh deployment before CDN has fully propagated the new asset files).
+        return await new Promise((resolve) => {
+            const timeoutId = setTimeout(() => resolve('error'), 30000);
+            installing.addEventListener('statechange', function () {
+                if (installing.state === 'installed') {
+                    clearTimeout(timeoutId);
+                    // Mirror the controller check in the global onupdatefound handler: with no
+                    // controller this is the page's very first SW install, not an update.
+                    if (navigator.serviceWorker.controller) {
+                        window.dispatchEvent(new CustomEvent('updateAvailable'));
+                        resolve('found');
+                    } else {
+                        resolve('none');
+                    }
+                } else if (installing.state === 'redundant') {
+                    clearTimeout(timeoutId);
+                    resolve('error');
+                }
+            });
         });
-    });
+    } finally {
+        registration.removeEventListener('updatefound', signalUpdateFound);
+    }
 };
 

--- a/tools/preview-shared/HtmlRenderer.cs
+++ b/tools/preview-shared/HtmlRenderer.cs
@@ -9,15 +9,15 @@ namespace Pkmds.Preview;
 public static class HtmlRenderer
 {
     // Final fallback when even the base-species URL can't be built (invalid species).
-    private const string PlaceholderSpriteUrl =
-        "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/home/0.png";
+    // Transport is centralized in SpriteSource; this is a local alias.
+    private const string PlaceholderSpriteUrl = SpriteSource.PlaceholderSpriteUrl;
 
     /// <summary>
     /// Optional hook that resolves a bundled sprite (a relative path from <see cref="SpritePaths"/>)
     /// to an <c>&lt;img src&gt;</c> value — typically a <c>data:</c> URI read from a local sprite
-    /// bundle. When set and it returns non-null, the renderer uses it instead of a remote PokeAPI
+    /// bundle. When set and it returns non-null, the renderer uses it instead of a remote CDN
     /// URL, making previews fully offline. Hosts that don't bundle sprites leave it null (or return
-    /// null for a missing file) to fall back to PokeAPI.
+    /// null for a missing file) to fall back to the remote sprite CDN (see <see cref="SpriteSource"/>).
     /// </summary>
     public static Func<string, string?>? SpriteResolver { get; set; }
 


### PR DESCRIPTION
## Summary

Two changes from today's session:

### 1. Sprite transport: `codemonkey85/sprites` fork via jsDelivr
- All sprite fetching now points at our own fork of `PokeAPI/sprites`, served over the jsDelivr CDN (`cdn.jsdelivr.net/gh/codemonkey85/sprites@master/...`) instead of hotlinking `PokeAPI/sprites` on `raw.githubusercontent.com`.
- **Why:** owning the fork insulates the app from an upstream takedown/restructure of `PokeAPI/sprites`; jsDelivr adds real edge caching (multi-CDN) over GitHub raw, which is rate-limited and not intended for production hotlinking.
- Transport is centralized in a new `SpriteSource` type in `Pkmds.Core` — a future CDN/fork/branch change is a one-line edit to `SpriteSource.RepoRoot`. `PokeApiSpriteUrls` and the preview `HtmlRenderer` alias into it; the URL-building logic itself is untouched.
- Companion automation (already live in the sprites repo, not part of this PR): a daily `merge-upstream` GitHub Action keeps the fork synced with `PokeAPI/sprites` — verified end-to-end.
- Verified jsDelivr serves all three path classes from the fork (HOME artwork, `versions/` pixel art, placeholder) with HTTP 200.

### 2. Fix contradictory snackbars on manual update check
Fixes the mobile-prevalent bug where "Check for updates" could show **both** "You're up to date." and "An update is available." for the same check.

- **Root cause:** `registration.update()` resolves before browsers populate `registration.installing` / fire `updatefound` (the gap is widest on mobile). The manual check saw no new worker and reported "up to date" moments before the global `onupdatefound` handler announced the update it had just missed.
- **Fix:** subscribe to `updatefound` *before* calling `update()` and give the event a ~1.5s grace window before concluding "up to date" (the persistent "Checking for updates…" snackbar covers the delay).
- Also mirrors the global handler's `navigator.serviceWorker.controller` check in the manual install-wait path, so a first-ever SW install isn't misannounced as an update, and guards the C# `"none"` branch against a late-landing `updateAvailable` event as belt-and-braces.
- Note: timing race — verified by analysis, JS syntax check, and clean build; worth one manual on-device check against a real pending update after deploy.

## Test plan
- [x] `dotnet build Pkmds.slnx -c Debug` — 0 warnings, 0 errors
- [x] `dotnet format --verify-no-changes` on touched C#
- [x] `node --check` on `app.js`
- [x] jsDelivr URLs verified live (200) for home, versions, and placeholder sprites
- [ ] CI `buildandtest` workflow
- [ ] Post-deploy: manual update check on mobile against a pending update shows a single snackbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVBABqa4sjEdMCnKvshS1t