### PR TITLE
fix: restore iOS save-file export (user-tap download; MudBlazor 9.5.0 pin)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,19 @@
     <PackageVersion Include="Microsoft.JSInterop.WebAssembly" Version="10.0.3" />
     <!-- Windows Shell preview-handler PoC only (tools/windows-preview-poc). -->
     <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.3967.48" />
-    <PackageVersion Include="MudBlazor" Version="9.6.0" />
+    <!--
+      Pinned to 9.5.0: MudBlazor 9.6.0 (commit ef59e90d2, "MudMenu: Invoke OnClick
+      before closing the menu") reordered MudMenuItem so OnClick runs while the menu
+      popover is still open, then closes it afterward. Combined with the WebView
+      menu-close JS-interop change (3fcb3457a), this shifted the menu -> unsaved-changes
+      dialog -> programmatic download overlay/activation timing enough that iOS Safari
+      silently dropped the export download (it only honors anchor/data-URI downloads
+      tied to a live user gesture). Reported across #1044-#1060; desktop unaffected.
+      Do not bump past 9.5.0 until the export path is hardened against activation loss
+      or MudBlazor reverts the reorder. See also the app.css .mud-tab-panel override
+      (commit 71640687), which offsets the 9.6.0 display:contents tab-panel change.
+    -->
+    <PackageVersion Include="MudBlazor" Version="9.5.0" />
     <PackageVersion Include="PKHeX.Core" Version="26.5.5" />
     <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageVersion Include="Serilog.Sinks.BrowserConsole" Version="8.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,16 +22,18 @@
     <!-- Windows Shell preview-handler PoC only (tools/windows-preview-poc). -->
     <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.3967.48" />
     <!--
-      Pinned to 9.5.0: MudBlazor 9.6.0 (commit ef59e90d2, "MudMenu: Invoke OnClick
-      before closing the menu") reordered MudMenuItem so OnClick runs while the menu
-      popover is still open, then closes it afterward. Combined with the WebView
-      menu-close JS-interop change (3fcb3457a), this shifted the menu -> unsaved-changes
-      dialog -> programmatic download overlay/activation timing enough that iOS Safari
-      silently dropped the export download (it only honors anchor/data-URI downloads
-      tied to a live user gesture). Reported across #1044-#1060; desktop unaffected.
-      Do not bump past 9.5.0 until the export path is hardened against activation loss
-      or MudBlazor reverts the reorder. See also the app.css .mud-tab-panel override
-      (commit 71640687), which offsets the 9.6.0 display:contents tab-panel change.
+      Pinned to 9.5.0, but NOTE: this pin is NOT what fixed the iOS export outage
+      (#1044-#1060). It was an initial mitigation attempt based on the theory that
+      MudBlazor 9.6.0's MudMenuItem OnClick reorder (ef59e90d2) broke the export;
+      an on-device iOS retest disproved that — export still failed on 9.5.0. The
+      actual root cause is that iOS WebKit only honors a download inside a live user
+      gesture, and our export pipeline clicked the anchor after several awaits; the
+      real fix is the user-tap download in Pkmds.Rcl/wwwroot/js/fileSave.js
+      (pkmdsPresentDownload) and the WriteFileOldWay -> downloadBlob change, which are
+      MudBlazor-version-independent. The pin is retained only out of caution; unpinning
+      to current MudBlazor is tracked in #1063. If you unpin, drop the app.css
+      .mud-tab-panel override too only if it's no longer needed (commit 71640687
+      offsets the 9.6.0 display:contents tab-panel change).
     -->
     <PackageVersion Include="MudBlazor" Version="9.5.0" />
     <PackageVersion Include="PKHeX.Core" Version="26.5.5" />

--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
@@ -671,6 +671,14 @@ public partial class MainLayout : IDisposable
             fileName = "save";
         }
 
+        // No real extension to enforce (e.g. the original save had none, like "violet_main").
+        // Return the name untouched instead of appending a bare "." — that produced download
+        // names like "violet_main." with a trailing dot.
+        if (string.IsNullOrWhiteSpace(extension) || extension == ".")
+        {
+            return fileName;
+        }
+
         extension = extension.StartsWith('.')
             ? extension
             : $".{extension}";

--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
@@ -1154,21 +1154,12 @@ public partial class MainLayout : IDisposable
     {
         var finalName = EnsureExtension(fileName, fileTypeExtension);
 
-        var base64String = Convert.ToBase64String(data);
-
-        var element = await JSRuntime.InvokeAsync<IJSObjectReference>(
-            "eval",
-            "document.createElement('a')");
-
-        await element.InvokeVoidAsync(
-            "setAttribute",
-            "href",
-            $"data:{mimeType};base64,{base64String}");
-
-        await element.InvokeVoidAsync("setAttribute", "download", finalName);
-
-        // No need for target/rel; we're just triggering a download.
-        await element.InvokeVoidAsync("click");
+        // Delegate to downloadBlob (single interop hop). It routes iOS through a user-tap
+        // download (WebKit ignores script-triggered downloads outside a user gesture) and
+        // uses a Blob URL on other platforms. This replaces the old eval + data-URI +
+        // detached-anchor approach, which iOS Safari silently dropped and which relied on
+        // unsafe-eval.
+        await JSRuntime.InvokeVoidAsync("downloadBlob", finalName, data, mimeType);
     }
 
     private enum ThemeMode

--- a/Pkmds.Rcl/wwwroot/js/fileSave.js
+++ b/Pkmds.Rcl/wwwroot/js/fileSave.js
@@ -175,6 +175,11 @@ function pkmdsIsIOS() {
         (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
 }
 
+// Monotonic counter so each download dialog gets unique element ids for its
+// aria-labelledby / aria-describedby wiring (avoids id collisions if one is ever
+// shown before a previous one is torn down).
+let pkmdsDialogSeq = 0;
+
 // iOS/iPadOS Safari (WebKit) only starts a download when the anchor click happens
 // inside a live user gesture. Our export pipeline reaches the download after several
 // awaits (unsaved-changes dialog, IsSupportedAsync interop, the download interop call),
@@ -189,31 +194,55 @@ function pkmdsIsIOS() {
 function pkmdsPresentDownload(fileName, blob) {
     return new Promise((resolve) => {
         const url = URL.createObjectURL(blob);
+        const previouslyFocused = document.activeElement;
+        const uid = 'pkmds-dl-' + (++pkmdsDialogSeq);
         let settled = false;
         const finish = () => {
             if (settled) return;
             settled = true;
             document.removeEventListener('keydown', onKey);
             root.remove();
+            // Restore focus to wherever the user was before the dialog opened.
+            try { if (previouslyFocused && previouslyFocused.focus) previouslyFocused.focus(); } catch (e) { /* ignore */ }
             // Keep the object URL alive long enough for the download/share to read it.
             setTimeout(() => { try { URL.revokeObjectURL(url); } catch (e) { /* ignore */ } }, 60000);
             resolve();
         };
-        const onKey = (e) => { if (e.key === 'Escape') finish(); };
+        // Escape closes the dialog; Tab is trapped so keyboard focus can't leave the modal.
+        const onKey = (e) => {
+            if (e.key === 'Escape') { finish(); return; }
+            if (e.key !== 'Tab') return;
+            const focusables = Array.prototype.slice.call(root.querySelectorAll('a[href],button'));
+            if (focusables.length === 0) return;
+            const first = focusables[0];
+            const last = focusables[focusables.length - 1];
+            const active = document.activeElement;
+            if (e.shiftKey && (active === first || !root.contains(active))) {
+                e.preventDefault();
+                last.focus();
+            } else if (!e.shiftKey && (active === last || !root.contains(active))) {
+                e.preventDefault();
+                first.focus();
+            }
+        };
 
         const root = document.createElement('div');
         root.setAttribute('role', 'dialog');
         root.setAttribute('aria-modal', 'true');
+        root.setAttribute('aria-labelledby', uid + '-title');
+        root.setAttribute('aria-describedby', uid + '-sub');
         root.style.cssText = 'position:fixed;inset:0;z-index:200000;display:flex;align-items:center;justify-content:center;padding:24px;box-sizing:border-box;background:rgba(0,0,0,.62);-webkit-backdrop-filter:blur(3px);backdrop-filter:blur(3px);font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;';
 
         const card = document.createElement('div');
         card.style.cssText = 'background:#1e1e28;color:#fff;border-radius:16px;padding:24px 22px;width:min(420px,92vw);box-sizing:border-box;box-shadow:0 12px 40px rgba(0,0,0,.5);display:flex;flex-direction:column;gap:12px;text-align:center;';
 
         const title = document.createElement('div');
+        title.id = uid + '-title';
         title.textContent = 'Your save file is ready';
         title.style.cssText = 'font-size:1.15rem;font-weight:700;';
 
         const sub = document.createElement('div');
+        sub.id = uid + '-sub';
         sub.textContent = 'Tap below to save it to your device.';
         sub.style.cssText = 'font-size:.92rem;opacity:.8;margin-bottom:4px;';
 
@@ -269,6 +298,13 @@ function pkmdsPresentDownload(fileName, blob) {
         root.addEventListener('click', (e) => { if (e.target === root) finish(); });
         document.addEventListener('keydown', onKey);
         document.body.appendChild(root);
+
+        // Move focus into the dialog so keyboard / assistive-tech users aren't stranded
+        // behind the modal. Prefer the primary action (share button, else the download link).
+        const firstFocusable = root.querySelector('button,a[href]');
+        if (firstFocusable) {
+            try { firstFocusable.focus(); } catch (e) { /* ignore */ }
+        }
     });
 }
 
@@ -391,7 +427,11 @@ window.showFilePickerAndWrite = async function (fileName, byteArray, extension, 
 window.downloadBlob = function (fileName, byteArray, mimeType) {
     if (!byteArray) return;
     const uint8 = byteArray instanceof Uint8Array ? byteArray : new Uint8Array(byteArray);
-    const inferredExt = fileName ? fileName.slice(fileName.lastIndexOf('.')) : '';
+    // Only treat a trailing ".xyz" as an extension. Guard against lastIndexOf === -1, where
+    // slice(-1) would return the final character (wrong MIME for extension-less names like
+    // "violet_main", which EnsureExtension now preserves).
+    const dot = fileName ? fileName.lastIndexOf('.') : -1;
+    const inferredExt = dot > 0 ? fileName.slice(dot) : '';
     const blob = new Blob([uint8], { type: mimeType || pkmdsInferMimeType(inferredExt) });
     if (pkmdsIsIOS()) {
         // iOS ignores script-triggered downloads outside a user gesture — let the user tap.

--- a/Pkmds.Rcl/wwwroot/js/fileSave.js
+++ b/Pkmds.Rcl/wwwroot/js/fileSave.js
@@ -268,7 +268,11 @@ function pkmdsPresentDownload(fileName, blob) {
             shareBtn.style.cssText = btnStyle + 'background:#7c4dff;color:#fff;margin-bottom:2px;';
             shareBtn.addEventListener('click', async () => {
                 try {
-                    await navigator.share({ files: [file], title: fileName });
+                    // Share ONLY the file — no title/text. On iOS, when a share includes both a
+                    // file and a title/text and the user picks "Save to Files", the title is
+                    // written out as a separate .txt alongside the save (e.g. a 12-byte "text"
+                    // file containing "TR ADDED.dsv"). Files-only avoids that stray download.
+                    await navigator.share({ files: [file] });
                     finish();
                 } catch (e) {
                     // User cancelled the share sheet, or share failed — leave the dialog open

--- a/Pkmds.Rcl/wwwroot/js/fileSave.js
+++ b/Pkmds.Rcl/wwwroot/js/fileSave.js
@@ -170,6 +170,101 @@ function pkmdsInferMimeType(ext) {
     return 'application/octet-stream';
 }
 
+function pkmdsIsIOS() {
+    return /iPad|iPhone|iPod/.test(navigator.userAgent) ||
+        (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+}
+
+// iOS/iPadOS Safari (WebKit) only starts a download when the anchor click happens
+// inside a live user gesture. Our export pipeline reaches the download after several
+// awaits (unsaved-changes dialog, IsSupportedAsync interop, the download interop call),
+// by which point the transient activation is gone — so a script-triggered a.click() is
+// silently dropped and "Export Save File" appears to do nothing (issues #1044-#1060).
+//
+// Fix: instead of clicking for the user, present a real control they tap themselves.
+// The tap IS the gesture WebKit requires, so the download/share is always honored,
+// regardless of how much async ran before this point. Returns a Promise that resolves
+// once the user acts or dismisses. Used only on iOS; other platforms keep the direct
+// programmatic download, which works there.
+function pkmdsPresentDownload(fileName, blob) {
+    return new Promise((resolve) => {
+        const url = URL.createObjectURL(blob);
+        let settled = false;
+        const finish = () => {
+            if (settled) return;
+            settled = true;
+            document.removeEventListener('keydown', onKey);
+            root.remove();
+            // Keep the object URL alive long enough for the download/share to read it.
+            setTimeout(() => { try { URL.revokeObjectURL(url); } catch (e) { /* ignore */ } }, 60000);
+            resolve();
+        };
+        const onKey = (e) => { if (e.key === 'Escape') finish(); };
+
+        const root = document.createElement('div');
+        root.setAttribute('role', 'dialog');
+        root.setAttribute('aria-modal', 'true');
+        root.style.cssText = 'position:fixed;inset:0;z-index:200000;display:flex;align-items:center;justify-content:center;padding:24px;box-sizing:border-box;background:rgba(0,0,0,.62);-webkit-backdrop-filter:blur(3px);backdrop-filter:blur(3px);font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;';
+
+        const card = document.createElement('div');
+        card.style.cssText = 'background:#1e1e28;color:#fff;border-radius:16px;padding:24px 22px;width:min(420px,92vw);box-sizing:border-box;box-shadow:0 12px 40px rgba(0,0,0,.5);display:flex;flex-direction:column;gap:12px;text-align:center;';
+
+        const title = document.createElement('div');
+        title.textContent = 'Your save file is ready';
+        title.style.cssText = 'font-size:1.15rem;font-weight:700;';
+
+        const sub = document.createElement('div');
+        sub.textContent = 'Tap below to save it to your device.';
+        sub.style.cssText = 'font-size:.92rem;opacity:.8;margin-bottom:4px;';
+
+        const btnStyle = 'display:block;width:100%;box-sizing:border-box;padding:14px 18px;border-radius:9999px;font-weight:600;font-size:1rem;text-decoration:none;border:0;cursor:pointer;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;';
+
+        card.appendChild(title);
+        card.appendChild(sub);
+
+        // Primary: native share sheet ("Save to Files") when the platform can share the file.
+        let file = null;
+        try { file = new File([blob], fileName, { type: blob.type || 'application/octet-stream' }); } catch (e) { /* File ctor unsupported */ }
+        if (file && navigator.canShare && navigator.canShare({ files: [file] })) {
+            const shareBtn = document.createElement('button');
+            shareBtn.type = 'button';
+            shareBtn.textContent = 'Save to Files…';
+            shareBtn.style.cssText = btnStyle + 'background:#7c4dff;color:#fff;margin-bottom:2px;';
+            shareBtn.addEventListener('click', async () => {
+                try {
+                    await navigator.share({ files: [file], title: fileName });
+                    finish();
+                } catch (e) {
+                    // User cancelled the share sheet, or share failed — leave the dialog open
+                    // so they can still use the direct download link below.
+                }
+            });
+            card.appendChild(shareBtn);
+        }
+
+        // Always offer a direct download link the user taps (real anchor = real gesture).
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = fileName;
+        link.textContent = 'Download ' + fileName;
+        link.style.cssText = btnStyle + 'background:#fff;color:#111;';
+        link.addEventListener('click', () => { setTimeout(finish, 400); });
+        card.appendChild(link);
+
+        const cancel = document.createElement('button');
+        cancel.type = 'button';
+        cancel.textContent = 'Cancel';
+        cancel.style.cssText = btnStyle + 'background:transparent;color:#fff;border:1px solid rgba(255,255,255,.35);font-weight:500;margin-top:2px;';
+        cancel.addEventListener('click', finish);
+        card.appendChild(cancel);
+
+        root.appendChild(card);
+        root.addEventListener('click', (e) => { if (e.target === root) finish(); });
+        document.addEventListener('keydown', onKey);
+        document.body.appendChild(root);
+    });
+}
+
 window.showFilePickerAndWrite = async function (fileName, byteArray, extension, description, mimeType) {
     // byteArray is expected to be a JS array of numbers coming from a Blazor byte[]
     try {
@@ -206,17 +301,23 @@ window.showFilePickerAndWrite = async function (fileName, byteArray, extension, 
         // iOS (all browsers) uses WebKit, which may expose showSaveFilePicker but has
         // incomplete support for createWritable() — always use the anchor fallback on iOS.
         const supportsFS = !!window.showSaveFilePicker;
-        const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) ||
-            (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+        const isIOS = pkmdsIsIOS();
         if (!supportsFS || /Android/i.test(navigator.userAgent) || isIOS) {
-            console.warn('[showFilePickerAndWrite] Falling back to anchor download for this platform.');
-
             const uint8 = byteArray instanceof Uint8Array ? byteArray : new Uint8Array(byteArray);
             const blob = new Blob([uint8], {type: blobType});
 
             const hasExt = ext && fileName.toLowerCase().endsWith(ext.toLowerCase());
             const finalName = (ext && !hasExt) ? fileName + ext : fileName;
 
+            if (isIOS) {
+                // iOS drops script-triggered downloads made outside a user gesture — present a
+                // control the user taps instead of clicking the anchor for them. See pkmdsPresentDownload.
+                console.warn('[showFilePickerAndWrite] iOS: presenting user-tap download.');
+                await pkmdsPresentDownload(finalName, blob);
+                return;
+            }
+
+            console.warn('[showFilePickerAndWrite] Falling back to anchor download for this platform.');
             const a = document.createElement('a');
             a.href = URL.createObjectURL(blob);
             a.download = finalName;
@@ -285,6 +386,10 @@ window.downloadBlob = function (fileName, byteArray, mimeType) {
     const uint8 = byteArray instanceof Uint8Array ? byteArray : new Uint8Array(byteArray);
     const inferredExt = fileName ? fileName.slice(fileName.lastIndexOf('.')) : '';
     const blob = new Blob([uint8], { type: mimeType || pkmdsInferMimeType(inferredExt) });
+    if (pkmdsIsIOS()) {
+        // iOS ignores script-triggered downloads outside a user gesture — let the user tap.
+        return pkmdsPresentDownload(fileName, blob);
+    }
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;

--- a/Pkmds.Rcl/wwwroot/js/fileSave.js
+++ b/Pkmds.Rcl/wwwroot/js/fileSave.js
@@ -223,9 +223,16 @@ function pkmdsPresentDownload(fileName, blob) {
         card.appendChild(sub);
 
         // Primary: native share sheet ("Save to Files") when the platform can share the file.
+        // Guard both the File ctor and canShare: navigator.canShare({ files }) can throw on some
+        // WebKit builds (Web Share present but file-sharing unsupported / payload rejected). An
+        // unguarded throw here would reject pkmdsPresentDownload before the overlay is appended,
+        // aborting export on iOS with no download link at all — the very platform this fixes. On
+        // any failure we simply skip the share button and fall through to the direct download link.
         let file = null;
         try { file = new File([blob], fileName, { type: blob.type || 'application/octet-stream' }); } catch (e) { /* File ctor unsupported */ }
-        if (file && navigator.canShare && navigator.canShare({ files: [file] })) {
+        let canShareFile = false;
+        try { canShareFile = !!(file && navigator.canShare && navigator.canShare({ files: [file] })); } catch (e) { canShareFile = false; }
+        if (canShareFile) {
             const shareBtn = document.createElement('button');
             shareBtn.type = 'button';
             shareBtn.textContent = 'Save to Files…';


### PR DESCRIPTION
## Problem

Every open issue from #1044 through #1060 is the same regression: **"Export Save File" does nothing on iOS** — no download, no error. Desktop is unaffected. Affected reporters are all on iOS/WebKit (Safari + other iOS browsers, all WebKit).

Closes #1044, #1047, #1050, #1051, #1054, #1055, #1056, #1057, #1058, #1059, #1060.

## Root cause (revised — see history below)

iOS WebKit only starts a download when the anchor click happens inside a **live user gesture**. The export pipeline reaches the download after several `await`s (unsaved-changes dialog → `IsSupportedAsync` interop → the download interop call), so the transient activation is already gone and the script-triggered `a.click()` is silently dropped.

## Fix (the real one)

On iOS, stop clicking the anchor programmatically. Present a small modal with a **real, user-tappable control**:
- **Save to Files…** (native share sheet via `navigator.share`) when `navigator.canShare` supports the file, and
- a direct **Download** link (`<a href=blob download>`).

The user's tap is the gesture WebKit requires, so the download/share is always honored. Non-iOS platforms keep the existing direct programmatic download, which works there. All export/download call sites funnel through `showFilePickerAndWrite` and `downloadBlob`, so all are covered. `WriteFileOldWay` now delegates to `downloadBlob` (single interop hop), dropping the old `eval` + data-URI + detached-anchor path that iOS silently ignored and that relied on `unsafe-eval`.

**Confirmed working on a real iOS device** (issue #1058 reporter): both "Save to Files…" and the Download link now export successfully.

### Also in this PR
- Fix `EnsureExtension` appending a bare `.` to extension-less names (`violet_main` → `violet_main.`).
- Fix `downloadBlob` MIME inference for extension-less names (`slice(lastIndexOf('.'))` returned the last char when there was no dot).
- Download dialog accessibility: `aria-labelledby`/`aria-describedby`, focus moved into the dialog on open + restored on close, Tab trapped within the modal.
- Guard `navigator.canShare` (it can throw on some WebKit builds; an unguarded throw would abort export before the dialog appears).

### MudBlazor 9.5.0 pin — disproven mitigation, retained out of caution
The first commit pinned MudBlazor 9.6.0 → 9.5.0 on the theory that 9.6.0's `MudMenuItem` OnClick reorder (`ef59e90d2`) broke export. **An on-device iOS retest disproved that — export still failed on 9.5.0.** The pin is kept only as a precaution; it is **not** the fix. Unpinning to current MudBlazor is tracked in **#1063** (the fix above is MudBlazor-version-independent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)