### PR TITLE
Deploy PWA startup and tab scrolling regression fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Publish .NET Project
         run: dotnet publish Pkmds.Web/Pkmds.Web.csproj -c Release -o release --nologo /p:Version=${{ steps.version.outputs.VERSION }}
 
+      - name: Verify service worker assets
+        run: node tools/verify-service-worker-assets.mjs release/wwwroot
+
       # Create and push git tag with the version number
       - name: Create and push tag
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,8 @@ jobs:
       - name: Update version
         uses: datamonsters/replace-action@v2
         with:
-          files: 'release/wwwroot/service-worker.published.js'
+          # Publish renames service-worker.published.js to the deployed service-worker.js.
+          files: 'release/wwwroot/service-worker.js'
           replacements: '%%CACHE_VERSION%%=${{ github.run_id }}'
 
 

--- a/.github/workflows/uat.yml
+++ b/.github/workflows/uat.yml
@@ -52,7 +52,8 @@ jobs:
       - name: Update cache version
         uses: datamonsters/replace-action@v2
         with:
-          files: 'release/wwwroot/service-worker.published.js'
+          # Publish renames service-worker.published.js to the deployed service-worker.js.
+          files: 'release/wwwroot/service-worker.js'
           replacements: '%%CACHE_VERSION%%=${{ github.run_id }}'
 
 

--- a/.github/workflows/uat.yml
+++ b/.github/workflows/uat.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Publish
         run: dotnet publish Pkmds.Web/Pkmds.Web.csproj -c Release -o release --nologo -p:BlazorWebAssemblyEnvironment=Staging
 
+      - name: Verify service worker assets
+        run: node tools/verify-service-worker-assets.mjs release/wwwroot
+
       - name: Copy index.html to 404.html
         run: cp release/wwwroot/index.html release/wwwroot/404.html
 

--- a/Pkmds.Rcl/Tailwind.targets
+++ b/Pkmds.Rcl/Tailwind.targets
@@ -103,7 +103,7 @@
     <!-- Use Inputs/Outputs for incremental build to prevent rebuilding when unnecessary -->
     <Target Name="TailwindBuild"
             Condition="'$(SkipTailwind)' != 'true'"
-            BeforeTargets="BeforeCompile;ResolveCurrentProjectStaticWebAssetsInputs;ResolveStaticWebAssetsInputs"
+            BeforeTargets="ResolveProjectStaticWebAssets;BeforeCompile;ResolveCurrentProjectStaticWebAssetsInputs;ResolveStaticWebAssetsInputs"
             Inputs="$(TailwindInputCss);$(TailwindConfigJs);$(MSBuildThisFileDirectory)Tailwind.targets"
             Outputs="$(TailwindMarkerFile);$(TailwindOutputCss)">
         <PropertyGroup>

--- a/Pkmds.Rcl/Tailwind.targets
+++ b/Pkmds.Rcl/Tailwind.targets
@@ -103,7 +103,7 @@
     <!-- Use Inputs/Outputs for incremental build to prevent rebuilding when unnecessary -->
     <Target Name="TailwindBuild"
             Condition="'$(SkipTailwind)' != 'true'"
-            BeforeTargets="BeforeCompile;ResolveStaticWebAssetsInputs"
+            BeforeTargets="BeforeCompile;ResolveCurrentProjectStaticWebAssetsInputs;ResolveStaticWebAssetsInputs"
             Inputs="$(TailwindInputCss);$(TailwindConfigJs);$(MSBuildThisFileDirectory)Tailwind.targets"
             Outputs="$(TailwindMarkerFile);$(TailwindOutputCss)">
         <PropertyGroup>

