### PR TITLE
Deploy stale PWA startup recovery fix

### DIFF
--- a/Pkmds.Rcl/wwwroot/js/appCache.js
+++ b/Pkmds.Rcl/wwwroot/js/appCache.js
@@ -22,3 +22,40 @@ window.clearAppCacheAndReload = async function () {
         window.location.replace(`${window.location.href.replace(/[?&]_cb=\d+/g, '')}${sep}_cb=${bust}`);
     }
 };
+
+// Recover once from an online startup failure caused by a stale or mixed app cache. The marker
+// survives the repair reload so a genuine network problem cannot create a reload loop. A
+// successful Blazor boot clears it for future deployments. This intentionally touches only
+// service workers and Cache Storage; IndexedDB saves, backups, and the Pokémon Bank are retained.
+window.tryAutomaticAppCacheRecovery = async function () {
+    const recoveryKey = 'pkmds-app-cache-recovery-attempted';
+    try {
+        if (sessionStorage.getItem(recoveryKey) || !navigator.onLine) {
+            return false;
+        }
+
+        // Prove the current deployment is reachable before discarding offline app assets.
+        // service-worker.js is excluded from app caches and the query makes this probe unique.
+        const probe = await fetch(`service-worker.js?_recovery=${Date.now()}`, {cache: 'no-store'});
+        const contentType = probe.headers.get('Content-Type') || '';
+        if (!probe.ok || !contentType.includes('javascript')) {
+            return false;
+        }
+
+        sessionStorage.setItem(recoveryKey, 'true');
+        await window.clearAppCacheAndReload();
+        return true;
+    } catch (err) {
+        console.warn('tryAutomaticAppCacheRecovery: recovery probe failed', err);
+        return false;
+    }
+};
+
+window.markAppBootSucceeded = function () {
+    window._pkmdsBootInProgress = false;
+    try {
+        sessionStorage.removeItem('pkmds-app-cache-recovery-attempted');
+    } catch (_) {
+        // Storage can be unavailable in hardened/private browsing modes.
+    }
+};

--- a/Pkmds.Tests/ServiceWorkerAssetTests.cs
+++ b/Pkmds.Tests/ServiceWorkerAssetTests.cs
@@ -1,0 +1,59 @@
+using System.Text.RegularExpressions;
+
+namespace Pkmds.Tests;
+
+public sealed partial class ServiceWorkerAssetTests
+{
+    private static readonly string RepoRoot = FindRepoRoot();
+
+    private static string FindRepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "Pkmds.slnx")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory?.FullName ?? throw new DirectoryNotFoundException("Could not locate the repository root.");
+    }
+
+    private static string ReadRepoFile(params string[] pathSegments) =>
+        File.ReadAllText(Path.Combine([RepoRoot, .. pathSegments]));
+
+    [Fact]
+    public void PublishedServiceWorkerPreCachesNativeRuntime()
+    {
+        var serviceWorker = ReadRepoFile("Pkmds.Web", "wwwroot", "service-worker.published.js");
+        var exclusions = OfflineAssetsExcludeRegex().Match(serviceWorker);
+
+        exclusions.Success.Should().BeTrue();
+        exclusions.Value.Should().NotContain("dotnet\\.native");
+    }
+
+    [Fact]
+    public void PublishedServiceWorkerWaitsForExplicitUpdateHandoff()
+    {
+        var serviceWorker = ReadRepoFile("Pkmds.Web", "wwwroot", "service-worker.published.js");
+        var installHandler = InstallHandlerRegex().Match(serviceWorker);
+
+        installHandler.Success.Should().BeTrue();
+        installHandler.Value.Should().NotContain("skipWaiting");
+        serviceWorker.Should().Contain("event.waitUntil(self.skipWaiting())");
+    }
+
+    [Fact]
+    public void AutomaticCacheRecoveryDoesNotDeleteIndexedDb()
+    {
+        var cacheScript = ReadRepoFile("Pkmds.Rcl", "wwwroot", "js", "appCache.js");
+
+        cacheScript.Should().Contain("caches.delete");
+        cacheScript.Should().Contain("r.unregister()");
+        cacheScript.Should().NotContain("indexedDB.deleteDatabase");
+    }
+
+    [GeneratedRegex(@"const offlineAssetsExclude = \[[^;]+;", RegexOptions.CultureInvariant)]
+    private static partial Regex OfflineAssetsExcludeRegex();
+
+    [GeneratedRegex(@"self\.addEventListener\('install',[\s\S]+?\n}\);", RegexOptions.CultureInvariant)]
+    private static partial Regex InstallHandlerRegex();
+}

