### PR TITLE
Sync PWA window-chrome color with the app bar and de-duplicate theme colors

### DIFF
--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
@@ -254,7 +254,7 @@ public partial class MainLayout : IDisposable
             // setAppTheme call would otherwise be unobserved and could tear down rendering.
             try
             {
-                await JSRuntime.InvokeVoidAsync("setAppTheme", themeStr);
+                await JSRuntime.InvokeVoidAsync("setAppTheme", themeStr, AppTheme.PwaThemeColor);
             }
             catch (JSException ex)
             {
@@ -279,7 +279,7 @@ public partial class MainLayout : IDisposable
                 ? "dark"
                 : "light"
         };
-        await JSRuntime.InvokeVoidAsync("setAppTheme", themeStr);
+        await JSRuntime.InvokeVoidAsync("setAppTheme", themeStr, AppTheme.PwaThemeColor);
 
         // Persist the new theme through the settings service (keeps pkmds_theme in sync too)
         await SettingsService.SaveAsync(SettingsService.Settings with
@@ -354,7 +354,7 @@ public partial class MainLayout : IDisposable
             var themeStr = isDarkMode
                 ? "dark"
                 : "light";
-            await JSRuntime.InvokeVoidAsync("setAppTheme", themeStr);
+            await JSRuntime.InvokeVoidAsync("setAppTheme", themeStr, AppTheme.PwaThemeColor);
 
             StateHasChanged();
         }

--- a/Pkmds.Rcl/GlobalUsings.cs
+++ b/Pkmds.Rcl/GlobalUsings.cs
@@ -23,5 +23,6 @@ global using Pkmds.Rcl.Extensions;
 global using Pkmds.Rcl.Models;
 global using Pkmds.Rcl.Services;
 global using Pkmds.Rcl.Services.Json;
+global using Pkmds.Rcl.Theming;
 global using Serilog.Events;
 global using Severity = MudBlazor.Severity;

--- a/Pkmds.Rcl/Theming/AppTheme.cs
+++ b/Pkmds.Rcl/Theming/AppTheme.cs
@@ -2,45 +2,85 @@ namespace Pkmds.Rcl.Theming;
 
 public static class AppTheme
 {
+    /// <summary>
+    /// Tailwind-derived color ramp — the single source of truth for the app's palette,
+    /// including values mirrored into static host assets that can't reference C#
+    /// (index.html, manifest.webmanifest, the pre-boot splash styles in app.css, and
+    /// BrowserNotSupported.html). <c>ThemeSyncTests</c> verifies those files stay in sync.
+    /// </summary>
+    public static class Colors
+    {
+        public const string White = "#FFFFFF";
+        public const string Blue400 = "#60A5FA";
+        public const string Blue800 = "#1E40AF";
+        public const string Green400 = "#4ADE80";
+        public const string Green600 = "#16A34A";
+        public const string Violet400 = "#A78BFA";
+        public const string Violet600 = "#7C3AED";
+        public const string Stone50 = "#FAFAF9";
+        public const string Stone100 = "#F5F5F4";
+        public const string Stone200 = "#E7E5E4";
+        public const string Stone400 = "#A8A29E";
+        public const string Stone600 = "#57534E";
+        public const string Stone700 = "#44403C";
+        public const string Stone800 = "#292524";
+        public const string Stone900 = "#1C1917";
+        public const string Stone950 = "#0C0A09";
+    }
+
+    /// <summary>
+    /// Window-chrome color advertised to the OS via the theme-color meta tag in index.html
+    /// and theme_color in manifest.webmanifest. A single static value only works because
+    /// AppbarBackground is identical in both palettes — ThemeSyncTests enforces that
+    /// invariant, so if the palettes ever diverge the theme-color plumbing must become
+    /// mode-aware at the same time.
+    /// </summary>
+    public const string PwaThemeColor = Colors.Stone900;
+
+    /// <summary>
+    /// PWA manifest background_color — the color shown behind the pre-boot splash screen.
+    /// </summary>
+    public const string PwaBackgroundColor = Colors.Stone50;
+
     public static MudTheme Default { get; } = new()
     {
         PaletteLight = new PaletteLight
         {
-            Primary = "#1E40AF",
-            Secondary = "#16A34A",
-            Tertiary = "#7C3AED",
-            Background = "#FAFAF9",
-            BackgroundGray = "#F5F5F4",
-            Surface = "#FFFFFF",
-            AppbarBackground = "#1C1917",
-            AppbarText = "#FAFAF9",
-            DrawerBackground = "#FFFFFF",
-            DrawerText = "#1C1917",
-            DrawerIcon = "#44403C",
-            TextPrimary = "#1C1917",
-            TextSecondary = "#57534E",
-            ActionDefault = "#57534E",
-            Divider = "#E7E5E4",
-            LinesDefault = "#E7E5E4",
+            Primary = Colors.Blue800,
+            Secondary = Colors.Green600,
+            Tertiary = Colors.Violet600,
+            Background = Colors.Stone50,
+            BackgroundGray = Colors.Stone100,
+            Surface = Colors.White,
+            AppbarBackground = PwaThemeColor,
+            AppbarText = Colors.Stone50,
+            DrawerBackground = Colors.White,
+            DrawerText = Colors.Stone900,
+            DrawerIcon = Colors.Stone700,
+            TextPrimary = Colors.Stone900,
+            TextSecondary = Colors.Stone600,
+            ActionDefault = Colors.Stone600,
+            Divider = Colors.Stone200,
+            LinesDefault = Colors.Stone200,
         },
         PaletteDark = new PaletteDark
         {
-            Primary = "#60A5FA",
-            Secondary = "#4ADE80",
-            Tertiary = "#A78BFA",
-            Background = "#0C0A09",
-            BackgroundGray = "#1C1917",
-            Surface = "#292524",
-            AppbarBackground = "#1C1917",
-            AppbarText = "#FAFAF9",
-            DrawerBackground = "#0C0A09",
-            DrawerText = "#FAFAF9",
-            DrawerIcon = "#A8A29E",
-            TextPrimary = "#FAFAF9",
-            TextSecondary = "#A8A29E",
-            ActionDefault = "#A8A29E",
-            Divider = "#57534E",
-            LinesDefault = "#57534E",
+            Primary = Colors.Blue400,
+            Secondary = Colors.Green400,
+            Tertiary = Colors.Violet400,
+            Background = Colors.Stone950,
+            BackgroundGray = Colors.Stone900,
+            Surface = Colors.Stone800,
+            AppbarBackground = PwaThemeColor,
+            AppbarText = Colors.Stone50,
+            DrawerBackground = Colors.Stone950,
+            DrawerText = Colors.Stone50,
+            DrawerIcon = Colors.Stone400,
+            TextPrimary = Colors.Stone50,
+            TextSecondary = Colors.Stone400,
+            ActionDefault = Colors.Stone400,
+            Divider = Colors.Stone600,
+            LinesDefault = Colors.Stone600,
         },
     };
 }