--- a/Pkmds.Rcl/wwwroot/css/app.css
+++ b/Pkmds.Rcl/wwwroot/css/app.css
@@ -65,10 +65,10 @@ body, html {
    silently ignored. On narrow screens (< 1280px) the outer tab panel is the
    page's only scroll container (html/body are overflow:hidden), so 9.6.0 broke
    all scrolling there — box grid, edit form, and Trainer tab were clipped with
-   no way to reach the overflow. Restore the 9.5.x block box. This must stay
-   ABOVE the :has(...) rules that switch the Bank/Pokédex panels to display:flex;
-   the specificity ties at (0,5,0), so file order decides the winner. Keep the
-   :not(.mud-tab) term in sync with MudBlazor's active-panel selector. */
+   no way to reach the overflow. Restore the 9.5.x block box. The later
+   :has(...) rules that switch the Bank/Pokédex panels to display:flex repeat
+   these active-panel terms and add their panel context, so they outrank this
+   rule. Keep the state terms in sync across all three selectors. */
 .mud-tabs-panels > .mud-tab-panel:not(.mud-tab).mud-tab-panel-active:not(.mud-tab-panel-hidden) {
     display: block;
 }
@@ -390,7 +390,7 @@ body, html {
 
     /* Bank tab: the tab panel becomes a flex column so the card grid can
        fill remaining vertical space without a fragile calc() offset. */
-    .save-file-outer-tabs > .mud-tabs-panels > .mud-tab-panel:has(.bank-tab-content) {
+    .save-file-outer-tabs > .mud-tabs-panels > .mud-tab-panel:not(.mud-tab).mud-tab-panel-active:not(.mud-tab-panel-hidden):has(.bank-tab-content) {
         display: flex;
         flex-direction: column;
     }
@@ -566,7 +566,7 @@ body, html {
        outer panel scrollbar so the table-container has a definite, viewport-bounded
        height to size against (otherwise the Virtualize component cuts the list off
        at whatever fits in its initial computed height — ~106 rows on phone portrait). */
-    .save-file-outer-tabs > .mud-tabs-panels > .mud-tab-panel:has(.pokedex-tab-content) {
+    .save-file-outer-tabs > .mud-tabs-panels > .mud-tab-panel:not(.mud-tab).mud-tab-panel-active:not(.mud-tab-panel-hidden):has(.pokedex-tab-content) {
         overflow: hidden;
         display: flex;
         flex-direction: column;

--- a/Pkmds.Rcl/wwwroot/css/app.css
+++ b/Pkmds.Rcl/wwwroot/css/app.css
@@ -67,8 +67,9 @@ body, html {
    all scrolling there — box grid, edit form, and Trainer tab were clipped with
    no way to reach the overflow. Restore the 9.5.x block box. This must stay
    ABOVE the :has(...) rules that switch the Bank/Pokédex panels to display:flex;
-   the specificity ties at (0,4,0), so file order decides the winner. */
-.mud-tabs-panels > .mud-tab-panel.mud-tab-panel-active:not(.mud-tab-panel-hidden) {
+   the specificity ties at (0,5,0), so file order decides the winner. Keep the
+   :not(.mud-tab) term in sync with MudBlazor's active-panel selector. */
+.mud-tabs-panels > .mud-tab-panel:not(.mud-tab).mud-tab-panel-active:not(.mud-tab-panel-hidden) {
     display: block;
 }
 

--- a/Pkmds.Tests/LayoutAssetTests.cs
+++ b/Pkmds.Tests/LayoutAssetTests.cs
@@ -3,11 +3,15 @@ namespace Pkmds.Tests;
 public sealed class LayoutAssetTests
 {
     [Fact]
-    public void ActiveTabPanelOverridesMudBlazorDisplayContents()
+    public void ActiveTabPanelOverridesPreserveSpecializedFlexLayouts()
     {
         var appCss = RepoFileTestHelper.ReadAllText("Pkmds.Rcl", "wwwroot", "css", "app.css");
 
         appCss.Should().Contain(
             ".mud-tabs-panels > .mud-tab-panel:not(.mud-tab).mud-tab-panel-active:not(.mud-tab-panel-hidden)");
+        appCss.Should().Contain(
+            ".save-file-outer-tabs > .mud-tabs-panels > .mud-tab-panel:not(.mud-tab).mud-tab-panel-active:not(.mud-tab-panel-hidden):has(.bank-tab-content)");
+        appCss.Should().Contain(
+            ".save-file-outer-tabs > .mud-tabs-panels > .mud-tab-panel:not(.mud-tab).mud-tab-panel-active:not(.mud-tab-panel-hidden):has(.pokedex-tab-content)");
     }
 }

--- a/Pkmds.Tests/LayoutAssetTests.cs
+++ b/Pkmds.Tests/LayoutAssetTests.cs
@@ -2,25 +2,12 @@ namespace Pkmds.Tests;
 
 public sealed class LayoutAssetTests
 {
-    private static readonly string RepoRoot = FindRepoRoot();
-
     [Fact]
     public void ActiveTabPanelOverridesMudBlazorDisplayContents()
     {
-        var appCss = File.ReadAllText(Path.Combine(RepoRoot, "Pkmds.Rcl", "wwwroot", "css", "app.css"));
+        var appCss = RepoFileTestHelper.ReadAllText("Pkmds.Rcl", "wwwroot", "css", "app.css");
 
         appCss.Should().Contain(
             ".mud-tabs-panels > .mud-tab-panel:not(.mud-tab).mud-tab-panel-active:not(.mud-tab-panel-hidden)");
-    }
-
-    private static string FindRepoRoot()
-    {
-        var directory = new DirectoryInfo(AppContext.BaseDirectory);
-        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "Pkmds.slnx")))
-        {
-            directory = directory.Parent;
-        }
-
-        return directory?.FullName ?? throw new DirectoryNotFoundException("Could not locate the repository root.");
     }
 }

--- a/Pkmds.Tests/LayoutAssetTests.cs
+++ b/Pkmds.Tests/LayoutAssetTests.cs
@@ -1,0 +1,26 @@
+namespace Pkmds.Tests;
+
+public sealed class LayoutAssetTests
+{
+    private static readonly string RepoRoot = FindRepoRoot();
+
+    [Fact]
+    public void ActiveTabPanelOverridesMudBlazorDisplayContents()
+    {
+        var appCss = File.ReadAllText(Path.Combine(RepoRoot, "Pkmds.Rcl", "wwwroot", "css", "app.css"));
+
+        appCss.Should().Contain(
+            ".mud-tabs-panels > .mud-tab-panel:not(.mud-tab).mud-tab-panel-active:not(.mud-tab-panel-hidden)");
+    }
+
+    private static string FindRepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "Pkmds.slnx")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory?.FullName ?? throw new DirectoryNotFoundException("Could not locate the repository root.");
+    }
+}

--- a/Pkmds.Tests/RepoFileTestHelper.cs
+++ b/Pkmds.Tests/RepoFileTestHelper.cs
@@ -1,0 +1,20 @@
+namespace Pkmds.Tests;
+
+internal static class RepoFileTestHelper
+{
+    private static readonly string RepoRoot = FindRepoRoot();
+
+    public static string ReadAllText(params string[] pathSegments) =>
+        File.ReadAllText(Path.Combine([RepoRoot, .. pathSegments]));
+
+    private static string FindRepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "Pkmds.slnx")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory?.FullName ?? throw new DirectoryNotFoundException("Could not locate the repository root.");
+    }
+}

--- a/Pkmds.Tests/RepoFileTestHelper.cs
+++ b/Pkmds.Tests/RepoFileTestHelper.cs
@@ -2,6 +2,7 @@ namespace Pkmds.Tests;
 
 internal static class RepoFileTestHelper
 {
+    private const string RepoSentinelFileName = "Pkmds.slnx";
     private static readonly string RepoRoot = FindRepoRoot();
 
     public static string ReadAllText(params string[] pathSegments) =>
@@ -9,12 +10,14 @@ internal static class RepoFileTestHelper
 
     private static string FindRepoRoot()
     {
-        var directory = new DirectoryInfo(AppContext.BaseDirectory);
-        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "Pkmds.slnx")))
+        var startingDirectory = AppContext.BaseDirectory;
+        var directory = new DirectoryInfo(startingDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, RepoSentinelFileName)))
         {
             directory = directory.Parent;
         }
 
-        return directory?.FullName ?? throw new DirectoryNotFoundException("Could not locate the repository root.");
+        return directory?.FullName ?? throw new DirectoryNotFoundException(
+            $"Could not locate the repository root: {RepoSentinelFileName} was not found in or above {startingDirectory}.");
     }
 }

--- a/Pkmds.Tests/ServiceWorkerAssetTests.cs
+++ b/Pkmds.Tests/ServiceWorkerAssetTests.cs
@@ -73,6 +73,8 @@ public sealed partial class ServiceWorkerAssetTests
         MissingNewestWorkerRepairRegex().IsMatch(appScript).Should().BeTrue();
         appScript.Should().Contain("if (!isBenignServiceWorkerUpdateError(err))");
         appScript.Should().Contain("window._swRegistrationPromise = Promise.resolve(registration)");
+        appScript.Should().Contain("const currentRegistration = await window._swRegistrationPromise");
+        RepairedRegistrationReloadRegex().IsMatch(appScript).Should().BeTrue();
     }
 
     [GeneratedRegex(@"const offlineAssetsExclude = \[[^;]+;", RegexOptions.CultureInvariant)]
@@ -98,4 +100,7 @@ public sealed partial class ServiceWorkerAssetTests
 
     [GeneratedRegex(@"catch \(err\)\s*\{\s*if \(!isBenignServiceWorkerUpdateError\(err\)\)[\s\S]+?registration = await navigator\.serviceWorker\.register\([\s\S]+?registration\.addEventListener\('updatefound', signalUpdateFound\);", RegexOptions.CultureInvariant)]
     private static partial Regex MissingNewestWorkerRepairRegex();
