### PR TITLE
Fix PWA startup recovery and tab scrolling regressions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,8 @@ jobs:
       - name: Update version
         uses: datamonsters/replace-action@v2
         with:
-          files: 'release/wwwroot/service-worker.published.js'
+          # Publish renames service-worker.published.js to the deployed service-worker.js.
+          files: 'release/wwwroot/service-worker.js'
           replacements: '%%CACHE_VERSION%%=${{ github.run_id }}'
 
 

--- a/.github/workflows/uat.yml
+++ b/.github/workflows/uat.yml
@@ -52,7 +52,8 @@ jobs:
       - name: Update cache version
         uses: datamonsters/replace-action@v2
         with:
-          files: 'release/wwwroot/service-worker.published.js'
+          # Publish renames service-worker.published.js to the deployed service-worker.js.
+          files: 'release/wwwroot/service-worker.js'
           replacements: '%%CACHE_VERSION%%=${{ github.run_id }}'
 
 

--- a/Pkmds.Rcl/wwwroot/css/app.css
+++ b/Pkmds.Rcl/wwwroot/css/app.css
@@ -67,8 +67,9 @@ body, html {
    all scrolling there — box grid, edit form, and Trainer tab were clipped with
    no way to reach the overflow. Restore the 9.5.x block box. This must stay
    ABOVE the :has(...) rules that switch the Bank/Pokédex panels to display:flex;
-   the specificity ties at (0,4,0), so file order decides the winner. */
-.mud-tabs-panels > .mud-tab-panel.mud-tab-panel-active:not(.mud-tab-panel-hidden) {
+   the specificity ties at (0,5,0), so file order decides the winner. Keep the
+   :not(.mud-tab) term in sync with MudBlazor's active-panel selector. */
+.mud-tabs-panels > .mud-tab-panel:not(.mud-tab).mud-tab-panel-active:not(.mud-tab-panel-hidden) {
     display: block;
 }
 

--- a/Pkmds.Tests/LayoutAssetTests.cs
+++ b/Pkmds.Tests/LayoutAssetTests.cs
@@ -2,25 +2,12 @@ namespace Pkmds.Tests;
 
 public sealed class LayoutAssetTests
 {
-    private static readonly string RepoRoot = FindRepoRoot();
-
     [Fact]
     public void ActiveTabPanelOverridesMudBlazorDisplayContents()
     {
-        var appCss = File.ReadAllText(Path.Combine(RepoRoot, "Pkmds.Rcl", "wwwroot", "css", "app.css"));
+        var appCss = RepoFileTestHelper.ReadAllText("Pkmds.Rcl", "wwwroot", "css", "app.css");
 
         appCss.Should().Contain(
             ".mud-tabs-panels > .mud-tab-panel:not(.mud-tab).mud-tab-panel-active:not(.mud-tab-panel-hidden)");
-    }
-
-    private static string FindRepoRoot()
-    {
-        var directory = new DirectoryInfo(AppContext.BaseDirectory);
-        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "Pkmds.slnx")))
-        {
-            directory = directory.Parent;
-        }
-
-        return directory?.FullName ?? throw new DirectoryNotFoundException("Could not locate the repository root.");
     }
 }

--- a/Pkmds.Tests/LayoutAssetTests.cs
+++ b/Pkmds.Tests/LayoutAssetTests.cs
@@ -1,0 +1,26 @@
+namespace Pkmds.Tests;
+
+public sealed class LayoutAssetTests
+{
+    private static readonly string RepoRoot = FindRepoRoot();
+
+    [Fact]
+    public void ActiveTabPanelOverridesMudBlazorDisplayContents()
+    {
+        var appCss = File.ReadAllText(Path.Combine(RepoRoot, "Pkmds.Rcl", "wwwroot", "css", "app.css"));
+
+        appCss.Should().Contain(
+            ".mud-tabs-panels > .mud-tab-panel:not(.mud-tab).mud-tab-panel-active:not(.mud-tab-panel-hidden)");
+    }
+
+    private static string FindRepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "Pkmds.slnx")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory?.FullName ?? throw new DirectoryNotFoundException("Could not locate the repository root.");
+    }
+}