--- a/Pkmds.Tests/ServiceWorkerAssetTests.cs
+++ b/Pkmds.Tests/ServiceWorkerAssetTests.cs
@@ -51,6 +51,25 @@ public sealed partial class ServiceWorkerAssetTests
         cacheScript.Should().NotContain("indexedDB.deleteDatabase");
     }
 
+    [Fact]
+    public void WaitingServiceWorkerUpdateIsPreservedAndDispatched()
+    {
+        var appScript = ReadRepoFile("Pkmds.Web", "wwwroot", "js", "app.js");
+
+        appScript.Should().Contain("""
+            function notifyUpdateAvailable() {
+                window._pkmdsUpdateWaiting = true;
+                window.dispatchEvent(new CustomEvent('updateAvailable'));
+            }
+            """);
+        appScript.Should().Contain("""
+            if (registration.waiting && navigator.serviceWorker.controller) {
+                notifyUpdateAvailable();
+            }
+            """);
+        appScript.Should().Contain("if (window._pkmdsUpdateWaiting)");
+    }
+
     [GeneratedRegex(@"const offlineAssetsExclude = \[[^;]+;", RegexOptions.CultureInvariant)]
     private static partial Regex OfflineAssetsExcludeRegex();
 

--- a/Pkmds.Web/wwwroot/index.html
+++ b/Pkmds.Web/wwwroot/index.html
@@ -179,6 +179,7 @@
             return attempt(1);
         }
 