+
+    [GeneratedRegex(@"if \(repairedRegistration\)\s*\{\s*notifyUpdateAvailable\(\);\s*return 'found';\s*\}[\s\S]+?if \(navigator\.serviceWorker\.controller \|\| repairedRegistration\)", RegexOptions.CultureInvariant)]
+    private static partial Regex RepairedRegistrationReloadRegex();
 }

--- a/Pkmds.Tests/ServiceWorkerAssetTests.cs
+++ b/Pkmds.Tests/ServiceWorkerAssetTests.cs
@@ -46,7 +46,7 @@ public sealed partial class ServiceWorkerAssetTests
     {
         var targets = RepoFileTestHelper.ReadAllText("Pkmds.Rcl", "Tailwind.targets");
 
-        targets.Should().Contain("BeforeTargets=\"BeforeCompile;ResolveCurrentProjectStaticWebAssetsInputs;ResolveStaticWebAssetsInputs\"");
+        targets.Should().Contain("BeforeTargets=\"ResolveProjectStaticWebAssets;BeforeCompile;ResolveCurrentProjectStaticWebAssetsInputs;ResolveStaticWebAssetsInputs\"");
     }
 
     [Fact]

--- a/Pkmds.Tests/ServiceWorkerAssetTests.cs
+++ b/Pkmds.Tests/ServiceWorkerAssetTests.cs
@@ -37,7 +37,16 @@ public sealed partial class ServiceWorkerAssetTests
 
             workflowContents.Should().Contain("files: 'release/wwwroot/service-worker.js'");
             workflowContents.Should().NotContain("files: 'release/wwwroot/service-worker.published.js'");
+            workflowContents.Should().Contain("node tools/verify-service-worker-assets.mjs release/wwwroot");
         }
+    }
+
+    [Fact]
+    public void TailwindBuildPrecedesCurrentProjectStaticAssetHashing()
+    {
+        var targets = RepoFileTestHelper.ReadAllText("Pkmds.Rcl", "Tailwind.targets");
+
+        targets.Should().Contain("BeforeTargets=\"BeforeCompile;ResolveCurrentProjectStaticWebAssetsInputs;ResolveStaticWebAssetsInputs\"");
     }
 
     [Fact]

--- a/Pkmds.Tests/ServiceWorkerAssetTests.cs
+++ b/Pkmds.Tests/ServiceWorkerAssetTests.cs
@@ -31,14 +31,31 @@ public sealed partial class ServiceWorkerAssetTests
     }
 
     [Fact]
-    public void PublishedServiceWorkerWaitsForExplicitUpdateHandoff()
+    public void PublishedServiceWorkerWaitsUnlessLegacyCacheCannotBoot()
     {
         var serviceWorker = ReadRepoFile("Pkmds.Web", "wwwroot", "service-worker.published.js");
         var installHandler = InstallHandlerRegex().Match(serviceWorker);
 
         installHandler.Success.Should().BeTrue();
-        installHandler.Value.Should().NotContain("skipWaiting");
+        LegacyRecoveryActivationRegex().IsMatch(installHandler.Value).Should().BeTrue();
+        serviceWorker.Should().Contain("hasLegacyCacheWithoutNativeRuntime");
+        serviceWorker.Should().Contain("nativeRuntimePath");
+        serviceWorker.Should().Contain("legacyRecoveryMarkerUrl");
+        serviceWorker.Should().Contain("if (shouldClaimClients)");
+        serviceWorker.Should().Contain("return false;");
         serviceWorker.Should().Contain("event.waitUntil(self.skipWaiting())");
+    }
+
+    [Fact]
+    public void DeploymentWorkflowsStampTheDeployedServiceWorker()
+    {
+        foreach (var workflow in new[] { "main.yml", "uat.yml" })
+        {
+            var workflowContents = ReadRepoFile(".github", "workflows", workflow);
+
+            workflowContents.Should().Contain("files: 'release/wwwroot/service-worker.js'");
+            workflowContents.Should().NotContain("files: 'release/wwwroot/service-worker.published.js'");
+        }
     }
 
     [Fact]
@@ -71,6 +88,9 @@ public sealed partial class ServiceWorkerAssetTests
 
     [GeneratedRegex(@"self\.addEventListener\('install',[\s\S]+?\n}\);", RegexOptions.CultureInvariant)]
     private static partial Regex InstallHandlerRegex();
+
+    [GeneratedRegex(@"if \(await hasLegacyCacheWithoutNativeRuntime\(\)\)\s*\{[\s\S]+?await self\.skipWaiting\(\);\s*}", RegexOptions.CultureInvariant)]
+    private static partial Regex LegacyRecoveryActivationRegex();
 
     [GeneratedRegex(@"if \(registration\.waiting && navigator\.serviceWorker\.controller\)\s*\{\s*notifyUpdateAvailable\(\);\s*\}", RegexOptions.CultureInvariant)]
     private static partial Regex WaitingRegistrationNotificationRegex();

--- a/Pkmds.Tests/ServiceWorkerAssetTests.cs
+++ b/Pkmds.Tests/ServiceWorkerAssetTests.cs
@@ -100,7 +100,7 @@ public sealed partial class ServiceWorkerAssetTests
     [GeneratedRegex(@"if \(registration\.waiting && navigator\.serviceWorker\.controller\)\s*\{\s*notifyUpdateAvailable\(\);\s*\}", RegexOptions.CultureInvariant)]
     private static partial Regex WaitingRegistrationNotificationRegex();
 
-    [GeneratedRegex(@"catch \(err\)\s*\{\s*if \(!isBenignServiceWorkerUpdateError\(err\)\)[\s\S]+?registration = await navigator\.serviceWorker\.register\([\s\S]+?registration\.addEventListener\('updatefound', signalUpdateFound\);", RegexOptions.CultureInvariant)]
+    [GeneratedRegex(@"catch \(err\)\s*\{[\s\S]+?if \(!shouldRepairServiceWorkerRegistration\(err, registration\)\)[\s\S]+?registration = await navigator\.serviceWorker\.register\([\s\S]+?registration\.addEventListener\('updatefound', signalUpdateFound\);", RegexOptions.CultureInvariant)]
     private static partial Regex MissingNewestWorkerRepairRegex();
 
     [GeneratedRegex(@"if \(repairedRegistration\)\s*\{\s*notifyUpdateAvailable\(\);\s*return 'found';\s*\}[\s\S]+?if \(navigator\.serviceWorker\.controller \|\| repairedRegistration\)", RegexOptions.CultureInvariant)]

--- a/Pkmds.Tests/ServiceWorkerAssetTests.cs
+++ b/Pkmds.Tests/ServiceWorkerAssetTests.cs
@@ -72,6 +72,8 @@ public sealed partial class ServiceWorkerAssetTests
 
         MissingNewestWorkerRepairRegex().IsMatch(appScript).Should().BeTrue();
         appScript.Should().Contain("if (!isBenignServiceWorkerUpdateError(err))");
