### PR TITLE
Reduce service worker install burst on GitHub Pages

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,7 +54,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4.37.4
+      uses: github/codeql-action/init@v4.37.8
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -72,6 +72,6 @@ jobs:
       run: dotnet build Pkmds.Web/Pkmds.Web.csproj -c Release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4.37.4
+      uses: github/codeql-action/analyze@v4.37.8
       with:
         category: "/language:${{matrix.language}}"

--- a/Pkmds.Tests/ServiceWorkerAssetTests.cs
+++ b/Pkmds.Tests/ServiceWorkerAssetTests.cs
@@ -15,6 +15,18 @@ public sealed partial class ServiceWorkerAssetTests
     }
 
     [Fact]
+    public void PublishedServiceWorkerCachesBundledSpritesLazily()
+    {
+        var serviceWorker = RepoFileTestHelper.ReadAllText("Pkmds.Web", "wwwroot", "service-worker.published.js");
+        var exclusions = OfflineAssetsExcludeRegex().Match(serviceWorker);
+
+        exclusions.Success.Should().BeTrue();
+        exclusions.Value.Should().Contain("^_content\\/Pkmds\\.Rcl\\/sprites\\/");
+        serviceWorker.Should().Contain("const bundledSpritePathPrefix = new URL('_content/Pkmds.Rcl/sprites/', baseUrl).href;");
+        serviceWorker.Should().Contain("const cache = await caches.open(isPokeApiSprite ? spriteCacheName : cacheName);");
+    }
+
+    [Fact]
     public void PublishedServiceWorkerWaitsUnlessLegacyCacheCannotBoot()
     {
         var serviceWorker = RepoFileTestHelper.ReadAllText("Pkmds.Web", "wwwroot", "service-worker.published.js");

--- a/Pkmds.Web/wwwroot/service-worker.published.js
+++ b/Pkmds.Web/wwwroot/service-worker.published.js
@@ -74,12 +74,15 @@ const offlineAssetsInclude = [/\.dll$/, /\.pdb$/, /\.wasm/, /\.html/, /\.js$/, /
 // AOT is disabled now and the runtime is roughly 3 MB. It must be cached: an
 // old app version cannot boot after a deploy removes its fingerprinted runtime
 // from the server, which caused the recurring 98% startup failures (#1142+).
-const offlineAssetsExclude = [/^service-worker\.js$/, /^staticwebapp\.config\.json$/];
+// Bundled sprites are cached on demand below. Pre-caching thousands of them can
+// trigger transient GitHub Pages 503 responses and reject the whole worker install.
+const offlineAssetsExclude = [/^service-worker\.js$/, /^staticwebapp\.config\.json$/, /^_content\/Pkmds\.Rcl\/sprites\//];
 
 // Replace with your base path if you are hosting on a subfolder. Ensure there is a trailing '/'.
 const base = "/";
 const baseUrl = new URL(base, self.origin);
 const manifestUrlList = self.assetsManifest.assets.map(asset => new URL(asset.url, baseUrl).href);
+const bundledSpritePathPrefix = new URL('_content/Pkmds.Rcl/sprites/', baseUrl).href;
 const nativeRuntimePath = /\/_framework\/dotnet\.native\.[^/]+\.wasm$/;
 const legacyRecoveryMarkerUrl = new URL('__legacy-cache-recovery__', baseUrl).href;
 
@@ -211,12 +214,15 @@ function getClientIdFromLeaseRequest(request) {
 }
 
 async function onFetch(event) {
-    // Cache-first strategy for PokeAPI sprites — separate long-lived cache that survives app updates.
+    // Cache bundled sprites lazily in the current version cache instead of requesting thousands
+    // during worker installation. PokeAPI sprites use a separate cache that survives app updates.
     // Return the promise rather than calling event.respondWith() here: the outer 'fetch' listener
     // already wraps onFetch(event) in respondWith, and double-calling it throws InvalidStateError
     // (and on iOS Safari surfaces as `FetchEvent.respondWith received an error: TypeError: ...`).
-    if (event.request.method === 'GET' && event.request.url.startsWith(spriteOrigin)) {
-        const cache = await caches.open(spriteCacheName);
+    const isPokeApiSprite = event.request.url.startsWith(spriteOrigin);
+    const isBundledSprite = event.request.url.startsWith(bundledSpritePathPrefix);
+    if (event.request.method === 'GET' && (isPokeApiSprite || isBundledSprite)) {
+        const cache = await caches.open(isPokeApiSprite ? spriteCacheName : cacheName);
         const cached = await cache.match(event.request);
         if (cached) return cached;
         try {


### PR DESCRIPTION
## Summary

- exclude 3,278 bundled sprites from the all-or-nothing service-worker install cache
- cache bundled sprites lazily in the current version cache while retaining the fingerprinted native runtime and app shell in the pre-cache
- bump github/codeql-action from 4.37.4 to 4.37.8, superseding #1205

## Production diagnosis

After #1259 deployed, a stale production Chromium client still failed at 98 percent while requesting a removed dotnet.native WASM fingerprint. The replacement worker could not reliably install because its 3,461-request pre-cache burst triggered intermittent GitHub Pages 503 responses. Since worker installation is intentionally atomic, one failed sprite request rejected the whole recovery worker and left the stale client active.

Tracked in reopened #1142. Duplicate reports #1256, #1258, #1261, and #1262 have each received a response and were closed individually.

## Validation

- node syntax check passes
- dotnet format completed
- Web Debug build: 0 warnings, 0 errors
- Tests Debug build: 0 warnings, 0 errors
- local Debug manifest selection: 342 pre-cache assets out of 3,626 manifest assets, including dotnet.native WASM and zero bundled sprites
- push Build and Test workflow passed: https://github.com/codemonkey85/PKMDS-Blazor/actions/runs/32740973213

Per repository policy, test execution is left to GitHub Actions. Production lifecycle verification remains required before #1142 is closed.