### PR TITLE
Fix recent save export, detection, search, and startup regressions

### DIFF
--- a/Pkmds.Core/Extensions/SaveFileExtensions.cs
+++ b/Pkmds.Core/Extensions/SaveFileExtensions.cs
@@ -10,6 +10,14 @@ public static class SaveFileExtensions
     private const int PartySize = 6;
 
     /// <summary>
+    /// Runs the same storage finalization hook used by PKHeX before serializing a save.
+    /// LGPE in particular keeps unified storage in a form that must be compacted before export.
+    /// </summary>
+    /// <returns><see langword="true" /> when finalization changed the save.</returns>
+    public static bool PrepareForExport(this SaveFile sav) =>
+        sav is IStorageCleanup cleanup && cleanup.FixStoragePreWrite();
+
+    /// <summary>
     /// Validates that a freshly parsed save satisfies the core invariants the editor relies on,
     /// returning <see langword="false"/> with a user-facing <paramref name="reason"/> for saves that
     /// parse structurally but are unsafe to edit. This catches two cases the bare

--- a/Pkmds.Core/Utilities/SaveArchiveHelper.cs
+++ b/Pkmds.Core/Utilities/SaveArchiveHelper.cs
@@ -1,0 +1,160 @@
+using System.Diagnostics.CodeAnalysis;
+using System.IO.Compression;
+
+namespace Pkmds.Core.Utilities;
+
+public enum SaveArchiveKind
+{
+    GenericZip,
+    ManicEmu
+}
+
+/// <summary>
+/// Captures the ZIP wrapper around a loaded save so exports can replace the inner save without
+/// changing the file format the emulator expects.
+/// </summary>
+public sealed record SaveArchiveContext(
+    byte[] OriginalZipBytes,
+    string SaveEntryPath,
+    SaveArchiveKind Kind)
+{
+    public bool IsManicEmu => Kind == SaveArchiveKind.ManicEmu;
+}
+
+/// <summary>
+/// Loads and rebuilds ordinary ZIP-wrapped saves. Manic EMU archives keep using their dedicated
+/// writer because that emulator requires ZIPFoundation-compatible headers and store compression.
+/// </summary>
+public static class SaveArchiveHelper
+{
+    private const long MaxUncompressedEntrySize = 8 * 1024 * 1024;
+    private const int MaxTotalEntries = 500;
+
+    public static bool TryExtractGenericZip(
+        byte[] zipBytes,
+        [NotNullWhen(true)] out SaveFile? saveFile,
+        [NotNullWhen(true)] out SaveArchiveContext? context)
+    {
+        saveFile = null;
+        context = null;
+
+        if (!ManicEmuSaveHelper.IsZip(zipBytes))
+        {
+            return false;
+        }
+
+        try
+        {
+            using var zipStream = new MemoryStream(zipBytes);
+            using var archive = new ZipArchive(zipStream, ZipArchiveMode.Read);
+            if (archive.Entries.Count is 0 or > MaxTotalEntries)
+            {
+                return false;
+            }
+
+            foreach (var entry in GetCandidateEntries(archive))
+            {
+                if (entry.Length is 0 or > MaxUncompressedEntrySize || !SaveUtil.IsSizeValid(entry.Length))
+                {
+                    continue;
+                }
+
+                var entryBytes = ReadEntryWithLimit(entry);
+                if (entryBytes is null ||
+                    !SaveFileLoader.TryLoadRawSave(entryBytes, entry.FullName, out var parsedSave))
+                {
+                    continue;
+                }
+
+                saveFile = parsedSave;
+                context = new SaveArchiveContext(zipBytes, entry.FullName, SaveArchiveKind.GenericZip);
+                return true;
+            }
+        }
+        catch (InvalidDataException)
+        {
+            // Malformed ZIP data is not a supported save archive.
+        }
+        catch (IOException)
+        {
+            // Truncated or otherwise unreadable ZIP data.
+        }
+        catch (NotSupportedException)
+        {
+            // Unsupported ZIP feature.
+        }
+
+        return false;
+    }
+
+    public static byte[] RebuildZip(SaveArchiveContext context, byte[] newSaveBytes)
+    {
+        if (context.IsManicEmu)
+        {
+            var manicContext = new ManicEmuSaveHelper.ManicEmuSaveContext(
+                context.OriginalZipBytes,
+                context.SaveEntryPath);
+            return ManicEmuSaveHelper.RebuildZip(manicContext, newSaveBytes);
+        }
+
+        using var resultStream = new MemoryStream();
+        resultStream.Write(context.OriginalZipBytes);
+        resultStream.Position = 0;
+
+        using (var archive = new ZipArchive(resultStream, ZipArchiveMode.Update, leaveOpen: true))
+        {
+            if (archive.Entries.Count > MaxTotalEntries)
+            {
+                throw new InvalidDataException($"Save archive contains more than {MaxTotalEntries} entries.");
+            }
+
+            var entry = archive.GetEntry(context.SaveEntryPath)
+                        ?? throw new InvalidDataException(
+                            $"Save entry '{context.SaveEntryPath}' is missing from the archive.");
+            using var entryStream = entry.Open();
+            entryStream.SetLength(0);
+            entryStream.Write(newSaveBytes);
+        }
+
+        return resultStream.ToArray();
+    }
+
+    private static IEnumerable<ZipArchiveEntry> GetCandidateEntries(ZipArchive archive)
+    {
+        if (archive.Entries.Count == 1)
+        {
+            yield return archive.Entries[0];
+            yield break;
+        }
+
+        foreach (var entry in archive.Entries)
+        {
+            if (entry.Name.Equals("main", StringComparison.OrdinalIgnoreCase) ||
+                entry.Name.Equals("SaveData.bin", StringComparison.OrdinalIgnoreCase))
+            {
+                yield return entry;
+            }
+        }
+    }
+
+    private static byte[]? ReadEntryWithLimit(ZipArchiveEntry entry)
+    {
+        using var destination = new MemoryStream((int)entry.Length);
+        using var source = entry.Open();
+        var buffer = new byte[81920];
+        long totalRead = 0;
+        int read;
+        while ((read = source.Read(buffer, 0, buffer.Length)) > 0)
+        {
+            totalRead += read;
+            if (totalRead > MaxUncompressedEntrySize)
+            {
+                return null;
+            }
+
+            destination.Write(buffer, 0, read);
+        }
+
+        return destination.ToArray();
+    }
+}

--- a/Pkmds.Core/Utilities/SaveFileLoader.cs
+++ b/Pkmds.Core/Utilities/SaveFileLoader.cs
@@ -1,55 +1,116 @@
 using System.Diagnostics.CodeAnalysis;
+using static System.Buffers.Binary.BinaryPrimitives;
 
 namespace Pkmds.Core.Utilities;
 
 /// <summary>
-/// Unified entry point for loading user-supplied save data. Detects Manic EMU
-/// <c>.3ds.sav</c> ZIP archives before delegating to <see cref="SaveUtil.TryGetSaveFile(Memory{byte}, out SaveFile?, string?)" />
-/// for raw saves.
+/// Unified entry point for loading user-supplied save data. Captures ZIP wrappers before
+/// delegating to PKHeX for raw-save detection so exports can preserve the original format.
 /// </summary>
 /// <remarks>
 /// The ordering here is load-bearing. PKHeX.Core's built-in <see cref="ZipReader" />
 /// (registered in <see cref="SaveUtil.CustomSaveReaders" />) recognises any ZIP with a
 /// <c>main</c> or <c>SaveData.bin</c> entry and unwraps it invisibly — including Manic EMU
 /// archives. If we call <see cref="SaveUtil.TryGetSaveFile(Memory{byte}, out SaveFile?, string?)" />