--- a/Pkmds.Tests/RepoFileTestHelper.cs
+++ b/Pkmds.Tests/RepoFileTestHelper.cs
@@ -1,0 +1,20 @@
+namespace Pkmds.Tests;
+
+internal static class RepoFileTestHelper
+{
+    private static readonly string RepoRoot = FindRepoRoot();
+
+    public static string ReadAllText(params string[] pathSegments) =>
+        File.ReadAllText(Path.Combine([RepoRoot, .. pathSegments]));
+
+    private static string FindRepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "Pkmds.slnx")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory?.FullName ?? throw new DirectoryNotFoundException("Could not locate the repository root.");
+    }
+}

--- a/Pkmds.Tests/ServiceWorkerAssetTests.cs
+++ b/Pkmds.Tests/ServiceWorkerAssetTests.cs
@@ -31,14 +31,31 @@ public sealed partial class ServiceWorkerAssetTests
     }
 
     [Fact]
-    public void PublishedServiceWorkerWaitsForExplicitUpdateHandoff()
+    public void PublishedServiceWorkerWaitsUnlessLegacyCacheCannotBoot()
     {
         var serviceWorker = ReadRepoFile("Pkmds.Web", "wwwroot", "service-worker.published.js");
         var installHandler = InstallHandlerRegex().Match(serviceWorker);
 
         installHandler.Success.Should().BeTrue();
-        installHandler.Value.Should().NotContain("skipWaiting");
+        LegacyRecoveryActivationRegex().IsMatch(installHandler.Value).Should().BeTrue();
+        serviceWorker.Should().Contain("hasLegacyCacheWithoutNativeRuntime");
+        serviceWorker.Should().Contain("nativeRuntimePath");
+        serviceWorker.Should().Contain("legacyRecoveryMarkerUrl");
+        serviceWorker.Should().Contain("if (shouldClaimClients)");
+        serviceWorker.Should().Contain("return false;");
         serviceWorker.Should().Contain("event.waitUntil(self.skipWaiting())");
+    }
+
+    [Fact]
+    public void DeploymentWorkflowsStampTheDeployedServiceWorker()
+    {
+        foreach (var workflow in new[] { "main.yml", "uat.yml" })
+        {
+            var workflowContents = ReadRepoFile(".github", "workflows", workflow);
+
+            workflowContents.Should().Contain("files: 'release/wwwroot/service-worker.js'");
+            workflowContents.Should().NotContain("files: 'release/wwwroot/service-worker.published.js'");
+        }
     }
 
     [Fact]
@@ -71,6 +88,9 @@ public sealed partial class ServiceWorkerAssetTests
 
     [GeneratedRegex(@"self\.addEventListener\('install',[\s\S]+?\n}\);", RegexOptions.CultureInvariant)]
     private static partial Regex InstallHandlerRegex();
+
+    [GeneratedRegex(@"if \(await hasLegacyCacheWithoutNativeRuntime\(\)\)\s*\{[\s\S]+?await self\.skipWaiting\(\);\s*}", RegexOptions.CultureInvariant)]
+    private static partial Regex LegacyRecoveryActivationRegex();
 
     [GeneratedRegex(@"if \(registration\.waiting && navigator\.serviceWorker\.controller\)\s*\{\s*notifyUpdateAvailable\(\);\s*\}", RegexOptions.CultureInvariant)]
     private static partial Regex WaitingRegistrationNotificationRegex();