--- a/Pkmds.Rcl/wwwroot/css/app.css
+++ b/Pkmds.Rcl/wwwroot/css/app.css
@@ -662,6 +662,10 @@ body, html {
     max-width: 10rem;
 }
 
+/* begin pkmds-splash — pre-boot loading screen. MudBlazor's CSS variables don't
+   exist yet at this point, so colors must be literal hexes mirroring
+   AppTheme.Colors. ThemeSyncTests scans this marker-bounded section and fails
+   if a hex here drifts from the C# palette. */
 .pkmds-splash {
     position: fixed;
     inset: 0;
@@ -846,6 +850,8 @@ body, html {
 [data-theme="light"] .loading-progress-text {
     color: #57534E;
 }
+
+/* end pkmds-splash */
 
 /* Drag and drop styles */
 .slot-dragging {

--- a/Pkmds.Tests/ThemeSyncTests.cs
+++ b/Pkmds.Tests/ThemeSyncTests.cs
@@ -1,0 +1,125 @@
+using System.Reflection;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using MudBlazor.Utilities;
+using Pkmds.Rcl.Theming;
+
+namespace Pkmds.Tests;
+
+/// <summary>
+/// Guards the colors that AppTheme shares with static host assets which cannot reference C#
+/// (index.html, manifest.webmanifest, the pre-boot splash styles in app.css, and
+/// BrowserNotSupported.html). AppTheme.Colors is the single source of truth; when a palette
+/// color changes there, these tests fail until the static files are updated to match.
+/// </summary>
+public class ThemeSyncTests
+{
+    private static readonly string RepoRoot = FindRepoRoot();
+
+    private static readonly HashSet<string> AllThemeColors = typeof(AppTheme.Colors)
+        .GetFields(BindingFlags.Public | BindingFlags.Static)
+        .Where(f => f.IsLiteral)
+        .Select(f => (string)f.GetRawConstantValue()!)
+        .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Pkmds.slnx")))
+        {
+            dir = dir.Parent;
+        }
+
+        return dir?.FullName
+            ?? throw new InvalidOperationException("Could not locate the repo root (no Pkmds.slnx found above the test bin directory).");
+    }
+
+    private static string ReadRepoFile(params string[] pathSegments) =>
+        File.ReadAllText(Path.Combine([RepoRoot, .. pathSegments]));
+
+    [Fact]
+    public void IndexHtml_ThemeColorMeta_IsSingleAndMatchesAppTheme()
+    {
+        var html = ReadRepoFile("Pkmds.Web", "wwwroot", "index.html");
+
+        var metas = Regex.Matches(html, """<meta[^>]*name="theme-color"[^>]*>""");
+
+        // A single mode-independent tag is only valid because AppbarBackground is identical
+        // in both palettes — see AppbarBackground_IsIdenticalInBothPalettes below.
+        metas.Should().ContainSingle();
+
+        var content = Regex.Match(metas[0].Value, """content="([^"]+)""").Groups[1].Value;
+        content.Should().BeEquivalentTo(AppTheme.PwaThemeColor);
+    }
+
+    [Fact]
+    public void IndexHtml_BrandAccents_MatchLightPrimary()
+    {
+        var html = ReadRepoFile("Pkmds.Web", "wwwroot", "index.html");
+
+        var maskIcon = Regex.Match(html, """<link[^>]*rel="mask-icon"[^>]*color="([^"]+)""");
+        maskIcon.Success.Should().BeTrue("index.html should declare a mask-icon color");
+        maskIcon.Groups[1].Value.Should().BeEquivalentTo(AppTheme.Colors.Blue800);
+
+        var tileColor = Regex.Match(html, """<meta[^>]*name="msapplication-TileColor"[^>]*content="([^"]+)""");
+        tileColor.Success.Should().BeTrue("index.html should declare msapplication-TileColor");
+        tileColor.Groups[1].Value.Should().BeEquivalentTo(AppTheme.Colors.Blue800);
+    }
+
+    [Fact]
+    public void Manifest_ThemeAndBackgroundColors_MatchAppTheme()
+    {
+        var manifest = ReadRepoFile("Pkmds.Web", "wwwroot", "manifest.webmanifest");
+
+        using var json = JsonDocument.Parse(manifest);
+        json.RootElement.GetProperty("theme_color").GetString()
+            .Should().BeEquivalentTo(AppTheme.PwaThemeColor);
+        json.RootElement.GetProperty("background_color").GetString()
+            .Should().BeEquivalentTo(AppTheme.PwaBackgroundColor);
+    }
+
+    [Fact]
+    public void AppbarBackground_IsIdenticalInBothPalettes_AndMatchesPwaThemeColor()
+    {
+        // The static theme-color meta tag and manifest theme_color carry one value for both
+        // light and dark. If the appbar colors ever diverge, this test fails as a signal that
+        // the theme-color plumbing (index.html, manifest, setAppTheme interop) must become
+        // mode-aware at the same time.
+        var expected = new MudColor(AppTheme.PwaThemeColor);
+        AppTheme.Default.PaletteLight.AppbarBackground.Should().Be(expected);
+        AppTheme.Default.PaletteDark.AppbarBackground.Should().Be(expected);
+    }
+
+    [Fact]
+    public void SplashCss_UsesOnlyAppThemeColors()
+    {
+        var css = ReadRepoFile("Pkmds.Rcl", "wwwroot", "css", "app.css");
+
+        var begin = css.IndexOf("/* begin pkmds-splash", StringComparison.Ordinal);
+        var end = css.IndexOf("/* end pkmds-splash", StringComparison.Ordinal);
+        begin.Should().BeGreaterThan(-1, "app.css should contain the 'begin pkmds-splash' marker comment");
+        end.Should().BeGreaterThan(begin, "app.css should contain the 'end pkmds-splash' marker comment after the begin marker");
+
+        var splashSection = css[begin..end];
+        var hexColors = Regex.Matches(splashSection, "#[0-9A-Fa-f]{6}(?![0-9A-Fa-f])")
+            .Select(m => m.Value)
+            .Distinct(StringComparer.OrdinalIgnoreCase);
+
+        hexColors.Should().NotBeEmpty()
+            .And.AllSatisfy(hex => AllThemeColors.Should().Contain(hex,
+                $"splash color {hex} in app.css should be one of the AppTheme.Colors constants"));
+    }
+
+    [Fact]
+    public void BrowserNotSupportedPage_LinkColors_MatchPalettePrimaries()
+    {
+        // The page has its own standalone grays (it renders without any app CSS), but its
+        // link colors mirror the palette primaries and should follow them if they change.
+        var html = ReadRepoFile("Pkmds.Web", "wwwroot", "BrowserNotSupported.html");
+
+        html.Should().ContainEquivalentOf(AppTheme.Colors.Blue800,
+            "BrowserNotSupported.html light link color should match the light palette Primary");
+        html.Should().ContainEquivalentOf(AppTheme.Colors.Blue400,
+            "BrowserNotSupported.html dark link color should match the dark palette Primary");
+    }
+}

--- a/Pkmds.Web/wwwroot/index.html
+++ b/Pkmds.Web/wwwroot/index.html
@@ -10,9 +10,8 @@
           name="description"/>
     <base href="/"/>
 
-    <!-- Theme color (matches new primary) -->
-    <meta name="theme-color" content="#1E40AF" media="(prefers-color-scheme: light)"/>
-    <meta name="theme-color" content="#60A5FA" media="(prefers-color-scheme: dark)"/>
+    <!-- Theme color (matches AppbarBackground in both palettes — see AppTheme.cs) -->
+    <meta name="theme-color" content="#1C1917"/>
 
     <!-- PWA manifest -->
     <link href="manifest.webmanifest" rel="manifest"/>

--- a/Pkmds.Web/wwwroot/js/theme-init.js
+++ b/Pkmds.Web/wwwroot/js/theme-init.js
@@ -28,6 +28,16 @@
     document.documentElement.setAttribute('data-theme', theme);
 })();
 