-/// first on a Manic EMU ZIP we get back a valid <see cref="SaveFile" />, but the surrounding
-/// <see cref="ManicEmuSaveHelper.ManicEmuSaveContext" /> (needed to rebuild the archive on export)
-/// is silently lost, and the user ends up exporting raw bytes that Manic EMU rejects
-/// on re-import (issue #750).
+/// first on a ZIP we get back a valid <see cref="SaveFile" />, but the surrounding archive
+/// metadata is silently lost. Export then writes bare save bytes under a <c>.zip</c> filename,
+/// which emulators reject as corrupt (issues #750 and #1131-#1133).
 /// </remarks>
 public static class SaveFileLoader
 {
     /// <summary>
-    /// Attempts to load <paramref name="data" /> as either a Manic EMU ZIP archive or a raw save.
+    /// Attempts to load <paramref name="data" /> as either a ZIP archive or a raw save.
     /// </summary>
     /// <param name="data">Raw upload bytes.</param>
     /// <param name="fileName">Original filename of the upload (may be <see langword="null" />).</param>
     /// <param name="saveFile">
     /// The parsed <see cref="SaveFile" /> instance on success.
     /// </param>
-    /// <param name="manicEmuContext">
-    /// Non-<see langword="null" /> only when the upload was a Manic EMU ZIP. Pass this back to
-    /// <see cref="ManicEmuSaveHelper.RebuildZip" /> on export to round-trip correctly.
+    /// <param name="archiveContext">
+    /// Non-<see langword="null" /> only when the upload was a supported ZIP. Pass this back to
+    /// <see cref="SaveArchiveHelper.RebuildZip" /> on export to round-trip correctly.
     /// </param>
     /// <returns><see langword="true" /> on successful load; <see langword="false" /> otherwise.</returns>
     public static bool TryLoad(
         byte[] data,
         string? fileName,
         [NotNullWhen(true)] out SaveFile? saveFile,
-        out ManicEmuSaveHelper.ManicEmuSaveContext? manicEmuContext)
+        out SaveArchiveContext? archiveContext)
     {
-        manicEmuContext = null;
+        archiveContext = null;
 
         // Manic EMU detection must run before SaveUtil.TryGetSaveFile because PKHeX's ZipReader
         // would otherwise unwrap the archive invisibly, stripping the context we need for re-export.
-        if (!ManicEmuSaveHelper.IsZip(data) ||
-            !ManicEmuSaveHelper.TryExtractSaveFromZip(data, fileName, out saveFile, out var ctx))
+        if (ManicEmuSaveHelper.IsZip(data))
         {
-            return SaveUtil.TryGetSaveFile(data, out saveFile, fileName);
+            if (ManicEmuSaveHelper.TryExtractSaveFromZip(data, fileName, out saveFile, out var manicContext))
+            {
+                archiveContext = new SaveArchiveContext(
+                    manicContext.OriginalZipBytes,
+                    manicContext.SaveEntryPath,
+                    SaveArchiveKind.ManicEmu);
+                return true;
+            }
+
+            if (SaveArchiveHelper.TryExtractGenericZip(data, out saveFile, out var genericContext))
+            {
+                archiveContext = genericContext;
+                return true;
+            }
         }
 
-        manicEmuContext = ctx;
-        return true;
+        return TryLoadRawSave(data, fileName, out saveFile);
+    }
 
+    internal static bool TryLoadRawSave(
+        byte[] data,
+        string? fileName,
+        [NotNullWhen(true)] out SaveFile? saveFile)
+    {
+        // Gen 4 and Gen 5 raw saves share the same 512 KiB size. PKHeX currently checks the
+        // Gen 4 signatures first, so unrelated Gen 5 extdata can occasionally satisfy an HGSS
+        // footer signature and win before PKHeX examines the valid Gen 5 checksum footer
+        // (issue #1127). Prefer a checksum-valid Gen 5 footer before delegating to the
+        // normal detector. This mirrors PKHeX's own footer validation; it does not repair or
+        // guess at damaged data.
+        if (TryLoadGen5ByFooter(data, out saveFile))
+        {
+            return true;
+        }
+
+        return SaveUtil.TryGetSaveFile(data, out saveFile, fileName);
+    }
+
+    private static bool TryLoadGen5ByFooter(
+        byte[] data,
+        [NotNullWhen(true)] out SaveFile? saveFile)
+    {
+        saveFile = null;
+        if (data.Length != SaveUtil.SIZE_G5RAW)
+        {
+            return false;
+        }
+
+        if (HasValidGen5Footer(data, SaveUtil.SIZE_G5BW, 0x8C))
+        {
+            saveFile = new SAV5BW(data);
+            return true;
+        }
+
+        if (HasValidGen5Footer(data, SaveUtil.SIZE_G5B2W2, 0x94))
+        {
+            saveFile = new SAV5B2W2(data);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool HasValidGen5Footer(ReadOnlySpan<byte> data, int mainSize, int infoLength)
+    {
+        var footer = data.Slice(mainSize - 0x100, infoLength + 0x10);
+        var stored = ReadUInt16LittleEndian(footer[^2..]);
+        var actual = Checksums.CRC16_CCITT(footer[..infoLength]);
+        return stored == actual;
     }
 }

--- a/Pkmds.Rcl/Components/AutocompleteSelect.razor.cs
+++ b/Pkmds.Rcl/Components/AutocompleteSelect.razor.cs
@@ -30,7 +30,10 @@ public partial class AutocompleteSelect<T>
 
     [Parameter] public bool Strict { get; set; } = true;
 
-    [Parameter] public int? MaxItems { get; set; }
+    // Keep MudAutocomplete's own bounded default. Leaving this null overrides MudBlazor's
+    // default of 10 and renders every match, which made one-letter item searches stall for
+    // several seconds on mobile devices (issue #1122).
+    [Parameter] public int? MaxItems { get; set; } = 10;
 
     [Parameter] public int DebounceInterval { get; set; } = 100;
 

--- a/Pkmds.Rcl/Components/Dialogs/BackupManagerDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/BackupManagerDialog.razor.cs
@@ -15,10 +15,7 @@ public partial class BackupManagerDialog
     public string? FileName { get; set; }
 
     [Parameter]
-    public bool IsManicEmu { get; set; }
-
-    [Parameter]
-    public ManicEmuSaveHelper.ManicEmuSaveContext? ManicEmuContext { get; set; }
+    public SaveArchiveContext? ArchiveContext { get; set; }
 
     [Inject]
     private IBackupService BackupService { get; set; } = null!;
@@ -49,11 +46,17 @@ public partial class BackupManagerDialog
             return;
         }
 
+        SaveFile.PrepareForExport();
         var rawBytes = SaveFile.Write().ToArray();
-        var data = IsManicEmu && ManicEmuContext is not null
-            ? ManicEmuSaveHelper.RebuildZip(ManicEmuContext, rawBytes)
+        var data = ArchiveContext is not null
+            ? SaveArchiveHelper.RebuildZip(ArchiveContext, rawBytes)
             : rawBytes;
-        await BackupService.CreateBackupAsync(data, SaveFile, FileName, isManicEmu: IsManicEmu, source: "manual");
+        await BackupService.CreateBackupAsync(
+            data,
+            SaveFile,
+            FileName,
+            isManicEmu: ArchiveContext?.IsManicEmu == true,
+            source: "manual");
         await BackupService.EnforceRetentionAsync(SettingsService.Settings.MaxBackupCount);
         await LoadBackups();
         Snackbar.Add("Backup created.", Severity.Success);

--- a/Pkmds.Rcl/Components/Dialogs/BugReportDialog.razor
+++ b/Pkmds.Rcl/Components/Dialogs/BugReportDialog.razor
@@ -109,7 +109,7 @@
             @if (ShowSaveAttach)
             {
                 <MudSwitch @bind-Value="@attachSaveFile"
-                           Label="Attach current save file"
+                           Label="Attach original uploaded save file"
                            Disabled="@(!HasSaveFile || uploadedBytes is not null)"
                            Color="@Color.Primary"/>
                 <MudFileUpload T="IBrowserFile"

--- a/Pkmds.Rcl/Components/Dialogs/BugReportDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/BugReportDialog.razor.cs
@@ -180,7 +180,10 @@ public partial class BugReportDialog
                 // Always populate source/type diagnostics — triagers need to know whether a Gen
                 // 1 save came from a VC dump or a physical cartridge even when the user opts
                 // out of attaching the save bytes, since legality rules diverge between them.
-                saveFileSource = SaveSourceDetector.Detect(sf, AppState.SaveFileName, AppState.ManicEmuSaveContext is not null);
+                saveFileSource = SaveSourceDetector.Detect(
+                    sf,
+                    AppState.SaveFileName,
+                    AppState.SaveArchiveContext?.IsManicEmu == true);
                 saveFileType = sf.GetType().Name;
             }
 