--- a/Pkmds.Tests/ServiceWorkerAssetTests.cs
+++ b/Pkmds.Tests/ServiceWorkerAssetTests.cs
@@ -4,26 +4,10 @@ namespace Pkmds.Tests;
 
 public sealed partial class ServiceWorkerAssetTests
 {
-    private static readonly string RepoRoot = FindRepoRoot();
-
-    private static string FindRepoRoot()
-    {
-        var directory = new DirectoryInfo(AppContext.BaseDirectory);
-        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "Pkmds.slnx")))
-        {
-            directory = directory.Parent;
-        }
-
-        return directory?.FullName ?? throw new DirectoryNotFoundException("Could not locate the repository root.");
-    }
-
-    private static string ReadRepoFile(params string[] pathSegments) =>
-        File.ReadAllText(Path.Combine([RepoRoot, .. pathSegments]));
-
     [Fact]
     public void PublishedServiceWorkerPreCachesNativeRuntime()
     {
-        var serviceWorker = ReadRepoFile("Pkmds.Web", "wwwroot", "service-worker.published.js");
+        var serviceWorker = RepoFileTestHelper.ReadAllText("Pkmds.Web", "wwwroot", "service-worker.published.js");
         var exclusions = OfflineAssetsExcludeRegex().Match(serviceWorker);
 
         exclusions.Success.Should().BeTrue();
@@ -33,16 +17,14 @@ public sealed partial class ServiceWorkerAssetTests
     [Fact]
     public void PublishedServiceWorkerWaitsUnlessLegacyCacheCannotBoot()
     {
-        var serviceWorker = ReadRepoFile("Pkmds.Web", "wwwroot", "service-worker.published.js");
+        var serviceWorker = RepoFileTestHelper.ReadAllText("Pkmds.Web", "wwwroot", "service-worker.published.js");
         var installHandler = InstallHandlerRegex().Match(serviceWorker);
 
         installHandler.Success.Should().BeTrue();
-        LegacyRecoveryActivationRegex().IsMatch(installHandler.Value).Should().BeTrue();
-        serviceWorker.Should().Contain("hasLegacyCacheWithoutNativeRuntime");
-        serviceWorker.Should().Contain("nativeRuntimePath");
-        serviceWorker.Should().Contain("legacyRecoveryMarkerUrl");
-        serviceWorker.Should().Contain("if (shouldClaimClients)");
-        serviceWorker.Should().Contain("return false;");
+        LegacyRecoveryInstallRegex().IsMatch(installHandler.Value).Should().BeTrue();
+        LiveLegacyClientGuardRegex().IsMatch(serviceWorker).Should().BeTrue();
+        LegacyRecoveryClientSafetyRegex().IsMatch(serviceWorker).Should().BeTrue();
+        NavigationCacheCleanupRegex().IsMatch(serviceWorker).Should().BeTrue();
         serviceWorker.Should().Contain("event.waitUntil(self.skipWaiting())");
     }
 
@@ -51,7 +33,7 @@ public sealed partial class ServiceWorkerAssetTests
     {
         foreach (var workflow in new[] { "main.yml", "uat.yml" })
         {
-            var workflowContents = ReadRepoFile(".github", "workflows", workflow);
+            var workflowContents = RepoFileTestHelper.ReadAllText(".github", "workflows", workflow);
 
             workflowContents.Should().Contain("files: 'release/wwwroot/service-worker.js'");
             workflowContents.Should().NotContain("files: 'release/wwwroot/service-worker.published.js'");
@@ -61,7 +43,7 @@ public sealed partial class ServiceWorkerAssetTests
     [Fact]
     public void AutomaticCacheRecoveryDoesNotDeleteIndexedDb()
     {
-        var cacheScript = ReadRepoFile("Pkmds.Rcl", "wwwroot", "js", "appCache.js");
+        var cacheScript = RepoFileTestHelper.ReadAllText("Pkmds.Rcl", "wwwroot", "js", "appCache.js");
 
         cacheScript.Should().Contain("caches.delete");
         cacheScript.Should().Contain("r.unregister()");
@@ -71,7 +53,7 @@ public sealed partial class ServiceWorkerAssetTests
     [Fact]
     public void WaitingServiceWorkerUpdateIsPreservedAndDispatched()
     {
-        var appScript = ReadRepoFile("Pkmds.Web", "wwwroot", "js", "app.js");
+        var appScript = RepoFileTestHelper.ReadAllText("Pkmds.Web", "wwwroot", "js", "app.js");
 
         appScript.Should().Contain("""
             function notifyUpdateAvailable() {
@@ -90,7 +72,16 @@ public sealed partial class ServiceWorkerAssetTests
     private static partial Regex InstallHandlerRegex();
 
     [GeneratedRegex(@"if \(await hasLegacyCacheWithoutNativeRuntime\(\)\)\s*\{[\s\S]+?await self\.skipWaiting\(\);\s*}", RegexOptions.CultureInvariant)]
-    private static partial Regex LegacyRecoveryActivationRegex();
+    private static partial Regex LegacyRecoveryInstallRegex();
+
+    [GeneratedRegex(@"const \{hasUnleasedClients} = await getLiveClientCacheLeases\(\);\s*if \(!hasUnleasedClients\)\s*\{\s*return false;\s*}", RegexOptions.CultureInvariant)]
+    private static partial Regex LiveLegacyClientGuardRegex();
+
+    [GeneratedRegex(@"if \(isLegacyRecovery\)\s*\{[\s\S]+?await currentCache\.delete\(legacyRecoveryMarkerUrl\);\s*return false;\s*}", RegexOptions.CultureInvariant)]
+    private static partial Regex LegacyRecoveryClientSafetyRegex();
+
+    [GeneratedRegex(@"const isNavigation = event\.request\.mode === 'navigate';[\s\S]+?if \(isNavigation\)\s*\{\s*await pruneUnusedAppCaches\(\);\s*}", RegexOptions.CultureInvariant)]
+    private static partial Regex NavigationCacheCleanupRegex();
 
     [GeneratedRegex(@"if \(registration\.waiting && navigator\.serviceWorker\.controller\)\s*\{\s*notifyUpdateAvailable\(\);\s*\}", RegexOptions.CultureInvariant)]
     private static partial Regex WaitingRegistrationNotificationRegex();

--- a/Pkmds.Tests/ThemeSyncTests.cs
+++ b/Pkmds.Tests/ThemeSyncTests.cs
@@ -14,33 +14,16 @@ namespace Pkmds.Tests;
 /// </summary>
 public class ThemeSyncTests
 {
-    private static readonly string RepoRoot = FindRepoRoot();
-
     private static readonly HashSet<string> AllThemeColors = typeof(AppTheme.Colors)
         .GetFields(BindingFlags.Public | BindingFlags.Static)
         .Where(f => f.IsLiteral)
         .Select(f => (string)f.GetRawConstantValue()!)
         .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-    private static string FindRepoRoot()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Pkmds.slnx")))
-        {
-            dir = dir.Parent;
-        }
-
-        return dir?.FullName
-            ?? throw new InvalidOperationException("Could not locate the repo root (no Pkmds.slnx found above the test bin directory).");
-    }
-
-    private static string ReadRepoFile(params string[] pathSegments) =>
-        File.ReadAllText(Path.Combine([RepoRoot, .. pathSegments]));
-
     [Fact]
     public void IndexHtml_ThemeColorMeta_IsSingleAndMatchesAppTheme()
     {
-        var html = ReadRepoFile("Pkmds.Web", "wwwroot", "index.html");
+        var html = RepoFileTestHelper.ReadAllText("Pkmds.Web", "wwwroot", "index.html");
 
         var metas = Regex.Matches(html, """<meta[^>]*name="theme-color"[^>]*>""");
 
@@ -55,7 +38,7 @@ public class ThemeSyncTests
     [Fact]
     public void IndexHtml_BrandAccents_MatchLightPrimary()
     {
-        var html = ReadRepoFile("Pkmds.Web", "wwwroot", "index.html");
+        var html = RepoFileTestHelper.ReadAllText("Pkmds.Web", "wwwroot", "index.html");
 
         var maskIcon = Regex.Match(html, """<link[^>]*rel="mask-icon"[^>]*color="([^"]+)""");
         maskIcon.Success.Should().BeTrue("index.html should declare a mask-icon color");
@@ -69,7 +52,7 @@ public class ThemeSyncTests
     [Fact]
     public void Manifest_ThemeAndBackgroundColors_MatchAppTheme()
     {
-        var manifest = ReadRepoFile("Pkmds.Web", "wwwroot", "manifest.webmanifest");
+        var manifest = RepoFileTestHelper.ReadAllText("Pkmds.Web", "wwwroot", "manifest.webmanifest");
 
         using var json = JsonDocument.Parse(manifest);
         json.RootElement.GetProperty("theme_color").GetString()
@@ -93,7 +76,7 @@ public class ThemeSyncTests
     [Fact]
     public void SplashCss_UsesOnlyAppThemeColors()
     {
-        var css = ReadRepoFile("Pkmds.Rcl", "wwwroot", "css", "app.css");
+        var css = RepoFileTestHelper.ReadAllText("Pkmds.Rcl", "wwwroot", "css", "app.css");
 
         var begin = css.IndexOf("/* begin pkmds-splash", StringComparison.Ordinal);
         var end = css.IndexOf("/* end pkmds-splash", StringComparison.Ordinal);
@@ -115,7 +98,7 @@ public class ThemeSyncTests
     {
         // The page has its own standalone grays (it renders without any app CSS), but its
         // link colors mirror the palette primaries and should follow them if they change.
-        var html = ReadRepoFile("Pkmds.Web", "wwwroot", "BrowserNotSupported.html");
+        var html = RepoFileTestHelper.ReadAllText("Pkmds.Web", "wwwroot", "BrowserNotSupported.html");
 
         html.Should().ContainEquivalentOf(AppTheme.Colors.Blue800,
             "BrowserNotSupported.html light link color should match the light palette Primary");

--- a/Pkmds.Web/wwwroot/service-worker.published.js
+++ b/Pkmds.Web/wwwroot/service-worker.published.js
@@ -38,12 +38,19 @@ self.addEventListener('message', event => {
 });
 self.addEventListener('fetch', event => {
     const clientId = event.resultingClientId || event.clientId;
-    if (clientId && !trackedClientIds.has(clientId)) {
+    const isNavigation = event.request.mode === 'navigate';
+    if (clientId && (!trackedClientIds.has(clientId) || isNavigation)) {
         trackedClientIds.add(clientId);
-        event.waitUntil(recordClientCacheLease(clientId).catch(err => {
-            trackedClientIds.delete(clientId);
-            console.warn('SW: Failed to record client cache lease.', err);
-        }));
+        event.waitUntil(recordClientCacheLease(clientId)
+            .then(async () => {
+                if (isNavigation) {
+                    await pruneUnusedAppCaches();
+                }
+            })
+            .catch(err => {
+                trackedClientIds.delete(clientId);
+                console.warn('SW: Failed to record client cache lease or prune unused caches.', err);
+            }));
     }
     event.respondWith(onFetch(event));
 });
@@ -98,6 +105,13 @@ async function onInstall(event) {
 }
 
 async function hasLegacyCacheWithoutNativeRuntime() {
+    // A stale cache by itself must not bypass the normal waiting-worker handoff. Workers from
+    // before cache leases can only strand a client when such an unleased client is still live.
+    const {hasUnleasedClients} = await getLiveClientCacheLeases();
+    if (!hasUnleasedClients) {
+        return false;
+    }
+
     const cacheKeys = await caches.keys();
     const legacyCacheKeys = cacheKeys.filter(key => key.startsWith(cacheNamePrefix) && key !== cacheName);
 
@@ -121,9 +135,15 @@ async function onActivate(event) {
         // Do not claim or prune a successfully running legacy tab. Its next deliberate reload
         // will use this now-active worker, while its current editor and cache remain untouched.
         console.warn('SW: Preserving legacy clients and cache until their next navigation.');
+        await currentCache.delete(legacyRecoveryMarkerUrl);
         return false;
     }
 
+    await pruneUnusedAppCaches();
+    return true;
+}
+
+async function pruneUnusedAppCaches() {
     // A tab can remain controlled by any older worker across multiple deployments. Each worker
     // records which version cache its clients use, so retain every cache leased by a live tab
     // instead of guessing that only the immediately previous cache can still be needed.
@@ -134,15 +154,13 @@ async function onActivate(event) {
         // uncontrolled. Preserve all app caches until a later activation can identify every
         // live client's cache rather than risking an in-use version during migration.
         console.info('SW: Live client without a cache lease; preserving prior app caches.');
-        return true;
+        return;
     }
 
     await Promise.all(cacheKeys
         .filter(key => key.startsWith(cacheNamePrefix)
             && !leasedCacheNames.has(key))
         .map(key => caches.delete(key)));
-
-    return true;
 }
 
 async function recordClientCacheLease(clientId) {

--- a/Pkmds.Web/wwwroot/service-worker.published.js
+++ b/Pkmds.Web/wwwroot/service-worker.published.js
@@ -3,18 +3,32 @@
 
 self.importScripts('./service-worker-assets.js');
 self.addEventListener('install', event => {
-    // Keep the new worker waiting until existing pages close or explicitly apply the update.
-    // Activating during an ordinary reload can pair HTML served by the old worker with boot
-    // resources served by the new worker, which strands clients on mixed app versions.
-    event.waitUntil(onInstall(event));
+    event.waitUntil((async () => {
+        await onInstall(event);
+
+        // Keep healthy updates waiting until existing pages close or explicitly apply them.
+        // The one exception is a legacy cache that cannot boot after deployment because it did
+        // not pre-cache its fingerprinted native runtime. Such a page can only ever serve the
+        // old recovery code, while this complete worker remains waiting behind it. Activate the
+        // complete worker so the user's next reload escapes that loop. Do not navigate/reload
+        // clients here: an already-running editor may contain unsaved changes.
+        if (await hasLegacyCacheWithoutNativeRuntime()) {
+            console.warn('SW: Legacy cache is missing its native runtime; activating recovery worker.');
+            const cache = await caches.open(cacheName);
+            await cache.put(legacyRecoveryMarkerUrl, new Response('true'));
+            await self.skipWaiting();
+        }
+    })());
 });
 
 self.addEventListener('activate', event => {
     event.waitUntil((async () => {
-        await onActivate(event);
+        const shouldClaimClients = await onActivate(event);
         // Explicit updates wait for controllerchange before reloading. Claiming here completes
         // that handoff; natural activation normally has no existing clients to claim.
-        await self.clients.claim();
+        if (shouldClaimClients) {
+            await self.clients.claim();
+        }
     })());
 });
 self.addEventListener('message', event => {
@@ -59,6 +73,8 @@ const offlineAssetsExclude = [/^service-worker\.js$/, /^staticwebapp\.config\.js
 const base = "/";
 const baseUrl = new URL(base, self.origin);
 const manifestUrlList = self.assetsManifest.assets.map(asset => new URL(asset.url, baseUrl).href);
+const nativeRuntimePath = /\/_framework\/dotnet\.native\.[^/]+\.wasm$/;
+const legacyRecoveryMarkerUrl = new URL('__legacy-cache-recovery__', baseUrl).href;
 
 async function onInstall(event) {
     console.info('Service worker: Install');
@@ -81,8 +97,32 @@ async function onInstall(event) {
     }
 }
 
+async function hasLegacyCacheWithoutNativeRuntime() {
+    const cacheKeys = await caches.keys();
+    const legacyCacheKeys = cacheKeys.filter(key => key.startsWith(cacheNamePrefix) && key !== cacheName);
+
+    for (const legacyCacheKey of legacyCacheKeys) {
+        const legacyCache = await caches.open(legacyCacheKey);
+        const cachedRequests = await legacyCache.keys();
+        if (!cachedRequests.some(request => nativeRuntimePath.test(new URL(request.url).pathname))) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 async function onActivate(event) {
     console.info('Service worker: Activate');
+
+    const currentCache = await caches.open(cacheName);
+    const isLegacyRecovery = Boolean(await currentCache.match(legacyRecoveryMarkerUrl));
+    if (isLegacyRecovery) {
+        // Do not claim or prune a successfully running legacy tab. Its next deliberate reload
+        // will use this now-active worker, while its current editor and cache remain untouched.
+        console.warn('SW: Preserving legacy clients and cache until their next navigation.');
+        return false;
+    }
 
     // A tab can remain controlled by any older worker across multiple deployments. Each worker
     // records which version cache its clients use, so retain every cache leased by a live tab
@@ -94,13 +134,15 @@ async function onActivate(event) {
         // uncontrolled. Preserve all app caches until a later activation can identify every
         // live client's cache rather than risking an in-use version during migration.
         console.info('SW: Live client without a cache lease; preserving prior app caches.');
-        return;
+        return true;
     }
 
     await Promise.all(cacheKeys
         .filter(key => key.startsWith(cacheNamePrefix)
             && !leasedCacheNames.has(key))
         .map(key => caches.delete(key)));
+
+    return true;
 }
 
 async function recordClientCacheLease(clientId) {


### PR DESCRIPTION
## Summary

- recover clients stranded on a legacy cache that omitted the fingerprinted native runtime
- activate the complete recovery worker without claiming existing tabs or pruning their cache, so open editors remain untouched until deliberate navigation
- preserve the normal waiting-worker handoff for healthy updates
- restore the active tab panel's scroll box after MudBlazor 9.8 increased its selector specificity
- stamp `%%CACHE_VERSION%%` in the actual deployed `service-worker.js` for both production and UAT
- add regression coverage for the service-worker, workflow target, and layout selector

## Validation

- `dotnet format Pkmds.Tests/Pkmds.Tests.csproj --include Pkmds.Tests/ServiceWorkerAssetTests.cs Pkmds.Tests/LayoutAssetTests.cs --no-restore --verbosity minimal`
- `dotnet build Pkmds.Web/Pkmds.Web.csproj -c Debug -p:SkipTailwind=true --no-restore` — 0 warnings, 0 errors
- `dotnet build Pkmds.Tests/Pkmds.Tests.csproj -c Debug -p:SkipTailwind=true --no-restore` — 0 warnings, 0 errors
- `node --check Pkmds.Web/wwwroot/service-worker.published.js`
- `git diff --check`
- published two-version browser lifecycle:
  - real `2026.08.1719.1000` artifact reproduced the 98% `Failed to fetch` after switching the origin to this build
  - the recovery worker installed without clearing IndexedDB or forcing an existing tab to reload
  - the next reload booted successfully
  - a healthy prior build kept this build waiting and displayed the normal **An update is available** prompt
- published narrow-screen CSS harness scrolled the active tab panel from its top marker to its bottom marker

Per repository guidance, `dotnet test` was not run locally; GitHub Actions owns test execution.

Addresses #1142.
Addresses #1182.

Related to #1254: this fixes the verified deployment workflow bug that left `%%CACHE_VERSION%%` unstamped. The separate Safari manual-check error remains open and is not claimed as fixed here.
