### PR TITLE
iOS PWA fixes: respect rotation lock and keep snackbars below the status bar

### DIFF
--- a/Pkmds.Rcl/wwwroot/css/app.css
+++ b/Pkmds.Rcl/wwwroot/css/app.css
@@ -24,6 +24,17 @@ body, html {
     padding-top: env(safe-area-inset-top, 0px);
 }
 
+/* MudBlazor anchors top snackbars at a fixed top: 24px, which lands under the iOS
+   status bar in standalone PWA mode (viewport-fit=cover). Shift them down by the
+   safe-area inset; in a regular browser tab the inset is 0, so this is a no-op.
+   Same specificity as MudBlazor's rules, but our stylesheet loads after, so this
+   wins. */
+.mud-snackbar-location-top-left,
+.mud-snackbar-location-top-center,
+.mud-snackbar-location-top-right {
+    top: calc(24px + var(--pkmds-safe-area-top));
+}
+
 /* The padding above grows .mud-appbar's effective height by the iOS status-bar
    inset, but MudBlazor's .mud-main-content padding-top is fixed to the bar's
    nominal height — so page content (e.g. the save-file title row in

--- a/Pkmds.Rcl/wwwroot/css/app.css
+++ b/Pkmds.Rcl/wwwroot/css/app.css
@@ -59,6 +59,19 @@ body, html {
     padding-top: calc(var(--mud-appbar-height) - var(--mud-appbar-height) / 4 + env(safe-area-inset-top, 0px));
 }
 
+/* MudBlazor 9.6.0 renders the active tab panel with display: contents
+   (MudBlazor/MudBlazor#13288), so the panel div no longer generates a layout box
+   and every height/overflow rule this stylesheet puts on .mud-tab-panel is
+   silently ignored. On narrow screens (< 1280px) the outer tab panel is the
+   page's only scroll container (html/body are overflow:hidden), so 9.6.0 broke
+   all scrolling there — box grid, edit form, and Trainer tab were clipped with
+   no way to reach the overflow. Restore the 9.5.x block box. This must stay
+   ABOVE the :has(...) rules that switch the Bank/Pokédex panels to display:flex;
+   the specificity ties at (0,4,0), so file order decides the winner. */
+.mud-tabs-panels > .mud-tab-panel.mud-tab-panel-active:not(.mud-tab-panel-hidden) {
+    display: block;
+}
+
 .menu-container {
     padding-bottom: env(safe-area-inset-bottom, 16px); /* Fallback to 16px */
     padding-left: env(safe-area-inset-left, 8px); /* Fallback to 8px */

--- a/Pkmds.Rcl/wwwroot/css/app.css
+++ b/Pkmds.Rcl/wwwroot/css/app.css
@@ -24,15 +24,27 @@ body, html {
     padding-top: env(safe-area-inset-top, 0px);
 }
 
-/* MudBlazor anchors top snackbars at a fixed top: 24px, which lands under the iOS
-   status bar in standalone PWA mode (viewport-fit=cover). Shift them down by the
-   safe-area inset; in a regular browser tab the inset is 0, so this is a no-op.
-   Same specificity as MudBlazor's rules, but our stylesheet loads after, so this
-   wins. */
+/* MudBlazor anchors snackbars a fixed 24px from the screen edges, which lands
+   them under the iOS status bar (portrait) or the Dynamic Island / notch
+   (landscape) with viewport-fit=cover. The snackbar container is position:fixed,
+   so the body's safe-area padding doesn't reach it — shift each anchor by the
+   matching inset instead. Insets are 0 where no safe area exists, so this is a
+   no-op elsewhere. Same specificity as MudBlazor's rules, but our stylesheet
+   loads after, so this wins. */
 .mud-snackbar-location-top-left,
 .mud-snackbar-location-top-center,
 .mud-snackbar-location-top-right {
     top: calc(24px + var(--pkmds-safe-area-top));
+}
+
+.mud-snackbar-location-top-right,
+.mud-snackbar-location-bottom-right {
+    right: calc(24px + env(safe-area-inset-right, 0px));
+}
+
+.mud-snackbar-location-top-left,
+.mud-snackbar-location-bottom-left {
+    left: calc(24px + env(safe-area-inset-left, 0px));
 }
 
 /* The padding above grows .mud-appbar's effective height by the iOS status-bar

--- a/Pkmds.Web/wwwroot/manifest.webmanifest
+++ b/Pkmds.Web/wwwroot/manifest.webmanifest
@@ -5,7 +5,6 @@
   "start_url": "/",
   "scope": "/",
   "display": "standalone",
-  "orientation": "any",
   "background_color": "#FAFAF9",
   "theme_color": "#1C1917",
   "icons": [


### PR DESCRIPTION
## Summary

iOS PWA fixes, plus an urgent fix for the scrolling regression that shipped to production today.

- **Fix broken scrolling on phones caused by MudBlazor 9.6.0** (71640687) — **this is live-broken in production right now** (shipped this evening via the dependabot MudBlazor 9.5.0 → 9.6.0 bump in #1033, and reported by a user in #1030 as "the edit window isn't appearing"). MudBlazor 9.6.0 ([MudBlazor#13288](https://github.com/MudBlazor/MudBlazor/pull/13288)) renders the active tab panel with `display: contents`, so the panel div generates no layout box and every `height`/`overflow` rule app.css puts on `.mud-tab-panel` is silently ignored. On narrow screens the outer tab panel is the page's *only* scroll container (`html`/`body` are `overflow: hidden`), so the box grid, edit form, and Trainer tab were clipped with no way to scroll. Fixed with a same-specificity override restoring the 9.5.x block box, placed above the `:has(...)` rules so the Bank/Pokédex flex panels still win their specificity ties.
- **Remove `orientation: any` from the PWA manifest** (f9bb31ec) — declaring an orientation preference caused the installed app to ignore the device's rotation lock. Omitting the key restores default behavior.
- **Offset top snackbars by the iOS safe-area inset** (c0604903) — MudBlazor anchors top snackbars at a fixed `top: 24px`, which lands under the iOS status bar with `viewport-fit=cover` in standalone PWA mode.
- **Offset side-anchored snackbars by the horizontal safe-area insets** (83ea08be) — same bug on the other axis: in landscape the Dynamic Island / notch occupies `env(safe-area-inset-left/right)`, hiding the snackbar's close button.

## Verification (scroll fix)

Verified end-to-end with Playwright against a local Debug build at 393×750 (iPhone-sized) and 1400×900:

- Loading a save and selecting a box Pokémon: the outer tab panel is `display: block` / `overflow-y: auto` again, scrolls (scrollHeight 1976 vs clientHeight 588), and the edit form scrolls into view.
- Counterfactual: forcing `display: contents` back on the panel reproduces the bug exactly (zero-height box, scroll pinned at 0, content clipped by the parent's `overflow: hidden`).
- Trainer tab scrolls at phone width; Bank (desktop) and Pokédex (phone) panels still get their `display: flex` `:has(...)` overrides.

## Test plan

- [x] `dotnet build` passes with 0 warnings
- [x] Playwright verification above
- [ ] Verify on an installed iOS PWA that update snackbars render below the status bar (portrait) and clear the Dynamic Island (landscape)
- [ ] Verify rotation lock is respected in the installed PWA
- [ ] Verify box/edit-form/Trainer scrolling on a real iPhone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVBABqa4sjEdMCnKvshS1t