@@ -193,32 +196,41 @@ public partial class BugReportDialog
                 saveBytes = uploadedBytes;
                 saveFileName = uploadedFileName ?? "save.bin";
             }
+            else if (ShowSaveAttach && attachSaveFile && AppState.OriginalSaveFileBytes is { Length: > 0 } originalBytes)
+            {
+                // Preserve the exact upload for diagnostics. Serializing the parsed object can
+                // contaminate the evidence when format detection itself is the bug: issue #1127's
+                // White 2 input was misdetected as HGSS, then the old report path wrote HGSS
+                // checksums into the attached copy.
+                saveBytes = originalBytes;
+                saveFileName = AppState.SaveFileName ?? "save.bin";
+            }
             else if (ShowSaveAttach && attachSaveFile && AppState.SaveFile is { } currentSave)
             {
+                currentSave.PrepareForExport();
                 var rawBytes = currentSave.Write().ToArray();
-                // If the current save was loaded from a Manic EMU .3ds.sav ZIP, rebuild the
-                // archive so the bug report preserves the wrapper. Without this the submitted
-                // bytes are the bare inner save and we can never diagnose ZIP round-trip
-                // issues from user reports (see issue #750). The attachment name must carry
-                // the compound extension so triagers can see at a glance the payload is a ZIP
-                // and not a bare .sav — a generic save.bin fallback would mask that.
+                // Preserve any ZIP wrapper captured during load. Without this the submitted
+                // bytes are the bare inner save and archive round-trip bugs become impossible
+                // to diagnose (issues #750 and #1131-#1133).
                 //
                 // RebuildZip can throw (InvalidDataException on oversized non-save entries,
                 // corrupt archives, etc.). Getting the report through matters more than the
                 // wrapper, so on failure we fall back to the bare save — the submission
                 // itself must not be blocked by an attach-side issue.
-                if (AppState.ManicEmuSaveContext is { } ctx)
+                if (AppState.SaveArchiveContext is { } ctx)
                 {
                     try
                     {
-                        saveBytes = ManicEmuSaveHelper.RebuildZip(ctx, rawBytes);
-                        saveFileName = ManicEmuSaveHelper.GetExportFileName(AppState.SaveFileName).ExportName;
+                        saveBytes = SaveArchiveHelper.RebuildZip(ctx, rawBytes);
+                        saveFileName = ctx.IsManicEmu
+                            ? ManicEmuSaveHelper.GetExportFileName(AppState.SaveFileName).ExportName
+                            : AppState.SaveFileName ?? "save.zip";
                     }
                     catch (Exception ex)
                     {
-                        Logger.LogWarning(ex, "Failed to rebuild Manic EMU ZIP for bug report attachment; falling back to bare save");
+                        Logger.LogWarning(ex, "Failed to rebuild save ZIP for bug report attachment; falling back to bare save");
                         saveBytes = rawBytes;
-                        saveFileName = AppState.SaveFileName ?? "save.bin";
+                        saveFileName = GetBareSaveFileName(AppState.SaveFileName, currentSave.Extension);
                     }
                 }
                 else
@@ -256,5 +268,13 @@ public partial class BugReportDialog
             isSubmitting = false;
             StateHasChanged();
         }
+    }
+
+    private static string GetBareSaveFileName(string? originalName, string extension)
+    {
+        var stem = string.IsNullOrWhiteSpace(originalName)
+            ? "save"
+            : Path.GetFileNameWithoutExtension(originalName);
+        return $"{stem}{extension}";
     }
 }

--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
@@ -146,7 +146,7 @@ public partial class MainLayout : IDisposable
     }
 
     private async Task ReloadApp() =>