+        window._pkmdsBootInProgress = true;
         Blazor.start({
             loadBootResource: function (type, name, defaultUri, integrity) {
                 // The 'dotnetjs' module is imported as a script and must be
@@ -193,6 +194,8 @@
                 }
                 return retryFetchBootResource(defaultUri, integrity);
             }
+        }).then(function () {
+            window.markAppBootSucceeded();
         });
     } else {
         // Resolve against document.baseURI so the redirect lands on the

--- a/Pkmds.Web/wwwroot/js/app.js
+++ b/Pkmds.Web/wwwroot/js/app.js
@@ -25,6 +25,9 @@ if (pkmdsIsEmbedded()) {
 } else if ('serviceWorker' in navigator) {
     window._swRegistrationPromise = navigator.serviceWorker.register('service-worker.js', {updateViaCache: 'none'}).then(registration => {
         console.info('Service worker registered, scope:', registration.scope);
+        if (registration.waiting && navigator.serviceWorker.controller) {
+            window._pkmdsUpdateWaiting = true;
+        }
         setInterval(() => registration.update().catch(err => {
             // Safari may throw "newestWorker is null" — this is benign
             if (!(err.name === 'InvalidStateError' || (err.message && err.message.includes('newestWorker is null')))) {
@@ -36,6 +39,7 @@ if (pkmdsIsEmbedded()) {
             installingWorker.onstatechange = () => {
                 if (installingWorker.state === 'installed' && navigator.serviceWorker.controller) {
                     // Notify Blazor about the update
+                    window._pkmdsUpdateWaiting = true;
                     window.dispatchEvent(new CustomEvent('updateAvailable'));
                 }
             };
@@ -100,13 +104,17 @@ window.pkmdsGetUserAgent = () => navigator.userAgent;
 // Listen for update events and forward to Blazor
 window.addUpdateListener = () => {
     window.addEventListener('updateAvailable', () => {
+        window._pkmdsUpdateWaiting = false;
         DotNet.invokeMethodAsync('Pkmds.Web', 'ShowUpdateMessage');
     });
+    if (window._pkmdsUpdateWaiting) {
+        window._pkmdsUpdateWaiting = false;
+        DotNet.invokeMethodAsync('Pkmds.Web', 'ShowUpdateMessage');
+    }
 };
 
-// Apply a downloaded update. Current workers activate without claiming an already-running
-// page, so a normal reload transitions to the new version atomically. The waiting-worker path
-// also supports browsers or future lifecycle changes that leave the update in `waiting`.
+// Apply a downloaded update. The worker waits until this explicit handoff, then claims the
+// current page; controllerchange tells us it is safe to reload under the new version.
 window.applyUpdate = async () => {
     const registration = await window._swRegistrationPromise;
     if (!registration) {

--- a/Pkmds.Web/wwwroot/js/app.js
+++ b/Pkmds.Web/wwwroot/js/app.js
@@ -18,6 +18,11 @@ function pkmdsIsEmbedded() {
     return false;
 }
 
+function notifyUpdateAvailable() {
+    window._pkmdsUpdateWaiting = true;
+    window.dispatchEvent(new CustomEvent('updateAvailable'));
+}
+
 // Service worker registration
 if (pkmdsIsEmbedded()) {
     console.info('Service worker registration skipped: embedded host mode.');
@@ -26,7 +31,7 @@ if (pkmdsIsEmbedded()) {
     window._swRegistrationPromise = navigator.serviceWorker.register('service-worker.js', {updateViaCache: 'none'}).then(registration => {
         console.info('Service worker registered, scope:', registration.scope);
         if (registration.waiting && navigator.serviceWorker.controller) {
-            window._pkmdsUpdateWaiting = true;
+            notifyUpdateAvailable();
         }
         setInterval(() => registration.update().catch(err => {
             // Safari may throw "newestWorker is null" — this is benign
@@ -39,8 +44,7 @@ if (pkmdsIsEmbedded()) {
             installingWorker.onstatechange = () => {
                 if (installingWorker.state === 'installed' && navigator.serviceWorker.controller) {
                     // Notify Blazor about the update
-                    window._pkmdsUpdateWaiting = true;
-                    window.dispatchEvent(new CustomEvent('updateAvailable'));
+                    notifyUpdateAvailable();
                 }
             };
         };
@@ -144,7 +148,7 @@ window.checkForUpdates = async () => {
 
     // A waiting worker was already downloaded but not yet activated — notify immediately.
     if (registration.waiting) {
-        window.dispatchEvent(new CustomEvent('updateAvailable'));
+        notifyUpdateAvailable();
         return 'found';
     }
 
@@ -180,7 +184,7 @@ window.checkForUpdates = async () => {
 
         // A fast install may have already moved the new worker to the waiting slot.
         if (registration.waiting) {
-            window.dispatchEvent(new CustomEvent('updateAvailable'));
+            notifyUpdateAvailable();
             return 'found';
         }
 
@@ -200,7 +204,7 @@ window.checkForUpdates = async () => {
                     // Mirror the controller check in the global onupdatefound handler: with no
                     // controller this is the page's very first SW install, not an update.
                     if (navigator.serviceWorker.controller) {
-                        window.dispatchEvent(new CustomEvent('updateAvailable'));
+                        notifyUpdateAvailable();
                         resolve('found');
                     } else {
                         resolve('none');

--- a/Pkmds.Web/wwwroot/js/error-reporting.js
+++ b/Pkmds.Web/wwwroot/js/error-reporting.js
@@ -140,9 +140,26 @@
             repairBtn.addEventListener('click', function () {
                 repairBtn.disabled = true;
                 repairBtn.textContent = 'Repairing…';
-                window.clearAppCacheAndReload();
+                if (typeof window.clearAppCacheAndReload === 'function') {
+                    window.clearAppCacheAndReload();
+                } else {
+                    window.location.reload();
+                }
             });
             row.appendChild(repairBtn);
+
+            // If the network is reachable, repair stale app caches automatically once. The
+            // guarded helper preserves IndexedDB and prevents reload loops when the failure is
+            // a real connectivity problem rather than a mixed service-worker version.
+            if (window._pkmdsBootInProgress === true
+                && typeof window.tryAutomaticAppCacheRecovery === 'function') {
+                window.tryAutomaticAppCacheRecovery().then(function (started) {
+                    if (started) {
+                        repairBtn.disabled = true;
+                        repairBtn.textContent = 'Repairing…';
+                    }
+                });
+            }
         }
 
         row.appendChild(reportLink);

--- a/Pkmds.Web/wwwroot/service-worker.published.js
+++ b/Pkmds.Web/wwwroot/service-worker.published.js
@@ -3,14 +3,19 @@
 
 self.importScripts('./service-worker-assets.js');
 self.addEventListener('install', event => {
-    // Activate the downloaded worker promptly, but do not claim pages that are already
-    // running the previous app version. They keep their matching worker/cache until reload.
-    self.skipWaiting();
+    // Keep the new worker waiting until existing pages close or explicitly apply the update.
+    // Activating during an ordinary reload can pair HTML served by the old worker with boot
+    // resources served by the new worker, which strands clients on mixed app versions.
     event.waitUntil(onInstall(event));
 });
 
 self.addEventListener('activate', event => {
-    event.waitUntil(onActivate(event));
+    event.waitUntil((async () => {
+        await onActivate(event);
+        // Explicit updates wait for controllerchange before reloading. Claiming here completes
+        // that handoff; natural activation normally has no existing clients to claim.
+        await self.clients.claim();
+    })());
 });
 self.addEventListener('message', event => {
     if (event.data && event.data.type === 'SKIP_WAITING') {
@@ -39,19 +44,16 @@ const cacheName = `${cacheNamePrefix}${self.assetsManifest.version}${CACHE_VERSI
 const trackedClientIds = new Set();
 
 const offlineAssetsInclude = [/\.dll$/, /\.pdb$/, /\.wasm/, /\.html/, /\.js$/, /\.json$/, /\.css$/, /\.woff$/, /\.woff2$/, /\.png$/, /\.jpe?g$/, /\.gif$/, /\.ico$/, /\.svg$/, /\.webp$/, /\.blat$/, /\.dat$/];
-// AOT-compiled native blob (~44 MB raw, ~7.75 MB brotli) is excluded from
-// SW pre-cache because it alone has caused iOS Safari to reject the entire
-// install on tight per-origin SW cache quotas, breaking offline reload.
-// Browsers continue to serve it via the regular HTTP cache (1-year max-age
-// on the fingerprinted asset), so returning users with a populated HTTP
-// cache still get offline reload; only stone-cold first-load-offline fails
-// for this single file, which has always been a thin scenario.
-//
 // appsettings*.json is intentionally NOT excluded: our appsettings.json is
 // static (just the Azure function URL) and excluding it caused 429 failures
 // for users on iCloud Private Relay / GitHub Pages rate-limited IPs, crashing
 // the Blazor bootstrap before the app could start (issue #910).
-const offlineAssetsExclude = [/^service-worker\.js$/, /^staticwebapp\.config\.json$/, /^_framework\/dotnet\.native\.[^\/]+\.wasm$/];
+//
+// dotnet.native.*.wasm used to be excluded when AOT made it roughly 44 MB.
+// AOT is disabled now and the runtime is roughly 3 MB. It must be cached: an
+// old app version cannot boot after a deploy removes its fingerprinted runtime
+// from the server, which caused the recurring 98% startup failures (#1142+).
+const offlineAssetsExclude = [/^service-worker\.js$/, /^staticwebapp\.config\.json$/];
 
 // Replace with your base path if you are hosting on a subfolder. Ensure there is a trailing '/'.
 const base = "/";


### PR DESCRIPTION
## Summary

- promote #1162 to production to fix recurring stale PWA startup failures
- pre-cache the fingerprinted native WASM runtime now that it is roughly 3 MB without AOT
- keep service-worker updates waiting for an explicit handoff so a reload cannot mix app versions
- perform one guarded, online-only app-cache repair after a startup network failure
- preserve IndexedDB-backed saves, backups, and Pokémon Bank data during recovery
- retain update notifications regardless of whether Blazor subscribes before or after the waiting worker is discovered

## Root cause

Older clients cached the app shell but deliberately excluded the fingerprinted `dotnet.native.*.wasm` runtime. After a later deployment removed that old fingerprint, those clients reached about 98% startup and then failed integrity checking while requesting the missing runtime. Chromium surfaced this as `Failed to fetch`; Safari reported `Load failed`.

## Validation

- live production reproduction confirmed the stale client requested a removed native-WASM fingerprint
- `node --check` passed for all changed JavaScript files
- `dotnet format --no-restore`
- Debug builds of `Pkmds.Web` and `Pkmds.Tests` passed with zero warnings and errors
- service-worker regression assertions cover native-runtime caching, explicit update handoff, IndexedDB safety, and update-notification timing
- conflict-free merge simulation from `dev` into `main`

Per repository policy, the test suite is left to GitHub Actions.

## Issue tracking

Closes #1142. Duplicate reports #1139 and #1143–#1161 were consolidated into that issue.

After the Pages deployment completes, #1142 should receive safe recovery instructions for users already stranded on an older cache. Those instructions must avoid clearing site data so IndexedDB saves, backups, and Pokémon Bank data are preserved.