### PR TITLE
chore(deps): unpin and update MudBlazor to 9.7.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,21 +21,7 @@
     <PackageVersion Include="Microsoft.JSInterop.WebAssembly" Version="10.0.3" />
     <!-- Windows Shell preview-handler PoC only (tools/windows-preview-poc). -->
     <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.3967.48" />
-    <!--
-      Pinned to 9.5.0, but NOTE: this pin is NOT what fixed the iOS export outage
-      (#1044-#1060). It was an initial mitigation attempt based on the theory that
-      MudBlazor 9.6.0's MudMenuItem OnClick reorder (ef59e90d2) broke the export;
-      an on-device iOS retest disproved that — export still failed on 9.5.0. The
-      actual root cause is that iOS WebKit only honors a download inside a live user
-      gesture, and our export pipeline clicked the anchor after several awaits; the
-      real fix is the user-tap download in Pkmds.Rcl/wwwroot/js/fileSave.js
-      (pkmdsPresentDownload) and the WriteFileOldWay -> downloadBlob change, which are
-      MudBlazor-version-independent. The pin is retained only out of caution; unpinning
-      to current MudBlazor is tracked in #1063. If you unpin, drop the app.css
-      .mud-tab-panel override too only if it's no longer needed (commit 71640687
-      offsets the 9.6.0 display:contents tab-panel change).
-    -->
-    <PackageVersion Include="MudBlazor" Version="9.5.0" />
+    <PackageVersion Include="MudBlazor" Version="9.7.0" />
     <PackageVersion Include="PKHeX.Core" Version="26.5.5" />
     <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageVersion Include="Serilog.Sinks.BrowserConsole" Version="8.0.0" />


### PR DESCRIPTION
Removes the MudBlazor 9.5.0 pin and updates to the current release (9.7.0).

## Context
The 9.5.0 pin (originally in #1061) was a **disproven** mitigation for the iOS export outage (#1044–#1060). An on-device retest showed export still failed on 9.5.0; the real cause was iOS/WebKit requiring a live user gesture for downloads. The actual fix — the user-tap download dialog (`pkmdsPresentDownload`) and `WriteFileOldWay` → `downloadBlob` — shipped in #1061, is MudBlazor-version-independent, and is confirmed working on iOS Safari and Chrome.

## Changes
- `Directory.Packages.props`: MudBlazor `9.5.0` → `9.7.0`, pin comment removed.
- **Kept** the `app.css` `.mud-tab-panel` override (commit 71640687): MudBlazor 9.6.0+ still renders the active tab panel with `display:contents`, so the override is still needed for phone scrolling.

## Verification
- `dotnet build` clean (0 warnings / 0 errors; Debug treats warnings as errors, so no new 9.7.0 analyzer breakage).
- UAT smoke check on the preview build (app renders, export prompt works, phone scrolling intact).

## Issue tracking
Closes #1063 — its headline deliverables (iOS user-activation hardening in #1061, and this MudBlazor unpin) are both done. Its remaining acceptance criterion, the export→download **regression test**, is spun off to #1066 so it isn't dropped (per Copilot's review note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)