-        await JSRuntime.InvokeVoidAsync("location.reload");
+        await JSRuntime.InvokeVoidAsync("applyUpdate");
 
     private bool ComputeIsDarkMode() => themeMode switch
     {
@@ -400,7 +400,12 @@ public partial class MainLayout : IDisposable
 
     private async Task ShowBackupManagerDialog()
     {
-        var parameters = new DialogParameters { { nameof(BackupManagerDialog.SaveFile), AppState.SaveFile }, { nameof(BackupManagerDialog.FileName), AppState.SaveFileName }, { nameof(BackupManagerDialog.IsManicEmu), AppState.ManicEmuSaveContext is not null }, { nameof(BackupManagerDialog.ManicEmuContext), AppState.ManicEmuSaveContext } };
+        var parameters = new DialogParameters
+        {
+            { nameof(BackupManagerDialog.SaveFile), AppState.SaveFile },
+            { nameof(BackupManagerDialog.FileName), AppState.SaveFileName },
+            { nameof(BackupManagerDialog.ArchiveContext), AppState.SaveArchiveContext }
+        };
         var options = await DialogOptionsHelper.BuildAsync(MaxWidth.Medium);
         var dialog = await DialogService.ShowAsync<BackupManagerDialog>("Backup Manager", parameters, options);
         var result = await dialog.Result;
@@ -439,9 +444,10 @@ public partial class MainLayout : IDisposable
         try
         {
             var data = restore.SaveBytes;
+            var originalData = data.ToArray();
             var fileName = restore.Entry.FileName;
 
-            if (SaveFileLoader.TryLoad(data, fileName, out var saveFile, out var manicContext))
+            if (SaveFileLoader.TryLoad(data, fileName, out var saveFile, out var archiveContext))
             {
                 if (!saveFile.IsSupportedForEditing(out var unsupportedReason))
                 {
@@ -451,7 +457,8 @@ public partial class MainLayout : IDisposable
                     return;
                 }
 
-                AppState.ManicEmuSaveContext = manicContext;
+                AppState.OriginalSaveFileBytes = originalData;
+                AppState.SaveArchiveContext = archiveContext;
                 FinishLoadingSaveFile(saveFile, fileName);
             }
             else
@@ -552,7 +559,7 @@ public partial class MainLayout : IDisposable
         AppService.ClearSelection();
         ParseSettings.ClearActiveTrainer();
         AppState.SaveFile = null;
-        AppState.ManicEmuSaveContext = null;
+        AppState.SaveArchiveContext = null;
         AppState.ShowProgressIndicator = true;
 
         // Now broadcast the state flip so SaveFileComponent's skeleton paints, then yield via
@@ -563,12 +570,13 @@ public partial class MainLayout : IDisposable
 
         try
         {
-            // SaveFileLoader checks for a Manic EMU .3ds.sav ZIP (sdmc/… entries) before delegating
+            var originalData = data.ToArray();
+            // SaveFileLoader captures supported ZIP wrappers before delegating
             // to SaveUtil.TryGetSaveFile for raw saves. The ordering matters: PKHeX's built-in
             // ZipReader would otherwise recognise the archive by its inner `main` entry and unwrap
-            // it invisibly, so manicContext would never be set and export would silently produce
-            // raw bytes that Manic EMU rejects on re-import (see issue #750).
-            if (SaveFileLoader.TryLoad(data, selectedFile.Name, out var saveFile, out var manicContext))
+            // it invisibly, so archiveContext would never be set and export would silently produce
+            // raw bytes under a ZIP filename (see issues #750 and #1131-#1133).
+            if (SaveFileLoader.TryLoad(data, selectedFile.Name, out var saveFile, out var archiveContext))
             {
                 if (!saveFile.IsSupportedForEditing(out var unsupportedReason))
                 {
@@ -578,13 +586,20 @@ public partial class MainLayout : IDisposable
                     return;
                 }
 
-                if (manicContext is not null)
+                AppState.OriginalSaveFileBytes = originalData;
+                if (archiveContext is not null)
                 {
-                    AppState.ManicEmuSaveContext = manicContext;
-                    Logger.LogInformation("Loaded save from Manic EMU .3ds.sav archive; entry: {EntryPath}", manicContext.SaveEntryPath);
-                    Snackbar.Add(
-                        "Manic EMU save archive detected — export will rebuild the ZIP for seamless re-import.",
-                        Severity.Info);
+                    AppState.SaveArchiveContext = archiveContext;
+                    Logger.LogInformation(
+                        "Loaded save archive ({ArchiveKind}); entry: {EntryPath}",
+                        archiveContext.Kind,
+                        archiveContext.SaveEntryPath);
+                    if (archiveContext.IsManicEmu)
+                    {
+                        Snackbar.Add(
+                            "Manic EMU save archive detected — export will rebuild the ZIP for seamless re-import.",
+                            Severity.Info);
+                    }
                 }
 
                 FinishLoadingSaveFile(saveFile, selectedFile.Name);
@@ -622,13 +637,14 @@ public partial class MainLayout : IDisposable
         {
             try
             {
+                AppState.SaveFile.PrepareForExport();
                 var rawSave = AppState.SaveFile.Write().ToArray();
-                var backupBytes = AppState.ManicEmuSaveContext is not null
-                    ? ManicEmuSaveHelper.RebuildZip(AppState.ManicEmuSaveContext, rawSave)
+                var backupBytes = AppState.SaveArchiveContext is not null
+                    ? SaveArchiveHelper.RebuildZip(AppState.SaveArchiveContext, rawSave)
                     : rawSave;
                 await BackupService.CreateBackupAsync(
                     backupBytes, AppState.SaveFile, selectedFile.Name,
-                    isManicEmu: AppState.ManicEmuSaveContext is not null, source: "auto");
+                    isManicEmu: AppState.SaveArchiveContext?.IsManicEmu == true, source: "auto");
                 await BackupService.EnforceRetentionAsync(SettingsService.Settings.MaxBackupCount);
             }
             catch (Exception ex)
@@ -714,6 +730,11 @@ public partial class MainLayout : IDisposable
 
         try
         {
+            if (AppState.SaveFile.PrepareForExport())
+            {
+                RefreshService.RefreshBoxAndPartyState();
+            }
+
             var rawSaveBytes = AppState.SaveFile.Write().ToArray();
             // Prefer AppState.SaveFileName — it's set consistently by both the upload path and
             // the restore-from-backup path, whereas browserLoadSaveFile?.Name is null whenever
@@ -722,19 +743,25 @@ public partial class MainLayout : IDisposable
             // ".3ds.sav" compound extension on re-export.
             var originalName = AppState.SaveFileName ?? browserLoadSaveFile?.Name;
 
-            // If the save was loaded from a Manic EMU .3ds.sav ZIP, rebuild the ZIP so the
-            // user can import it directly back into Manic EMU without any manual repacking.
-            if (AppState.ManicEmuSaveContext is not null)
+            // If the save was loaded from an archive, replace the inner save and preserve
+            // the wrapper expected by the originating emulator.
+            if (AppState.SaveArchiveContext is { } archiveContext)
             {
-                // Echo back whichever compound extension the upload carried (.3ds.sav canonically, or
-                // .3ds.save if the user renamed manually or iOS Safari mangled the suffix) so the
-                // round-trip is bit-for-bit transparent. Flag the MIME as application/zip — the default
-                // application/x-pokemon-savedata is wrong for an archive and confuses iOS Safari.
-                var (exportName, compoundExt) = ManicEmuSaveHelper.GetExportFileName(originalName);
-                Logger.LogDebug("Exporting save as Manic EMU {Extension}: {FileName}", compoundExt, exportName);
-
-                var zipBytes = ManicEmuSaveHelper.RebuildZip(AppState.ManicEmuSaveContext, rawSaveBytes);
-                await WriteFile(zipBytes, exportName, compoundExt, "Save File", mimeType: "application/zip");
+                var zipBytes = SaveArchiveHelper.RebuildZip(archiveContext, rawSaveBytes);
+                if (archiveContext.IsManicEmu)
+                {
+                    // Echo back whichever compound extension the upload carried (.3ds.sav canonically,
+                    // or .3ds.save) so the round-trip remains transparent to Manic EMU.
+                    var (exportName, compoundExt) = ManicEmuSaveHelper.GetExportFileName(originalName);
+                    Logger.LogDebug("Exporting save as Manic EMU {Extension}: {FileName}", compoundExt, exportName);
+                    await WriteFile(zipBytes, exportName, compoundExt, "Save File", mimeType: "application/zip");
+                }
+                else
+                {
+                    var exportName = string.IsNullOrWhiteSpace(originalName) ? "save.zip" : originalName;
+                    Logger.LogDebug("Exporting save in original ZIP wrapper: {FileName}", exportName);
+                    await WriteFile(zipBytes, exportName, ".zip", "Save File", mimeType: "application/zip");
+                }
             }
             // Only default to "save.sav" if we have no original filename at all
             else if (string.IsNullOrWhiteSpace(originalName))

--- a/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor.cs
@@ -4,9 +4,9 @@ public partial class TradeTab : RefreshAwareComponent
 {
     private bool isLoading;
 
-    // Preserve the slot-B Manic EMU ZIP context across the session so Export Slot B
-    // can rebuild the .3ds.sav/.3ds.save ZIP without requiring the user to re-upload.
-    private ManicEmuSaveHelper.ManicEmuSaveContext? manicEmuSaveContextB;
+    // Preserve the slot-B ZIP context so Export Slot B can replace the inner save
+    // without changing the wrapper expected by the originating emulator.
+    private SaveArchiveContext? saveArchiveContextB;
 
     [Inject]
     private IBackupService BackupService { get; set; } = null!;
@@ -86,7 +86,7 @@ public partial class TradeTab : RefreshAwareComponent
         StateHasChanged();
 
         SaveFile? loadedSave = null;
-        ManicEmuSaveHelper.ManicEmuSaveContext? manicContext = null;
+        SaveArchiveContext? archiveContext = null;
 
         try
         {
@@ -95,28 +95,15 @@ public partial class TradeTab : RefreshAwareComponent
             await fileStream.CopyToAsync(memoryStream);
             var data = memoryStream.ToArray();
 
-            if (SaveUtil.TryGetSaveFile(data, out var saveFile, selectedFile.Name))
+            if (SaveFileLoader.TryLoad(data, selectedFile.Name, out var saveFile, out archiveContext))
             {
-                if (!saveFile.State.Exportable)
+                if (!saveFile.IsSupportedForEditing(out var unsupportedReason))
                 {
-                    await DialogService.ShowMessageBoxAsync("Unsupported save file",
-                        "This save file cannot be loaded — it may be from an unsupported ROM hack or format.");
+                    await DialogService.ShowMessageBoxAsync("Unsupported save file", unsupportedReason);
                     return;
                 }
 
                 loadedSave = saveFile;
-            }
-            else if (ManicEmuSaveHelper.TryExtractSaveFromZip(data, selectedFile.Name, out saveFile, out var ctx))
-            {
-                if (!saveFile.State.Exportable)
-                {
-                    await DialogService.ShowMessageBoxAsync("Unsupported save file",
-                        "This save file cannot be loaded — it may be from an unsupported ROM hack or format.");
-                    return;
-                }
-
-                loadedSave = saveFile;
-                manicContext = ctx;
             }
             else
             {
@@ -138,7 +125,7 @@ public partial class TradeTab : RefreshAwareComponent
             AppState.SelectedBoxNumberB = loadedSave.CurrentBox;
             AppState.SelectedBoxSlotNumberB = null;
             AppState.SelectedPartySlotNumberB = null;
-            manicEmuSaveContextB = manicContext;
+            saveArchiveContextB = archiveContext;
 
             // Per-slot on-load backup. Identical contract to the slot-A load path:
             // bytes come from the freshly loaded SaveFile (handles Manic EMU rebuild),
@@ -148,13 +135,14 @@ public partial class TradeTab : RefreshAwareComponent
             {
                 try
                 {
+                    loadedSave.PrepareForExport();
                     var rawSave = loadedSave.Write().ToArray();
-                    var backupBytes = manicContext is not null
-                        ? ManicEmuSaveHelper.RebuildZip(manicContext, rawSave)
+                    var backupBytes = archiveContext is not null
+                        ? SaveArchiveHelper.RebuildZip(archiveContext, rawSave)
                         : rawSave;
                     await BackupService.CreateBackupAsync(
                         backupBytes, loadedSave, selectedFile.Name,
-                        isManicEmu: manicContext is not null, source: "auto");
+                        isManicEmu: archiveContext?.IsManicEmu == true, source: "auto");
                     await BackupService.EnforceRetentionAsync(SettingsService.Settings.MaxBackupCount);
                 }
                 catch (Exception ex)
@@ -195,7 +183,7 @@ public partial class TradeTab : RefreshAwareComponent
 
         AppState.SaveFileB = null;
         AppState.SaveFileNameB = null;
-        manicEmuSaveContextB = null;
+        saveArchiveContextB = null;
         RefreshService.Refresh();
     }
 
@@ -207,17 +195,25 @@ public partial class TradeTab : RefreshAwareComponent
         }
 
         Logger.LogInformation("Exporting slot-B save file");
+        saveB.PrepareForExport();
         var rawSaveBytes = saveB.Write().ToArray();
         var originalName = AppState.SaveFileNameB;
 
         bool wrote;
-        // Same branching as MainLayout.ExportSaveFile — rebuild the Manic EMU ZIP
-        // when the slot-B save came from one, otherwise preserve the original name.
-        if (manicEmuSaveContextB is not null)
+        // Same branching as MainLayout.ExportSaveFile — rebuild any captured ZIP wrapper.
+        if (saveArchiveContextB is { } archiveContext)
         {
-            var (exportName, compoundExt) = ManicEmuSaveHelper.GetExportFileName(originalName);
-            var zipBytes = ManicEmuSaveHelper.RebuildZip(manicEmuSaveContextB, rawSaveBytes);
-            wrote = await WriteSlotBFileAsync(zipBytes, exportName, compoundExt);
+            var zipBytes = SaveArchiveHelper.RebuildZip(archiveContext, rawSaveBytes);
+            if (archiveContext.IsManicEmu)
+            {
+                var (exportName, compoundExt) = ManicEmuSaveHelper.GetExportFileName(originalName);
+                wrote = await WriteSlotBFileAsync(zipBytes, exportName, compoundExt);
+            }
+            else
+            {
+                var exportName = string.IsNullOrWhiteSpace(originalName) ? "save.zip" : originalName;
+                wrote = await WriteSlotBFileAsync(zipBytes, exportName, ".zip");
+            }
         }
         else if (string.IsNullOrWhiteSpace(originalName))
         {

--- a/Pkmds.Rcl/IAppState.cs
+++ b/Pkmds.Rcl/IAppState.cs
@@ -30,12 +30,18 @@ public interface IAppState
     string? SaveFileName { get; set; }
 
     /// <summary>
-    /// Gets or sets the Manic EMU ZIP context captured when the user uploaded a
-    /// <c>.3ds.sav</c> / <c>.3ds.save</c> archive. Non-null only while a Manic EMU save is loaded.
-    /// Export, auto-backup, and bug-report submission all read this to round-trip the
-    /// original ZIP wrapper instead of the raw inner save. Cleared when the save file is unloaded.
+    /// Gets or sets an untouched copy of the bytes supplied when the current save was loaded.
+    /// Bug reports use this instead of serializing a potentially misdetected save object.
     /// </summary>
-    ManicEmuSaveHelper.ManicEmuSaveContext? ManicEmuSaveContext { get; set; }
+    byte[]? OriginalSaveFileBytes { get; set; }
+
+    /// <summary>
+    /// Gets or sets the ZIP context captured when the user uploaded an archived save.
+    /// Export, auto-backup, and bug-report submission all read this to round-trip the
+    /// original wrapper instead of writing bare save bytes under an archive filename.
+    /// Cleared when the save file is unloaded.
+    /// </summary>
+    SaveArchiveContext? SaveArchiveContext { get; set; }
 
     /// <summary>
     /// Gets or sets the secondary save file used by the cross-save Trade tab.

--- a/Pkmds.Rcl/Services/EmbeddedHostBridge.cs
+++ b/Pkmds.Rcl/Services/EmbeddedHostBridge.cs
@@ -85,12 +85,13 @@ public sealed partial class EmbeddedHostBridge
         _appService.ClearSelection();
         ParseSettings.ClearActiveTrainer();
         _appState.SaveFile = null;
-        _appState.ManicEmuSaveContext = null;
+        _appState.SaveArchiveContext = null;
         _appState.ShowProgressIndicator = true;
 
         try
         {
-            if (!SaveFileLoader.TryLoad(data, fileName, out var saveFile, out var manicContext))
+            var originalData = data.ToArray();
+            if (!SaveFileLoader.TryLoad(data, fileName, out var saveFile, out var archiveContext))
             {
                 _logger.LogError("Host save load failed: invalid format ({FileName})", fileName);
                 return false;
@@ -102,7 +103,8 @@ public sealed partial class EmbeddedHostBridge
                 return false;
             }
 
-            _appState.ManicEmuSaveContext = manicContext;
+            _appState.OriginalSaveFileBytes = originalData;
+            _appState.SaveArchiveContext = archiveContext;
             // Mirror the standalone load path: InitFromSaveFileData populates
             // ParseSettings.ActiveTrainer and AllowGBCartEra for legality
             // checks (see notes on FinishLoadingSaveFile in MainLayout).
@@ -138,10 +140,10 @@ public sealed partial class EmbeddedHostBridge
 
         try
         {
-            // Note: this emits raw save bytes only. Manic EMU ZIP rebuild is
-            // not applied here because the host is expected to deal in raw
-            // save bytes directly — embedded contexts don't carry the ZIP
-            // wrapper that the standalone web upload flow has to preserve.
+            // Note: this emits raw save bytes only. Archive rebuild is not applied
+            // because the embedded-host contract deliberately deals in raw save data,
+            // even when the host originally supplied an archive wrapper.
+            saveFile.PrepareForExport();
             var bytes = saveFile.Write().ToArray();
             var base64 = Convert.ToBase64String(bytes);
             var fileName = _appState.SaveFileName ?? "save.sav";

--- a/Pkmds.Tests/AdvancedSearchTests.cs
+++ b/Pkmds.Tests/AdvancedSearchTests.cs
@@ -437,7 +437,8 @@ public class AdvancedSearchTests
         public DateTime? AppBuildDate => null;
         public int? PinnedBoxNumber { get; set; }
         public string? SaveFileName { get; set; }
-        public ManicEmuSaveHelper.ManicEmuSaveContext? ManicEmuSaveContext { get; set; }
+        public SaveArchiveContext? SaveArchiveContext { get; set; }
+        public byte[]? OriginalSaveFileBytes { get; set; }
         public bool SelectedSlotsAreValid => true;
         public bool IsHaXEnabled { get; set; }
         public SpriteStyle SpriteStyle { get; set; }

--- a/Pkmds.Tests/AppServiceTests.cs
+++ b/Pkmds.Tests/AppServiceTests.cs
@@ -461,7 +461,8 @@ public class AppServiceTests
         public DateTime? AppBuildDate => null;
         public int? PinnedBoxNumber { get; set; }
         public string? SaveFileName { get; set; }
-        public ManicEmuSaveHelper.ManicEmuSaveContext? ManicEmuSaveContext { get; set; }
+        public SaveArchiveContext? SaveArchiveContext { get; set; }
+        public byte[]? OriginalSaveFileBytes { get; set; }
         public bool SelectedSlotsAreValid => true;
         public bool IsHaXEnabled { get; set; }
         public SpriteStyle SpriteStyle { get; set; }

--- a/Pkmds.Tests/AutocompleteSelectTests.cs
+++ b/Pkmds.Tests/AutocompleteSelectTests.cs
@@ -1,0 +1,12 @@
+namespace Pkmds.Tests;
+
+public class AutocompleteSelectTests
+{
+    [Fact]
+    public void MaxItems_DefaultsToBoundedMudBlazorValue()
+    {
+        var component = new AutocompleteSelect<ComboItem>();
+
+        component.MaxItems.Should().Be(10);
+    }
+}

--- a/Pkmds.Tests/BoxManagementTests.cs
+++ b/Pkmds.Tests/BoxManagementTests.cs
@@ -101,7 +101,8 @@ public class BoxManagementTests
         public DateTime? AppBuildDate => null;
         public int? PinnedBoxNumber { get; set; }
         public string? SaveFileName { get; set; }
-        public ManicEmuSaveHelper.ManicEmuSaveContext? ManicEmuSaveContext { get; set; }
+        public SaveArchiveContext? SaveArchiveContext { get; set; }
+        public byte[]? OriginalSaveFileBytes { get; set; }
         public bool SelectedSlotsAreValid => true;
         public bool IsHaXEnabled { get; set; }
         public SpriteStyle SpriteStyle { get; set; }

--- a/Pkmds.Tests/BunitTestHelpers.cs
+++ b/Pkmds.Tests/BunitTestHelpers.cs
@@ -74,7 +74,8 @@ internal class TestAppState : IAppState
     public DateTime? AppBuildDate => null;
     public int? PinnedBoxNumber { get; set; }
     public string? SaveFileName { get; set; }
-    public ManicEmuSaveHelper.ManicEmuSaveContext? ManicEmuSaveContext { get; set; }
+    public SaveArchiveContext? SaveArchiveContext { get; set; }
+    public byte[]? OriginalSaveFileBytes { get; set; }
     public bool SelectedSlotsAreValid => true;
     public bool IsHaXEnabled { get; set; }
     public SpriteStyle SpriteStyle { get; set; }

--- a/Pkmds.Tests/EncounterDatabaseTests.cs
+++ b/Pkmds.Tests/EncounterDatabaseTests.cs
@@ -212,7 +212,8 @@ public class EncounterDatabaseTests
         public DateTime? AppBuildDate => null;
         public int? PinnedBoxNumber { get; set; }
         public string? SaveFileName { get; set; }
-        public ManicEmuSaveHelper.ManicEmuSaveContext? ManicEmuSaveContext { get; set; }
+        public SaveArchiveContext? SaveArchiveContext { get; set; }
+        public byte[]? OriginalSaveFileBytes { get; set; }
         public bool SelectedSlotsAreValid => true;
         public bool IsHaXEnabled { get; set; }
         public SpriteStyle SpriteStyle { get; set; }

--- a/Pkmds.Tests/EvolveTests.cs
+++ b/Pkmds.Tests/EvolveTests.cs
@@ -392,7 +392,8 @@ public class EvolveTests
         public int? SelectedPartySlotNumber { get; set; }
         public int? PinnedBoxNumber { get; set; }
         public string? SaveFileName { get; set; }
-        public ManicEmuSaveHelper.ManicEmuSaveContext? ManicEmuSaveContext { get; set; }
+        public SaveArchiveContext? SaveArchiveContext { get; set; }
+        public byte[]? OriginalSaveFileBytes { get; set; }
         public bool ShowProgressIndicator { get; set; }
         public string AppVersion => "Test";
         public DateTime? AppBuildDate => null;

--- a/Pkmds.Tests/HaXModeTests.cs
+++ b/Pkmds.Tests/HaXModeTests.cs
@@ -165,7 +165,8 @@ public class HaXModeTests
         public DateTime? AppBuildDate => null;
         public int? PinnedBoxNumber { get; set; }
         public string? SaveFileName { get; set; }
-        public ManicEmuSaveHelper.ManicEmuSaveContext? ManicEmuSaveContext { get; set; }
+        public SaveArchiveContext? SaveArchiveContext { get; set; }
+        public byte[]? OriginalSaveFileBytes { get; set; }
         public bool SelectedSlotsAreValid => true;
         public bool IsHaXEnabled { get; set; }
         public SpriteStyle SpriteStyle { get; set; }

--- a/Pkmds.Tests/LegalityCheckerTests.cs
+++ b/Pkmds.Tests/LegalityCheckerTests.cs
@@ -244,7 +244,8 @@ public class LegalityCheckerTests
         public DateTime? AppBuildDate => null;
         public int? PinnedBoxNumber { get; set; }
         public string? SaveFileName { get; set; }
-        public ManicEmuSaveHelper.ManicEmuSaveContext? ManicEmuSaveContext { get; set; }
+        public SaveArchiveContext? SaveArchiveContext { get; set; }
+        public byte[]? OriginalSaveFileBytes { get; set; }
         public bool SelectedSlotsAreValid => true;
         public bool IsHaXEnabled { get; set; }
         public SpriteStyle SpriteStyle { get; set; }

--- a/Pkmds.Tests/SaveFileLoaderTests.cs
+++ b/Pkmds.Tests/SaveFileLoaderTests.cs
@@ -43,13 +43,14 @@ public class SaveFileLoaderTests
         var rawSave = File.ReadAllBytes(Path.Combine(TestFilesPath, "moon.sav"));
         var zipBytes = BuildManicEmuZip(rawSave);
 
-        var ok = SaveFileLoader.TryLoad(zipBytes, "moon.3ds.sav", out var saveFile, out var manicContext);
+        var ok = SaveFileLoader.TryLoad(zipBytes, "moon.3ds.sav", out var saveFile, out var archiveContext);
 
         ok.Should().BeTrue();
         saveFile.Should().NotBeNull();
         saveFile.Should().BeOfType<SAV7SM>();
-        manicContext.Should().NotBeNull();
-        manicContext!.SaveEntryPath.Should().Be(ManicEmuSavePath);
+        archiveContext.Should().NotBeNull();
+        archiveContext!.Kind.Should().Be(SaveArchiveKind.ManicEmu);
+        archiveContext.SaveEntryPath.Should().Be(ManicEmuSavePath);
     }
 
     [Fact]
@@ -65,11 +66,10 @@ public class SaveFileLoaderTests
     }
 
     [Fact]
-    public void TryLoad_ZipWithoutSdmcEntries_FallsThroughToPkhexZipReader()
+    public void TryLoad_GenericZip_ReturnsContextAndPreservesWrapper()
     {
-        // A plain ZIP whose inner file is named `main` — recognised by PKHeX's ZipReader but
-        // not by our Manic EMU helper (no sdmc/ prefix). TryLoad should still return true, with
-        // a null manic context, so non-Manic ZIPs (e.g. PKHeX-produced ones) still work.
+        // A plain ZIP whose inner file is named `main` is recognised by PKHeX's ZipReader.
+        // We must retain that wrapper so export does not put bare save bytes under a .zip name.
         var rawSave = File.ReadAllBytes(Path.Combine(TestFilesPath, "moon.sav"));
 
         using var ms = new MemoryStream();
@@ -80,11 +80,20 @@ public class SaveFileLoaderTests
             s.Write(rawSave, 0, rawSave.Length);
         }
 
-        var ok = SaveFileLoader.TryLoad(ms.ToArray(), "moon.zip", out var saveFile, out var manicContext);
+        var originalZip = ms.ToArray();
+        var ok = SaveFileLoader.TryLoad(originalZip, "moon.zip", out var saveFile, out var archiveContext);
 
         ok.Should().BeTrue();
         saveFile.Should().NotBeNull();
-        manicContext.Should().BeNull();
+        archiveContext.Should().NotBeNull();
+        archiveContext!.Kind.Should().Be(SaveArchiveKind.GenericZip);
+        archiveContext.SaveEntryPath.Should().Be("main");
+
+        var rebuilt = SaveArchiveHelper.RebuildZip(archiveContext, saveFile!.Write().ToArray());
+        rebuilt.AsSpan(0, 4).ToArray().Should().Equal(0x50, 0x4B, 0x03, 0x04);
+        SaveFileLoader.TryLoad(rebuilt, "moon.zip", out var reloaded, out var rebuiltContext).Should().BeTrue();
+        reloaded.Should().BeOfType<SAV7SM>();
+        rebuiltContext.Should().NotBeNull();
     }
 
     [Fact]
@@ -111,7 +120,7 @@ public class SaveFileLoaderTests
         SaveFileLoader.TryLoad(zipBytes, "moon.3ds.sav", out var saveFile, out var ctx).Should().BeTrue();
 
         var exportedBytes = saveFile!.Write().ToArray();
-        var rebuilt = ManicEmuSaveHelper.RebuildZip(ctx!, exportedBytes);
+        var rebuilt = SaveArchiveHelper.RebuildZip(ctx!, exportedBytes);
 
         SaveFileLoader.TryLoad(rebuilt, "moon.3ds.sav", out var reloaded, out var reloadedCtx).Should().BeTrue();
         reloaded.Should().NotBeNull();
@@ -133,7 +142,7 @@ public class SaveFileLoaderTests
         var original = BuildManicEmuZip(rawSave);
 
         SaveFileLoader.TryLoad(original, "moon.3ds.sav", out var saveFile, out var ctx).Should().BeTrue();
-        var rebuilt = ManicEmuSaveHelper.RebuildZip(ctx!, saveFile!.Write().ToArray());
+        var rebuilt = SaveArchiveHelper.RebuildZip(ctx!, saveFile!.Write().ToArray());
 
         // Walk the central directory and confirm bit 11 is set on every CDFH.
         var eocdOffset = FindEndOfCentralDirectory(rebuilt);
@@ -193,7 +202,7 @@ public class SaveFileLoaderTests
         var original = BuildManicEmuZip(rawSave);
 
         SaveFileLoader.TryLoad(original, "moon.3ds.sav", out var saveFile, out var ctx).Should().BeTrue();
-        var rebuilt = ManicEmuSaveHelper.RebuildZip(ctx!, saveFile!.Write().ToArray());
+        var rebuilt = SaveArchiveHelper.RebuildZip(ctx!, saveFile!.Write().ToArray());
 
         // Store-method rebuild must be close to the input size (allow modest drift from
         // timestamp/header differences). A deflate-compressed rebuild would be a fraction
@@ -210,5 +219,39 @@ public class SaveFileLoaderTests
             entry.CompressedLength.Should().Be(entry.Length,
                 $"entry '{entry.FullName}' should be store-method (uncompressed) to match Manic EMU's own output");
         }
+    }
+
+    [Fact]
+    public void TryLoad_ValidWhite2WithCoincidentalHgssSignature_PrefersGen5Footer()
+    {
+        var data = File.ReadAllBytes(Path.Combine(TestFilesPath, "Test-Save-White-2.sav"));
+        const int hgssSignatureOffset = 0x40000 + SAV4HGSS.GeneralSize - 0xC;
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt32LittleEndian(
+            data.AsSpan(hgssSignatureOffset),
+            SAV4HGSS.GeneralSize);
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt32LittleEndian(
+            data.AsSpan(hgssSignatureOffset + 4),
+            SAV4.MAGIC_JAPAN_INTL);
+
+        // Reproduce the PKHeX detection-order collision from issue #1127.
+        SaveUtil.TryGetSaveFile(data, out var pkhexResult, "white-2.dsv").Should().BeTrue();
+        pkhexResult.Should().BeOfType<SAV4HGSS>();
+
+        SaveFileLoader.TryLoad(data, "white-2.dsv", out var result, out var archiveContext).Should().BeTrue();
+        result.Should().BeOfType<SAV5B2W2>();
+        result!.Version.Should().Be(GameVersion.W2);
+        result.ChecksumsValid.Should().BeTrue();
+        archiveContext.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryLoad_GenuineHeartGold_RemainsHgss()
+    {
+        var data = File.ReadAllBytes(Path.Combine(TestFilesPath, "Pokemon Heart Gold  (JP)old.sav"));
+
+        SaveFileLoader.TryLoad(data, "heart-gold.sav", out var result, out var archiveContext).Should().BeTrue();
+
+        result.Should().BeOfType<SAV4HGSS>();
+        archiveContext.Should().BeNull();
     }
 }

--- a/Pkmds.Web/AppState.cs
+++ b/Pkmds.Web/AppState.cs
@@ -40,7 +40,8 @@ public record AppState : IAppState
             if (SaveFile is null)
             {
                 SaveFileName = null;
-                ManicEmuSaveContext = null;
+                OriginalSaveFileBytes = null;
+                SaveArchiveContext = null;
             }
 
             // Clear slot-A selections so a stale SelectedBoxNumber from a previous
@@ -57,7 +58,10 @@ public record AppState : IAppState
     public string? SaveFileName { get; set; }
 
     /// <inheritdoc />
-    public ManicEmuSaveHelper.ManicEmuSaveContext? ManicEmuSaveContext { get; set; }
+    public byte[]? OriginalSaveFileBytes { get; set; }
+
+    /// <inheritdoc />
+    public SaveArchiveContext? SaveArchiveContext { get; set; }
 
     /// <inheritdoc />
     public SaveFile? SaveFileB

--- a/Pkmds.Web/wwwroot/index.html
+++ b/Pkmds.Web/wwwroot/index.html
@@ -145,7 +145,7 @@
         // bootstrap and surfaces as `TypeError: Failed to fetch` (issue #978).
         // Retrying turns that one-off failure into a brief stall instead.
         function retryFetchBootResource(defaultUri, integrity) {
-            var maxAttempts = 3;
+            var maxAttempts = 5;
             var baseDelayMs = 500;
             function attempt(n) {
                 // Mirror Blazor's default boot fetch: revalidate via no-cache and
@@ -154,14 +154,11 @@
                     ? {cache: 'no-cache', integrity: integrity}
                     : {cache: 'no-cache'};
                 return fetch(defaultUri, init).then(function (response) {
-                    // Retry transient server-side failures; let other statuses
-                    // flow through, including 4xx and the SW's synthetic 504.
-                    // 504 is excluded deliberately: service-worker.published.js
-                    // returns it precisely when the network is already down, so
-                    // retrying can't recover and only adds startup delay.
+                    // Retry transient server-side failures and the service worker's
+                    // synthetic 504. A 504 can represent a momentary handoff or radio
+                    // interruption, so giving the network another chance is useful.
                     if (!response.ok && n < maxAttempts
-                        && ((response.status >= 500 && response.status !== 504)
-                            || response.status === 429)) {
+                        && (response.status >= 500 || response.status === 429)) {
                         return backoffThenRetry(n);
                     }
                     return response;

--- a/Pkmds.Web/wwwroot/js/app.js
+++ b/Pkmds.Web/wwwroot/js/app.js
@@ -104,6 +104,30 @@ window.addUpdateListener = () => {
     });
 };
 
+// Apply a downloaded update. Current workers activate without claiming an already-running
+// page, so a normal reload transitions to the new version atomically. The waiting-worker path
+// also supports browsers or future lifecycle changes that leave the update in `waiting`.
+window.applyUpdate = async () => {
+    const registration = await window._swRegistrationPromise;
+    if (!registration) {
+        window.location.reload();
+        return;
+    }
+
+    if (registration.waiting) {
+        const controllerChanged = new Promise(resolve => {
+            navigator.serviceWorker.addEventListener('controllerchange', resolve, {once: true});
+        });
+        registration.waiting.postMessage({type: 'SKIP_WAITING'});
+        await Promise.race([
+            controllerChanged,
+            new Promise(resolve => setTimeout(resolve, 3000)),
+        ]);
+    }
+
+    window.location.reload();
+};
+
 // Proactively check for a service worker update.
 // Returns: 'found' (update ready), 'none' (up to date), 'no-sw' (SW unavailable), 'error' (check/install failed)
 window.checkForUpdates = async () => {
@@ -183,4 +207,3 @@ window.checkForUpdates = async () => {
         registration.removeEventListener('updatefound', signalUpdateFound);
     }
 };
-

--- a/Pkmds.Web/wwwroot/js/error-reporting.js
+++ b/Pkmds.Web/wwwroot/js/error-reporting.js
@@ -92,7 +92,7 @@
         if (isNetworkError) {
             var hint = document.createElement('p');
             hint.style.cssText = 'margin: 0.4rem 0 0; font-size: 0.8rem; color: #555;';
-            hint.textContent = 'This is usually a temporary network problem or an app update in progress — reloading typically fixes it.';
+            hint.textContent = 'This is usually a temporary network problem or an app update in progress. You can safely repair the cached app files without deleting saves, backups, or your Pokémon Bank.';
             ui.insertBefore(hint, (stack ? details : msgEl).nextSibling);
         }
 
@@ -132,6 +132,19 @@
         reportLink.style.cssText = 'padding: 0.2rem 0.6rem; font-size: 0.78rem; background: #b91c1c; color: #fff; border-radius: 3px; text-decoration: none;';
 
         row.appendChild(copyBtn);
+
+        if (isNetworkError) {
+            var repairBtn = document.createElement('button');
+            repairBtn.textContent = 'Repair app cache and reload';
+            repairBtn.style.cssText = 'padding: 0.2rem 0.6rem; font-size: 0.78rem; cursor: pointer; border: 1px solid #1e40af; background: #1e40af; color: #fff; border-radius: 3px;';
+            repairBtn.addEventListener('click', function () {
+                repairBtn.disabled = true;
+                repairBtn.textContent = 'Repairing…';
+                window.clearAppCacheAndReload();
+            });
+            row.appendChild(repairBtn);
+        }
+
         row.appendChild(reportLink);
 
         var insertAfter = hint || (stack ? details : msgEl);

--- a/Pkmds.Web/wwwroot/service-worker.published.js
+++ b/Pkmds.Web/wwwroot/service-worker.published.js
@@ -13,7 +13,9 @@ self.addEventListener('activate', event => {
     event.waitUntil(onActivate(event));
 });
 self.addEventListener('message', event => {
-    if (event.data && event.data.type === 'SKIP_WAITING') self.skipWaiting();
+    if (event.data && event.data.type === 'SKIP_WAITING') {
+        event.waitUntil(self.skipWaiting());
+    }
 });
 self.addEventListener('fetch', event => event.respondWith(onFetch(event)));
 
@@ -73,7 +75,7 @@ async function onActivate(event) {
     const cacheKeys = await caches.keys();
     const oldAppCaches = cacheKeys
         .filter(key => key.startsWith(cacheNamePrefix) && key !== cacheName);
-    const previousCache = oldAppCaches.at(-1);
+    const previousCache = oldAppCaches.length ? oldAppCaches[oldAppCaches.length - 1] : undefined;
     await Promise.all(cacheKeys
         .filter(key => key.startsWith(cacheNamePrefix)
             && key !== cacheName

--- a/Pkmds.Web/wwwroot/service-worker.published.js
+++ b/Pkmds.Web/wwwroot/service-worker.published.js
@@ -3,13 +3,17 @@
 
 self.importScripts('./service-worker-assets.js');
 self.addEventListener('install', event => {
+    // Activate the downloaded worker promptly, but do not claim pages that are already
+    // running the previous app version. They keep their matching worker/cache until reload.
     self.skipWaiting();
     event.waitUntil(onInstall(event));
 });
 
 self.addEventListener('activate', event => {
     event.waitUntil(onActivate(event));
-    self.clients.claim();
+});
+self.addEventListener('message', event => {
+    if (event.data && event.data.type === 'SKIP_WAITING') self.skipWaiting();
 });
 self.addEventListener('fetch', event => event.respondWith(onFetch(event)));
 
@@ -42,31 +46,38 @@ const manifestUrlList = self.assetsManifest.assets.map(asset => new URL(asset.ur
 async function onInstall(event) {
     console.info('Service worker: Install');
 
-    // Fetch and cache all matching items from the assets manifest.
-    // Use per-file error handling instead of cache.addAll() (which is all-or-nothing) so that a
-    // single SRI hash mismatch — e.g. during the brief CDN propagation window after a new deploy
-    // reaches GitHub Pages edge nodes at different times — does not abort the entire install.
-    // Any file that fails to pre-cache here will simply be fetched live from the network until
-    // the next successful install picks it up.
+    // A worker must not install with a partial version cache. That creates a mixed app where
+    // some boot resources are served from this deployment and missing ones fall through to the
+    // network (or a newer deployment). Reject the install instead; the previous worker/cache
+    // stays healthy and the browser can retry once the deployment has propagated.
     const assetsRequests = self.assetsManifest.assets
         .filter(asset => offlineAssetsInclude.some(pattern => pattern.test(asset.url)))
         .filter(asset => !offlineAssetsExclude.some(pattern => pattern.test(asset.url)))
         .map(asset => new Request(asset.url, {integrity: asset.hash, cache: 'no-cache'}));
     const cache = await caches.open(cacheName);
-    await Promise.allSettled(
-        assetsRequests.map(req =>
-            cache.add(req).catch(err => console.warn(`SW: Failed to pre-cache ${req.url}:`, err))
-        )
-    );
+    try {
+        await Promise.all(assetsRequests.map(req => cache.add(req)));
+    } catch (err) {
+        await caches.delete(cacheName);
+        console.error('SW: Version cache install failed; keeping the previous worker active.', err);
+        throw err;
+    }
 }
 
 async function onActivate(event) {
     console.info('Service worker: Activate');
 
-    // Delete unused caches
+    // Keep the immediately previous app cache while any already-open page is still controlled
+    // by its previous worker. Because activate intentionally does not call clients.claim(), a
+    // reload moves that page to this worker without mixing old HTML with new boot resources.
     const cacheKeys = await caches.keys();
+    const oldAppCaches = cacheKeys
+        .filter(key => key.startsWith(cacheNamePrefix) && key !== cacheName);
+    const previousCache = oldAppCaches.at(-1);
     await Promise.all(cacheKeys
-        .filter(key => key.startsWith(cacheNamePrefix) && key !== cacheName)
+        .filter(key => key.startsWith(cacheNamePrefix)
+            && key !== cacheName
+            && key !== previousCache)
         .map(key => caches.delete(key)));
 }
 


### PR DESCRIPTION
## Summary

This PR addresses all currently open issues from #1122 onward:

- [^1122](https://github.com/codemonkey85/PKMDS-Blazor/issues/1122) — limits autocomplete rendering to 10 results so broad item searches do not render the entire catalog and stall mobile browsers.
- [^1127](https://github.com/codemonkey85/PKMDS-Blazor/issues/1127) — detects checksum-valid Gen 5 saves before PKHeX's conflicting same-size HGSS probe and keeps the original uploaded bytes for bug-report attachments.
- [^1131](https://github.com/codemonkey85/PKMDS-Blazor/issues/1131), [^1132](https://github.com/codemonkey85/PKMDS-Blazor/issues/1132), and [^1133](https://github.com/codemonkey85/PKMDS-Blazor/issues/1133) — preserve generic ZIP wrappers through load, export, backup, bug reporting, and Trade slot B, while running PKHeX's storage cleanup before serialization so LGPE saves are finalized correctly.
- [^1139](https://github.com/codemonkey85/PKMDS-Blazor/issues/1139) — retries transient boot-resource failures, makes service-worker cache installation atomic, keeps existing pages paired with their matching worker/cache until reload, and adds a safe **Repair app cache and reload** action that preserves IndexedDB saves, backups, and Pokémon Bank data.

## Issue #1127 diagnosis

The reported file is a raw 512 KiB save, not a DeSmuME file with a damaged footer. PKHeX checks HGSS before Gen 5, and this White 2 save's extdata happens to contain the same size/magic signature used by the HGSS probe. The previous bug-report path then serialized that misdetected `SAV4HGSS` instance, which explains the damaged regions in the attachment.

The fix uses the valid Gen 5 checksum footer as a deterministic discriminator; it does not guess at or repair damaged data. The PKHeX.Core detection-order limitation is documented next to the workaround, and bug reports now retain the pristine bytes originally uploaded by the user.

## Validation

- `dotnet format --no-restore` (workspace-load warnings only)
- `dotnet build Pkmds.Web/Pkmds.Web.csproj -c Debug -p:SkipTailwind=true --no-restore --disable-build-servers -m:1`
- `dotnet build Pkmds.Tests/Pkmds.Tests.csproj -c Debug -p:SkipTailwind=true -p:NuGetAudit=false --no-restore --disable-build-servers -m:1`
- JavaScript syntax checks for the startup, error-reporting, and service-worker changes
- `git diff --check`

Per repository policy, the test suite was not run locally; GitHub Actions will run it.

Closes #1122
Closes #1127
Closes #1131
Closes #1132
Closes #1133
Closes #1139