+        appScript.Should().Contain("if (!shouldRepairServiceWorkerRegistration(err, registration))");
+        appScript.Should().Contain("error.message.includes('Not found')");
         appScript.Should().Contain("window._swRegistrationPromise = Promise.resolve(registration)");
         appScript.Should().Contain("const currentRegistration = await window._swRegistrationPromise");
         RepairedRegistrationReloadRegex().IsMatch(appScript).Should().BeTrue();

--- a/Pkmds.Tests/ServiceWorkerAssetTests.cs
+++ b/Pkmds.Tests/ServiceWorkerAssetTests.cs
@@ -66,12 +66,13 @@ public sealed partial class ServiceWorkerAssetTests
     }
 
     [Fact]
-    public void ManualUpdateCheckTreatsKnownBrowserStateErrorAsNoUpdate()
+    public void ManualUpdateCheckRepairsMissingNewestWorkerRegistration()
     {
         var appScript = RepoFileTestHelper.ReadAllText("Pkmds.Web", "wwwroot", "js", "app.js");
 
-        BenignManualUpdateErrorRegex().IsMatch(appScript).Should().BeTrue();
+        MissingNewestWorkerRepairRegex().IsMatch(appScript).Should().BeTrue();
         appScript.Should().Contain("if (!isBenignServiceWorkerUpdateError(err))");
+        appScript.Should().Contain("window._swRegistrationPromise = Promise.resolve(registration)");
     }
 
     [GeneratedRegex(@"const offlineAssetsExclude = \[[^;]+;", RegexOptions.CultureInvariant)]
@@ -95,6 +96,6 @@ public sealed partial class ServiceWorkerAssetTests
     [GeneratedRegex(@"if \(registration\.waiting && navigator\.serviceWorker\.controller\)\s*\{\s*notifyUpdateAvailable\(\);\s*\}", RegexOptions.CultureInvariant)]
     private static partial Regex WaitingRegistrationNotificationRegex();
 
-    [GeneratedRegex(@"catch \(err\)\s*\{[\s\S]+?if \(isBenignServiceWorkerUpdateError\(err\)\)\s*\{\s*return 'none';\s*\}[\s\S]+?return 'error';", RegexOptions.CultureInvariant)]
-    private static partial Regex BenignManualUpdateErrorRegex();
+    [GeneratedRegex(@"catch \(err\)\s*\{\s*if \(!isBenignServiceWorkerUpdateError\(err\)\)[\s\S]+?registration = await navigator\.serviceWorker\.register\([\s\S]+?registration\.addEventListener\('updatefound', signalUpdateFound\);", RegexOptions.CultureInvariant)]
+    private static partial Regex MissingNewestWorkerRepairRegex();
 }

--- a/Pkmds.Tests/ServiceWorkerAssetTests.cs
+++ b/Pkmds.Tests/ServiceWorkerAssetTests.cs
@@ -65,6 +65,15 @@ public sealed partial class ServiceWorkerAssetTests
         appScript.Should().Contain("if (window._pkmdsUpdateWaiting)");
     }
 
+    [Fact]
+    public void ManualUpdateCheckTreatsKnownBrowserStateErrorAsNoUpdate()
+    {
+        var appScript = RepoFileTestHelper.ReadAllText("Pkmds.Web", "wwwroot", "js", "app.js");
+
+        BenignManualUpdateErrorRegex().IsMatch(appScript).Should().BeTrue();
+        appScript.Should().Contain("if (!isBenignServiceWorkerUpdateError(err))");
+    }
+
     [GeneratedRegex(@"const offlineAssetsExclude = \[[^;]+;", RegexOptions.CultureInvariant)]
     private static partial Regex OfflineAssetsExcludeRegex();
 
@@ -85,4 +94,7 @@ public sealed partial class ServiceWorkerAssetTests
 
     [GeneratedRegex(@"if \(registration\.waiting && navigator\.serviceWorker\.controller\)\s*\{\s*notifyUpdateAvailable\(\);\s*\}", RegexOptions.CultureInvariant)]
     private static partial Regex WaitingRegistrationNotificationRegex();
+
+    [GeneratedRegex(@"catch \(err\)\s*\{[\s\S]+?if \(isBenignServiceWorkerUpdateError\(err\)\)\s*\{\s*return 'none';\s*\}[\s\S]+?return 'error';", RegexOptions.CultureInvariant)]
+    private static partial Regex BenignManualUpdateErrorRegex();
 }