-window.setAppTheme = function (theme) {
+window.setAppTheme = function (theme, themeColor) {
     document.documentElement.setAttribute('data-theme', theme);
+
+    // Keep the PWA window-chrome color derived from the C# theme (AppTheme.PwaThemeColor,
+    // passed via interop) instead of duplicating the hex here. The static value in
+    // index.html is only the pre-boot placeholder.
+    if (themeColor) {
+        const meta = document.querySelector('meta[name="theme-color"]');
+        if (meta) {
+            meta.setAttribute('content', themeColor);
+        }
+    }
 };

--- a/Pkmds.Web/wwwroot/manifest.webmanifest
+++ b/Pkmds.Web/wwwroot/manifest.webmanifest
@@ -7,7 +7,7 @@
   "display": "standalone",
   "orientation": "any",
   "background_color": "#FAFAF9",
-  "theme_color": "#1E40AF",
+  "theme_color": "#1C1917",
   "icons": [
     {
       "src": "_content/Pkmds.Rcl/icon-192.png",


### PR DESCRIPTION
## Summary

- **Fix the color mismatch between the installed PWA's macOS window bar and the in-app bar.** The `theme-color` meta tags and manifest advertised the Primary blue (`#1E40AF` / `#60A5FA`) while the `MudAppBar` is `#1C1917` in both palettes. The window chrome now uses `#1C1917` everywhere, so it blends into the app bar in every OS/in-app theme combination.
- **Make `AppTheme.Colors` the single source of truth for theme colors shared with static assets.** Palette hexes were duplicated as magic strings across `AppTheme.cs`, `index.html` (theme-color, mask-icon, TileColor), `manifest.webmanifest`, the pre-boot splash styles in `app.css`, and `BrowserNotSupported.html`:
  - `AppTheme.cs` defines a named Tailwind-derived color ramp plus `PwaThemeColor` / `PwaBackgroundColor` aliases, and the MudBlazor palettes reference those constants.
  - `setAppTheme()` accepts an optional theme color passed from C# via interop, so the theme-color meta tag is derived from `AppTheme` at runtime; the static value in `index.html` is just the pre-boot placeholder.
  - New `ThemeSyncTests` fail CI if any static file drifts from the constants, including the invariant that `AppbarBackground` is identical in both palettes — which is what makes a single mode-independent `theme-color` valid at all. The splash CSS check scans a marker-bounded section, since MudBlazor's CSS variables don't exist pre-boot and those hexes must stay literal.

## Test plan

- [x] `dotnet format` + `dotnet build Pkmds.slnx -c Debug` clean locally
- [ ] `ThemeSyncTests` pass in CI
- [ ] After deploy: installed PWA window bar matches the app bar (note: macOS caches the manifest at install time — remove and re-add the Dock app if it still shows blue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVBABqa4sjEdMCnKvshS1t