--- a/Pkmds.Tests/ServiceWorkerAssetTests.cs
+++ b/Pkmds.Tests/ServiceWorkerAssetTests.cs
@@ -4,26 +4,10 @@ namespace Pkmds.Tests;
 
 public sealed partial class ServiceWorkerAssetTests
 {
-    private static readonly string RepoRoot = FindRepoRoot();
-
-    private static string FindRepoRoot()
-    {
-        var directory = new DirectoryInfo(AppContext.BaseDirectory);
-        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "Pkmds.slnx")))
-        {
-            directory = directory.Parent;
-        }
-
-        return directory?.FullName ?? throw new DirectoryNotFoundException("Could not locate the repository root.");
-    }
-
-    private static string ReadRepoFile(params string[] pathSegments) =>
-        File.ReadAllText(Path.Combine([RepoRoot, .. pathSegments]));
-
     [Fact]
     public void PublishedServiceWorkerPreCachesNativeRuntime()
     {
-        var serviceWorker = ReadRepoFile("Pkmds.Web", "wwwroot", "service-worker.published.js");
+        var serviceWorker = RepoFileTestHelper.ReadAllText("Pkmds.Web", "wwwroot", "service-worker.published.js");
         var exclusions = OfflineAssetsExcludeRegex().Match(serviceWorker);
 
         exclusions.Success.Should().BeTrue();
@@ -33,16 +17,14 @@ public sealed partial class ServiceWorkerAssetTests
     [Fact]
     public void PublishedServiceWorkerWaitsUnlessLegacyCacheCannotBoot()
     {
-        var serviceWorker = ReadRepoFile("Pkmds.Web", "wwwroot", "service-worker.published.js");
+        var serviceWorker = RepoFileTestHelper.ReadAllText("Pkmds.Web", "wwwroot", "service-worker.published.js");
         var installHandler = InstallHandlerRegex().Match(serviceWorker);
 
         installHandler.Success.Should().BeTrue();
-        LegacyRecoveryActivationRegex().IsMatch(installHandler.Value).Should().BeTrue();
-        serviceWorker.Should().Contain("hasLegacyCacheWithoutNativeRuntime");
-        serviceWorker.Should().Contain("nativeRuntimePath");
-        serviceWorker.Should().Contain("legacyRecoveryMarkerUrl");
-        serviceWorker.Should().Contain("if (shouldClaimClients)");
-        serviceWorker.Should().Contain("return false;");
+        LegacyRecoveryInstallRegex().IsMatch(installHandler.Value).Should().BeTrue();
+        LiveLegacyClientGuardRegex().IsMatch(serviceWorker).Should().BeTrue();
+        LegacyRecoveryClientSafetyRegex().IsMatch(serviceWorker).Should().BeTrue();
+        NavigationCacheCleanupRegex().IsMatch(serviceWorker).Should().BeTrue();
         serviceWorker.Should().Contain("event.waitUntil(self.skipWaiting())");
     }
 
@@ -51,7 +33,7 @@ public sealed partial class ServiceWorkerAssetTests
     {
         foreach (var workflow in new[] { "main.yml", "uat.yml" })
         {
-            var workflowContents = ReadRepoFile(".github", "workflows", workflow);
+            var workflowContents = RepoFileTestHelper.ReadAllText(".github", "workflows", workflow);
 
             workflowContents.Should().Contain("files: 'release/wwwroot/service-worker.js'");
             workflowContents.Should().NotContain("files: 'release/wwwroot/service-worker.published.js'");
@@ -61,7 +43,7 @@ public sealed partial class ServiceWorkerAssetTests
     [Fact]
     public void AutomaticCacheRecoveryDoesNotDeleteIndexedDb()
     {
-        var cacheScript = ReadRepoFile("Pkmds.Rcl", "wwwroot", "js", "appCache.js");
+        var cacheScript = RepoFileTestHelper.ReadAllText("Pkmds.Rcl", "wwwroot", "js", "appCache.js");
 
         cacheScript.Should().Contain("caches.delete");
         cacheScript.Should().Contain("r.unregister()");
@@ -71,7 +53,7 @@ public sealed partial class ServiceWorkerAssetTests
     [Fact]
     public void WaitingServiceWorkerUpdateIsPreservedAndDispatched()
     {
-        var appScript = ReadRepoFile("Pkmds.Web", "wwwroot", "js", "app.js");
+        var appScript = RepoFileTestHelper.ReadAllText("Pkmds.Web", "wwwroot", "js", "app.js");
 
         appScript.Should().Contain("""
             function notifyUpdateAvailable() {
@@ -90,7 +72,16 @@ public sealed partial class ServiceWorkerAssetTests
     private static partial Regex InstallHandlerRegex();
 
     [GeneratedRegex(@"if \(await hasLegacyCacheWithoutNativeRuntime\(\)\)\s*\{[\s\S]+?await self\.skipWaiting\(\);\s*}", RegexOptions.CultureInvariant)]
-    private static partial Regex LegacyRecoveryActivationRegex();
+    private static partial Regex LegacyRecoveryInstallRegex();
+
+    [GeneratedRegex(@"const \{hasUnleasedClients} = await getLiveClientCacheLeases\(\);\s*if \(!hasUnleasedClients\)\s*\{\s*return false;\s*}", RegexOptions.CultureInvariant)]
+    private static partial Regex LiveLegacyClientGuardRegex();
+
+    [GeneratedRegex(@"if \(isLegacyRecovery\)\s*\{[\s\S]+?await currentCache\.delete\(legacyRecoveryMarkerUrl\);\s*return false;\s*}", RegexOptions.CultureInvariant)]
+    private static partial Regex LegacyRecoveryClientSafetyRegex();
+
+    [GeneratedRegex(@"const isNavigation = event\.request\.mode === 'navigate';[\s\S]+?if \(isNavigation\)\s*\{\s*await pruneUnusedAppCaches\(\);\s*}", RegexOptions.CultureInvariant)]
+    private static partial Regex NavigationCacheCleanupRegex();
 
     [GeneratedRegex(@"if \(registration\.waiting && navigator\.serviceWorker\.controller\)\s*\{\s*notifyUpdateAvailable\(\);\s*\}", RegexOptions.CultureInvariant)]
     private static partial Regex WaitingRegistrationNotificationRegex();

--- a/Pkmds.Tests/ThemeSyncTests.cs
+++ b/Pkmds.Tests/ThemeSyncTests.cs
@@ -14,33 +14,16 @@ namespace Pkmds.Tests;
 /// </summary>
 public class ThemeSyncTests
 {
-    private static readonly string RepoRoot = FindRepoRoot();
-
     private static readonly HashSet<string> AllThemeColors = typeof(AppTheme.Colors)
         .GetFields(BindingFlags.Public | BindingFlags.Static)
         .Where(f => f.IsLiteral)
         .Select(f => (string)f.GetRawConstantValue()!)
         .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-    private static string FindRepoRoot()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Pkmds.slnx")))
-        {
-            dir = dir.Parent;
-        }
-
-        return dir?.FullName
-            ?? throw new InvalidOperationException("Could not locate the repo root (no Pkmds.slnx found above the test bin directory).");
-    }
-
-    private static string ReadRepoFile(params string[] pathSegments) =>
-        File.ReadAllText(Path.Combine([RepoRoot, .. pathSegments]));
-
     [Fact]
     public void IndexHtml_ThemeColorMeta_IsSingleAndMatchesAppTheme()
     {
-        var html = ReadRepoFile("Pkmds.Web", "wwwroot", "index.html");
+        var html = RepoFileTestHelper.ReadAllText("Pkmds.Web", "wwwroot", "index.html");
 
         var metas = Regex.Matches(html, """<meta[^>]*name="theme-color"[^>]*>""");
 
@@ -55,7 +38,7 @@ public class ThemeSyncTests
     [Fact]
     public void IndexHtml_BrandAccents_MatchLightPrimary()
     {
-        var html = ReadRepoFile("Pkmds.Web", "wwwroot", "index.html");
+        var html = RepoFileTestHelper.ReadAllText("Pkmds.Web", "wwwroot", "index.html");
 
         var maskIcon = Regex.Match(html, """<link[^>]*rel="mask-icon"[^>]*color="([^"]+)""");
         maskIcon.Success.Should().BeTrue("index.html should declare a mask-icon color");
@@ -69,7 +52,7 @@ public class ThemeSyncTests
     [Fact]
     public void Manifest_ThemeAndBackgroundColors_MatchAppTheme()
     {
-        var manifest = ReadRepoFile("Pkmds.Web", "wwwroot", "manifest.webmanifest");
+        var manifest = RepoFileTestHelper.ReadAllText("Pkmds.Web", "wwwroot", "manifest.webmanifest");
 
         using var json = JsonDocument.Parse(manifest);
         json.RootElement.GetProperty("theme_color").GetString()
@@ -93,7 +76,7 @@ public class ThemeSyncTests
     [Fact]
     public void SplashCss_UsesOnlyAppThemeColors()
     {
-        var css = ReadRepoFile("Pkmds.Rcl", "wwwroot", "css", "app.css");
+        var css = RepoFileTestHelper.ReadAllText("Pkmds.Rcl", "wwwroot", "css", "app.css");
 
         var begin = css.IndexOf("/* begin pkmds-splash", StringComparison.Ordinal);
         var end = css.IndexOf("/* end pkmds-splash", StringComparison.Ordinal);
@@ -115,7 +98,7 @@ public class ThemeSyncTests
     {
         // The page has its own standalone grays (it renders without any app CSS), but its
         // link colors mirror the palette primaries and should follow them if they change.
-        var html = ReadRepoFile("Pkmds.Web", "wwwroot", "BrowserNotSupported.html");
+        var html = RepoFileTestHelper.ReadAllText("Pkmds.Web", "wwwroot", "BrowserNotSupported.html");
 
         html.Should().ContainEquivalentOf(AppTheme.Colors.Blue800,
             "BrowserNotSupported.html light link color should match the light palette Primary");

--- a/Pkmds.Web/wwwroot/js/app.js
+++ b/Pkmds.Web/wwwroot/js/app.js
@@ -38,12 +38,17 @@ if (pkmdsIsEmbedded()) {
         if (registration.waiting && navigator.serviceWorker.controller) {
             notifyUpdateAvailable();
         }
-        setInterval(() => registration.update().catch(err => {
-            // Safari may throw "newestWorker is null" — this is benign
-            if (!isBenignServiceWorkerUpdateError(err)) {
-                console.warn('Periodic registration.update() failed:', err);
-            }
-        }), 60 * 60 * 1000); // check for updates every hour
+        setInterval(async () => {
+            const currentRegistration = await window._swRegistrationPromise;
+            if (!currentRegistration) return;
+
+            currentRegistration.update().catch(err => {
+                // A manual check repairs this state and updates the shared promise.
+                if (!isBenignServiceWorkerUpdateError(err)) {
+                    console.warn('Periodic registration.update() failed:', err);
+                }
+            });
+        }, 60 * 60 * 1000); // check for updates every hour
         registration.onupdatefound = () => {
             const installingWorker = registration.installing;
             installingWorker.onstatechange = () => {
@@ -164,6 +169,7 @@ window.checkForUpdates = async () => {
     // up to date") moments before the global onupdatefound handler announces "An update is
     // available" — two contradictory snackbars for the same check (issue seen mostly on mobile).
     let signalUpdateFound;
+    let repairedRegistration = false;
     const updateFoundPromise = new Promise(resolve => { signalUpdateFound = resolve; });
     registration.addEventListener('updatefound', signalUpdateFound);
 
@@ -182,6 +188,7 @@ window.checkForUpdates = async () => {
             // still discover a deployment that happened while it remained open.
             registration.removeEventListener('updatefound', signalUpdateFound);
             try {
+                repairedRegistration = true;
                 registration = await navigator.serviceWorker.register(
                     'service-worker.js',
                     {updateViaCache: 'none'});
@@ -211,6 +218,14 @@ window.checkForUpdates = async () => {
 
         const installing = registration.installing;
         if (!installing) {
+            // The repaired worker may have installed and activated before register() resolved.
+            // This page is still uncontrolled by it, so offer the same deliberate reload as a
+            // waiting update instead of claiming the stale page is current.
+            if (repairedRegistration) {
+                notifyUpdateAvailable();
+                return 'found';
+            }
+
             return 'none';
         }
 
@@ -224,7 +239,7 @@ window.checkForUpdates = async () => {
                     clearTimeout(timeoutId);
                     // Mirror the controller check in the global onupdatefound handler: with no
                     // controller this is the page's very first SW install, not an update.
-                    if (navigator.serviceWorker.controller) {
+                    if (navigator.serviceWorker.controller || repairedRegistration) {
                         notifyUpdateAvailable();
                         resolve('found');
                     } else {

--- a/Pkmds.Web/wwwroot/js/app.js
+++ b/Pkmds.Web/wwwroot/js/app.js
@@ -28,6 +28,19 @@ function isBenignServiceWorkerUpdateError(error) {
         || (error.message && error.message.includes('newestWorker is null'));
 }
 
+function isMissingNewestWorkerRegistration(registration) {
+    return !registration.installing && !registration.waiting && !registration.active;
+}
+
+function shouldRepairServiceWorkerRegistration(error, registration) {
+    return isBenignServiceWorkerUpdateError(error)
+        || isMissingNewestWorkerRegistration(registration)
+        || (error.name === 'TypeError'
+            && error.message
+            && error.message.includes('ServiceWorker')
+            && error.message.includes('Not found'));
+}
+
 // Service worker registration
 if (pkmdsIsEmbedded()) {
     console.info('Service worker registration skipped: embedded host mode.');
@@ -177,7 +190,10 @@ window.checkForUpdates = async () => {
         try {
             await registration.update();
         } catch (err) {
-            if (!isBenignServiceWorkerUpdateError(err)) {
+            // Safari reports this empty-registration state as InvalidStateError
+            // ("newestWorker is null"), while Chromium may report TypeError ("Not found").
+            // Use the registration's actual slots so both can take the same repair path.
+            if (!shouldRepairServiceWorkerRegistration(err, registration)) {
                 console.warn('Manual update check failed:', err);
                 return 'error';
             }

--- a/Pkmds.Web/wwwroot/js/app.js
+++ b/Pkmds.Web/wwwroot/js/app.js
@@ -23,6 +23,11 @@ function notifyUpdateAvailable() {
     window.dispatchEvent(new CustomEvent('updateAvailable'));
 }
 
+function isBenignServiceWorkerUpdateError(error) {
+    return error.name === 'InvalidStateError'
+        || (error.message && error.message.includes('newestWorker is null'));
+}
+
 // Service worker registration
 if (pkmdsIsEmbedded()) {
     console.info('Service worker registration skipped: embedded host mode.');
@@ -35,7 +40,7 @@ if (pkmdsIsEmbedded()) {
         }
         setInterval(() => registration.update().catch(err => {
             // Safari may throw "newestWorker is null" — this is benign
-            if (!(err.name === 'InvalidStateError' || (err.message && err.message.includes('newestWorker is null')))) {
+            if (!isBenignServiceWorkerUpdateError(err)) {
                 console.warn('Periodic registration.update() failed:', err);
             }
         }), 60 * 60 * 1000); // check for updates every hour
@@ -166,9 +171,14 @@ window.checkForUpdates = async () => {
         try {
             await registration.update();
         } catch (err) {
-            if (!(err.name === 'InvalidStateError' || (err.message && err.message.includes('newestWorker is null')))) {
-                console.warn('Manual update check failed:', err);
+            // Some browsers reject a redundant manual check even though their normal
+            // navigation update check completed successfully. Do not report that known
+            // browser state quirk as a failed update; genuine failures remain visible.
+            if (isBenignServiceWorkerUpdateError(err)) {
+                return 'none';
             }
+
+            console.warn('Manual update check failed:', err);
             return 'error';
         }
 

--- a/Pkmds.Web/wwwroot/js/app.js
+++ b/Pkmds.Web/wwwroot/js/app.js
@@ -148,7 +148,7 @@ window.applyUpdate = async () => {
 // Proactively check for a service worker update.
 // Returns: 'found' (update ready), 'none' (up to date), 'no-sw' (SW unavailable), 'error' (check/install failed)
 window.checkForUpdates = async () => {
-    const registration = await window._swRegistrationPromise;
+    let registration = await window._swRegistrationPromise;
     if (!registration) return 'no-sw';
 
     // A waiting worker was already downloaded but not yet activated — notify immediately.
@@ -171,15 +171,26 @@ window.checkForUpdates = async () => {
         try {
             await registration.update();
         } catch (err) {
-            // Some browsers reject a redundant manual check even though their normal
-            // navigation update check completed successfully. Do not report that known
-            // browser state quirk as a failed update; genuine failures remain visible.
-            if (isBenignServiceWorkerUpdateError(err)) {
-                return 'none';
+            if (!isBenignServiceWorkerUpdateError(err)) {
+                console.warn('Manual update check failed:', err);
+                return 'error';
             }
 
-            console.warn('Manual update check failed:', err);
-            return 'error';
+            // InvalidStateError means this registration has no installing, waiting, or active
+            // worker. It does not mean the open page is current. Re-registering the same script
+            // and scope repairs that state and also performs the update check, so a stale tab can
+            // still discover a deployment that happened while it remained open.
+            registration.removeEventListener('updatefound', signalUpdateFound);
+            try {
+                registration = await navigator.serviceWorker.register(
+                    'service-worker.js',
+                    {updateViaCache: 'none'});
+                window._swRegistrationPromise = Promise.resolve(registration);
+                registration.addEventListener('updatefound', signalUpdateFound);
+            } catch (repairError) {
+                console.warn('Manual service worker registration repair failed:', repairError);
+                return 'error';
+            }
         }
 
         // No new worker visible yet — give the async 'updatefound' event a grace window

--- a/Pkmds.Web/wwwroot/service-worker.published.js
+++ b/Pkmds.Web/wwwroot/service-worker.published.js
@@ -38,12 +38,19 @@ self.addEventListener('message', event => {
 });
 self.addEventListener('fetch', event => {
     const clientId = event.resultingClientId || event.clientId;
-    if (clientId && !trackedClientIds.has(clientId)) {
+    const isNavigation = event.request.mode === 'navigate';
+    if (clientId && (!trackedClientIds.has(clientId) || isNavigation)) {
         trackedClientIds.add(clientId);
-        event.waitUntil(recordClientCacheLease(clientId).catch(err => {
-            trackedClientIds.delete(clientId);
-            console.warn('SW: Failed to record client cache lease.', err);
-        }));
+        event.waitUntil(recordClientCacheLease(clientId)
+            .then(async () => {
+                if (isNavigation) {
+                    await pruneUnusedAppCaches();
+                }
+            })
+            .catch(err => {
+                trackedClientIds.delete(clientId);
+                console.warn('SW: Failed to record client cache lease or prune unused caches.', err);
+            }));
     }
     event.respondWith(onFetch(event));
 });
@@ -98,6 +105,13 @@ async function onInstall(event) {
 }
 
 async function hasLegacyCacheWithoutNativeRuntime() {
+    // A stale cache by itself must not bypass the normal waiting-worker handoff. Workers from
+    // before cache leases can only strand a client when such an unleased client is still live.
+    const {hasUnleasedClients} = await getLiveClientCacheLeases();
+    if (!hasUnleasedClients) {
+        return false;
+    }
+
     const cacheKeys = await caches.keys();
     const legacyCacheKeys = cacheKeys.filter(key => key.startsWith(cacheNamePrefix) && key !== cacheName);
 
@@ -121,9 +135,15 @@ async function onActivate(event) {
         // Do not claim or prune a successfully running legacy tab. Its next deliberate reload
         // will use this now-active worker, while its current editor and cache remain untouched.
         console.warn('SW: Preserving legacy clients and cache until their next navigation.');
+        await currentCache.delete(legacyRecoveryMarkerUrl);
         return false;
     }
 
+    await pruneUnusedAppCaches();
+    return true;
+}
+
+async function pruneUnusedAppCaches() {
     // A tab can remain controlled by any older worker across multiple deployments. Each worker
     // records which version cache its clients use, so retain every cache leased by a live tab
     // instead of guessing that only the immediately previous cache can still be needed.
@@ -134,15 +154,13 @@ async function onActivate(event) {
         // uncontrolled. Preserve all app caches until a later activation can identify every
         // live client's cache rather than risking an in-use version during migration.
         console.info('SW: Live client without a cache lease; preserving prior app caches.');
-        return true;
+        return;
     }
 
     await Promise.all(cacheKeys
         .filter(key => key.startsWith(cacheNamePrefix)
             && !leasedCacheNames.has(key))
         .map(key => caches.delete(key)));
-
-    return true;
 }
 
 async function recordClientCacheLease(clientId) {

--- a/Pkmds.Web/wwwroot/service-worker.published.js
+++ b/Pkmds.Web/wwwroot/service-worker.published.js
@@ -3,18 +3,32 @@
 
 self.importScripts('./service-worker-assets.js');
 self.addEventListener('install', event => {
-    // Keep the new worker waiting until existing pages close or explicitly apply the update.
-    // Activating during an ordinary reload can pair HTML served by the old worker with boot
-    // resources served by the new worker, which strands clients on mixed app versions.
-    event.waitUntil(onInstall(event));
+    event.waitUntil((async () => {
+        await onInstall(event);
+
+        // Keep healthy updates waiting until existing pages close or explicitly apply them.
+        // The one exception is a legacy cache that cannot boot after deployment because it did
+        // not pre-cache its fingerprinted native runtime. Such a page can only ever serve the
+        // old recovery code, while this complete worker remains waiting behind it. Activate the
+        // complete worker so the user's next reload escapes that loop. Do not navigate/reload
+        // clients here: an already-running editor may contain unsaved changes.
+        if (await hasLegacyCacheWithoutNativeRuntime()) {
+            console.warn('SW: Legacy cache is missing its native runtime; activating recovery worker.');
+            const cache = await caches.open(cacheName);
+            await cache.put(legacyRecoveryMarkerUrl, new Response('true'));
+            await self.skipWaiting();
+        }
+    })());
 });
 
 self.addEventListener('activate', event => {
     event.waitUntil((async () => {
-        await onActivate(event);
+        const shouldClaimClients = await onActivate(event);
         // Explicit updates wait for controllerchange before reloading. Claiming here completes
         // that handoff; natural activation normally has no existing clients to claim.
-        await self.clients.claim();
+        if (shouldClaimClients) {
+            await self.clients.claim();
+        }
     })());
 });
 self.addEventListener('message', event => {
@@ -59,6 +73,8 @@ const offlineAssetsExclude = [/^service-worker\.js$/, /^staticwebapp\.config\.js
 const base = "/";
 const baseUrl = new URL(base, self.origin);
 const manifestUrlList = self.assetsManifest.assets.map(asset => new URL(asset.url, baseUrl).href);
+const nativeRuntimePath = /\/_framework\/dotnet\.native\.[^/]+\.wasm$/;
+const legacyRecoveryMarkerUrl = new URL('__legacy-cache-recovery__', baseUrl).href;
 
 async function onInstall(event) {
     console.info('Service worker: Install');
@@ -81,8 +97,32 @@ async function onInstall(event) {
     }
 }
 
+async function hasLegacyCacheWithoutNativeRuntime() {
+    const cacheKeys = await caches.keys();
+    const legacyCacheKeys = cacheKeys.filter(key => key.startsWith(cacheNamePrefix) && key !== cacheName);
+
+    for (const legacyCacheKey of legacyCacheKeys) {
+        const legacyCache = await caches.open(legacyCacheKey);
+        const cachedRequests = await legacyCache.keys();
+        if (!cachedRequests.some(request => nativeRuntimePath.test(new URL(request.url).pathname))) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 async function onActivate(event) {
     console.info('Service worker: Activate');
+
+    const currentCache = await caches.open(cacheName);
+    const isLegacyRecovery = Boolean(await currentCache.match(legacyRecoveryMarkerUrl));
+    if (isLegacyRecovery) {
+        // Do not claim or prune a successfully running legacy tab. Its next deliberate reload
+        // will use this now-active worker, while its current editor and cache remain untouched.
+        console.warn('SW: Preserving legacy clients and cache until their next navigation.');
+        return false;
+    }
 
     // A tab can remain controlled by any older worker across multiple deployments. Each worker
     // records which version cache its clients use, so retain every cache leased by a live tab
@@ -94,13 +134,15 @@ async function onActivate(event) {
         // uncontrolled. Preserve all app caches until a later activation can identify every
         // live client's cache rather than risking an in-use version during migration.
         console.info('SW: Live client without a cache lease; preserving prior app caches.');
-        return;
+        return true;
     }
 
     await Promise.all(cacheKeys
         .filter(key => key.startsWith(cacheNamePrefix)
             && !leasedCacheNames.has(key))
         .map(key => caches.delete(key)));
+
+    return true;
 }
 
 async function recordClientCacheLease(clientId) {

--- a/tools/verify-service-worker-assets.mjs
+++ b/tools/verify-service-worker-assets.mjs
@@ -1,0 +1,48 @@
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { isAbsolute, resolve, relative } from 'node:path';
+
+const publishRoot = resolve(process.argv[2] ?? 'release/wwwroot');
+const manifestPath = resolve(publishRoot, 'service-worker-assets.js');
+const manifestScript = await readFile(manifestPath, 'utf8');
+const jsonStart = manifestScript.indexOf('{');
+const jsonEnd = manifestScript.lastIndexOf('}');
+
+if (jsonStart < 0 || jsonEnd <= jsonStart) {
+    throw new Error(`Could not parse ${manifestPath}`);
+}
+
+const manifest = JSON.parse(manifestScript.slice(jsonStart, jsonEnd + 1));
+const include = [/\.dll$/, /\.pdb$/, /\.wasm/, /\.html/, /\.js$/, /\.json$/, /\.css$/, /\.woff$/, /\.woff2$/, /\.png$/, /\.jpe?g$/, /\.gif$/, /\.ico$/, /\.svg$/, /\.webp$/, /\.blat$/, /\.dat$/];
+const exclude = [/^service-worker\.js$/, /^staticwebapp\.config\.json$/];
+const assets = manifest.assets.filter(asset =>
+    include.some(pattern => pattern.test(asset.url))
+    && !exclude.some(pattern => pattern.test(asset.url)));
+
+const failures = [];
+await Promise.all(assets.map(async asset => {
+    const assetPath = resolve(publishRoot, decodeURIComponent(asset.url));
+    const relativePath = relative(publishRoot, assetPath);
+    if (relativePath.startsWith('..') || isAbsolute(relativePath)) {
+        failures.push(`${asset.url}: resolves outside the publish root`);
+        return;
+    }
+
+    try {
+        const bytes = await readFile(assetPath);
+        const actualHash = `sha256-${createHash('sha256').update(bytes).digest('base64')}`;
+        if (actualHash !== asset.hash) {
+            failures.push(`${asset.url}: expected ${asset.hash}, got ${actualHash}`);
+        }
+    } catch (error) {
+        failures.push(`${asset.url}: ${error.message}`);
+    }
+}));
+
+if (failures.length > 0) {
+    console.error(`Service-worker asset verification failed (${failures.length}/${assets.length}):`);
+    for (const failure of failures) console.error(`- ${failure}`);
+    process.exitCode = 1;
+} else {
+    console.log(`Verified ${assets.length} service-worker assets for manifest ${manifest.version}.`);
+}


### PR DESCRIPTION
## Summary

- promote #1257 to production to recover PWA clients stranded by a legacy cache missing the fingerprinted native runtime
- preserve live editors and IndexedDB-backed saves, backups, and Pokémon Bank data during service-worker recovery
- keep healthy updates on the normal waiting-worker handoff and prevent stale unused caches from forcing activation
- restore scrolling within the active tab panel after the MudBlazor 9.8 selector change
- stamp the cache version in the service-worker file actually deployed by both production and UAT workflows
- add focused regression coverage and a shared repository-file test helper

## Validation

- `node --check Pkmds.Web/wwwroot/service-worker.published.js`
- `dotnet format Pkmds.Tests/Pkmds.Tests.csproj --include Pkmds.Tests/RepoFileTestHelper.cs Pkmds.Tests/LayoutAssetTests.cs Pkmds.Tests/ServiceWorkerAssetTests.cs Pkmds.Tests/ThemeSyncTests.cs --no-restore --verbosity minimal`
- Debug builds of `Pkmds.Web` and `Pkmds.Tests` passed with zero warnings and errors
- published two-version browser lifecycle reproduced the legacy 98% startup failure, verified recovery on the next reload, and confirmed healthy updates still wait and display the normal update prompt
- published narrow-screen CSS harness verified scrolling from the active tab panel's top marker to its bottom marker
- conflict-free merge simulation from `dev` into `main`

Per repository policy, the test suite is left to GitHub Actions.

## Issue tracking

Closes #1142.
Closes #1182.

Related to #1254: this promotes the verified deployment workflow correction that stamps `%%CACHE_VERSION%%` in the deployed service worker. The separate Safari manual-check error remains open and is not claimed as fixed here.
