### PR TITLE
Deploy private bug report contact handling

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -127,6 +127,14 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
+      - name: Configure private report-data retention
+        run: |
+          az storage account management-policy create \
+            --account-name pkmdsbugreports \
+            --resource-group pkmds-bug-reports \
+            --policy @Pkmds.Functions/report-retention-policy.json \
+            --output none
+
       - name: Deploy to Azure Functions
         run: |
           az functionapp deployment source config-zip \

--- a/Pkmds.Functions/Functions/GitHubWebhook.cs
+++ b/Pkmds.Functions/Functions/GitHubWebhook.cs
@@ -44,14 +44,14 @@ public class GitHubWebhook(IBlobService blobService, IConfiguration configuratio
         }
 
         {
-            logger.LogInformation("GitHub issue #{IssueNumber} closed — cleaning up blobs", payload.Issue.Number);
+            logger.LogInformation("GitHub issue #{IssueNumber} closed — applying private-data retention", payload.Issue.Number);
             try
             {
-                await blobService.DeleteIssueFilesAsync(payload.Issue.Number, cancellationToken);
+                await blobService.CloseIssueAsync(payload.Issue.Number, cancellationToken);
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, "Failed to delete blobs for issue #{IssueNumber}", payload.Issue.Number);
+                logger.LogError(ex, "Failed to apply private-data retention for issue #{IssueNumber}", payload.Issue.Number);
             }
         }
 

--- a/Pkmds.Functions/Functions/GitHubWebhook.cs
+++ b/Pkmds.Functions/Functions/GitHubWebhook.cs
@@ -43,16 +43,17 @@ public class GitHubWebhook(IBlobService blobService, IConfiguration configuratio
             return new OkResult();
         }
 
+        logger.LogInformation("GitHub issue #{IssueNumber} closed — applying private-data retention", payload.Issue.Number);
+        try
         {
-            logger.LogInformation("GitHub issue #{IssueNumber} closed — applying private-data retention", payload.Issue.Number);
-            try
-            {
-                await blobService.CloseIssueAsync(payload.Issue.Number, cancellationToken);
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Failed to apply private-data retention for issue #{IssueNumber}", payload.Issue.Number);
-            }
+            await blobService.CloseIssueAsync(payload.Issue.Number, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to apply private-data retention for issue #{IssueNumber}", payload.Issue.Number);
+            // GitHub retries webhook deliveries that receive a non-2xx response. CloseIssueAsync
+            // is idempotent, so a retry safely resumes any cleanup that failed partway through.
+            return new StatusCodeResult(StatusCodes.Status503ServiceUnavailable);
         }
 
         return new OkResult();

--- a/Pkmds.Functions/Functions/SubmitBugReport.cs
+++ b/Pkmds.Functions/Functions/SubmitBugReport.cs
@@ -29,8 +29,8 @@ public class SubmitBugReport(IGitHubService gitHubService, IBlobService blobServ
             return new BadRequestObjectResult(new { error = "Failed to read form data." });
         }
 
-        var name = form["name"].ToString().Trim();
-        var email = form["email"].ToString().Trim();
+        var contactOptIn = bool.TryParse(form["contactOptIn"], out var parsedContactOptIn) && parsedContactOptIn;
+        var contactEmail = contactOptIn ? form["contactEmail"].ToString().Trim() : string.Empty;
         var category = form["category"].ToString().Trim();
         var appVersion = form["appVersion"].ToString().Trim();
         var pkhexVersion = form["pkhexVersion"].ToString().Trim();
@@ -44,7 +44,9 @@ public class SubmitBugReport(IGitHubService gitHubService, IBlobService blobServ
         var details = form["details"].ToString().Trim();
         var saveGameName = form["saveGameName"].ToString().Trim();
         var saveRevision = form["saveRevision"].ToString().Trim();
-        var saveFileName = form["saveFileName"].ToString().Trim();
+        var saveFileExtension = GetSafeExtension(FirstNonEmpty(
+            form["saveFileExtension"].ToString().Trim(),
+            form["saveFileName"].ToString().Trim()));
         var saveFileSource = form["saveFileSource"].ToString().Trim();
         var saveFileType = form["saveFileType"].ToString().Trim();
 
@@ -55,9 +57,9 @@ public class SubmitBugReport(IGitHubService gitHubService, IBlobService blobServ
             ? FirstNonEmpty(actual, form["description"].ToString().Trim())
             : details;
 
-        if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(email))
+        if (contactOptIn && !System.Net.Mail.MailAddress.TryCreate(contactEmail, out _))
         {
-            return new BadRequestObjectResult(new { error = "name and email are required." });
+            return new BadRequestObjectResult(new { error = "A valid contact email is required when contact permission is enabled." });
         }
 
         // primaryText is already trimmed at assignment (the source fields are .Trim()'d). A length
@@ -82,14 +84,14 @@ public class SubmitBugReport(IGitHubService gitHubService, IBlobService blobServ
 
         var saveFileSection = new StringBuilder();
         if (!string.IsNullOrWhiteSpace(saveGameName) ||
-            !string.IsNullOrWhiteSpace(saveFileName) ||
+            !string.IsNullOrWhiteSpace(saveFileExtension) ||
             !string.IsNullOrWhiteSpace(saveFileSource) ||
             !string.IsNullOrWhiteSpace(saveFileType))
         {
             saveFileSection.Append("\n\n## Save File\n");
-            if (!string.IsNullOrWhiteSpace(saveFileName))
+            if (!string.IsNullOrWhiteSpace(saveFileExtension))
             {
-                saveFileSection.Append($"\n- **File:** `{saveFileName}`");
+                saveFileSection.Append($"\n- **File type:** `{saveFileExtension}`");
             }
 
             if (!string.IsNullOrWhiteSpace(saveGameName))
@@ -140,7 +142,6 @@ public class SubmitBugReport(IGitHubService gitHubService, IBlobService blobServ
         }
 
         var issueBody =
-            $"**Reporter:** {name} ({email})\n" +
             $"**App version:** {appVersion}\n" +
             (string.IsNullOrWhiteSpace(pkhexVersion)
                 ? string.Empty
@@ -154,7 +155,7 @@ public class SubmitBugReport(IGitHubService gitHubService, IBlobService blobServ
         try
         {
             (issueNumber, issueUrl) = await gitHubService.CreateIssueAsync(issueTitle, issueBody, issueLabel);
-            logger.LogInformation("Created GitHub issue #{IssueNumber} for bug report from {Email}", issueNumber, email);
+            logger.LogInformation("Created GitHub issue #{IssueNumber} from an in-app report", issueNumber);
         }
         catch (Exception ex)
         {
@@ -162,10 +163,26 @@ public class SubmitBugReport(IGitHubService gitHubService, IBlobService blobServ
             return new ObjectResult(new { error = "Failed to create GitHub issue. Please try again later." }) { StatusCode = StatusCodes.Status502BadGateway };
         }
 
+        var contactStored = !contactOptIn;
+        if (contactOptIn)
+        {
+            try
+            {
+                await blobService.StoreContactAsync(issueNumber, contactEmail, cancellationToken);
+                contactStored = true;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to store private contact details for issue #{IssueNumber}", issueNumber);
+                // Non-fatal: the public issue already exists. Tell the client that follow-up by email
+                // is unavailable without echoing the address into logs or the response.
+            }
+        }
+
         var saveFile = form.Files["saveFile"];
         if (saveFile is not { Length: > 0 })
         {
-            return new ObjectResult(new { issueNumber, issueUrl }) { StatusCode = StatusCodes.Status201Created };
+            return new ObjectResult(new { issueNumber, issueUrl, contactStored }) { StatusCode = StatusCodes.Status201Created };
         }
 
         {
@@ -176,17 +193,13 @@ public class SubmitBugReport(IGitHubService gitHubService, IBlobService blobServ
             }
             else
             {
-                var safeFileName = SanitizeFileName(saveFile.FileName);
                 try
                 {
                     await using var stream = saveFile.OpenReadStream();
-                    await blobService.UploadAsync(issueNumber, safeFileName, stream, cancellationToken);
-                    var blobPath = $"{issueNumber}/{safeFileName}";
-                    var sasUrl = blobService.GetSasUrl(issueNumber, safeFileName, TimeSpan.FromDays(30));
-                    var comment = sasUrl is not null
-                        ? $"📎 [Download save file]({sasUrl}) — expires in 30 days (blob path: `{blobPath}`)"
-                        : $"📎 Save file attached at blob path: `{blobPath}`";
-                    await gitHubService.AddCommentAsync(issueNumber, comment);
+                    await blobService.UploadAttachmentAsync(issueNumber, stream, cancellationToken);
+                    await gitHubService.AddCommentAsync(issueNumber,
+                        "📎 A save-file attachment was stored privately for designated maintainers. " +
+                        "It will be deleted when this issue closes or after 30 days, whichever comes first.");
                 }
                 catch (Exception ex)
                 {
@@ -196,20 +209,25 @@ public class SubmitBugReport(IGitHubService gitHubService, IBlobService blobServ
             }
         }
 
-        return new ObjectResult(new { issueNumber, issueUrl }) { StatusCode = StatusCodes.Status201Created };
+        return new ObjectResult(new { issueNumber, issueUrl, contactStored }) { StatusCode = StatusCodes.Status201Created };
     }
 
     private static string FirstNonEmpty(params string[] values) =>
         Array.Find(values, v => !string.IsNullOrWhiteSpace(v)) ?? string.Empty;
 
-    private static string SanitizeFileName(string fileName)
+    private static string GetSafeExtension(string fileNameOrExtension)
     {
-        var name = Path.GetFileName(fileName);
-        var invalid = Path.GetInvalidFileNameChars();
-        name = invalid.Aggregate(name, (current, c) => current.Replace(c, '_'));
+        var extension = Path.GetExtension(fileNameOrExtension);
+        if (string.IsNullOrWhiteSpace(extension) && fileNameOrExtension.StartsWith('.'))
+        {
+            extension = fileNameOrExtension;
+        }
 
-        return string.IsNullOrWhiteSpace(name)
-            ? "save.bin"
-            : name;
+        if (extension.Length is < 2 or > 12 || extension[1..].Any(c => !char.IsAsciiLetterOrDigit(c)))
+        {
+            return string.Empty;
+        }
+
+        return extension.ToLowerInvariant();
     }
 }

--- a/Pkmds.Functions/Functions/SubmitBugReport.cs
+++ b/Pkmds.Functions/Functions/SubmitBugReport.cs
@@ -39,7 +39,7 @@ public class SubmitBugReport(IGitHubService gitHubService, IBlobService blobServ
         var actual = form["actual"].ToString().Trim();
         var steps = form["steps"].ToString().Trim();
         var expected = form["expected"].ToString().Trim();
-        var reportedSaveSource = form["reportedSaveSource"].ToString().Trim();
+        var reportedSaveSource = GetSafeReportedSaveSource(form["reportedSaveSource"].ToString().Trim());
         // Feature / Feedback free-text field.
         var details = form["details"].ToString().Trim();
         var saveGameName = form["saveGameName"].ToString().Trim();
@@ -180,9 +180,13 @@ public class SubmitBugReport(IGitHubService gitHubService, IBlobService blobServ
         }
 
         var saveFile = form.Files["saveFile"];
+        var attachmentStored = saveFile is not { Length: > 0 };
         if (saveFile is not { Length: > 0 })
         {
-            return new ObjectResult(new { issueNumber, issueUrl, contactStored }) { StatusCode = StatusCodes.Status201Created };
+            return new ObjectResult(new { issueNumber, issueUrl, contactStored, attachmentStored })
+            {
+                StatusCode = StatusCodes.Status201Created,
+            };
         }
 
         {
@@ -196,20 +200,37 @@ public class SubmitBugReport(IGitHubService gitHubService, IBlobService blobServ
                 try
                 {
                     await using var stream = saveFile.OpenReadStream();
-                    await blobService.UploadAttachmentAsync(issueNumber, stream, cancellationToken);
-                    await gitHubService.AddCommentAsync(issueNumber,
-                        "📎 A save-file attachment was stored privately for designated maintainers. " +
-                        "It will be deleted when this issue closes or after 30 days, whichever comes first.");
+                    attachmentStored = await blobService.UploadAttachmentAsync(issueNumber, stream, cancellationToken);
                 }
                 catch (Exception ex)
                 {
                     logger.LogError(ex, "Failed to upload save file for issue #{IssueNumber}", issueNumber);
-                    // Non-fatal: issue was already created; log and continue.
+                }
+
+                if (attachmentStored)
+                {
+                    try
+                    {
+                        await gitHubService.AddCommentAsync(issueNumber,
+                            "📎 A save-file attachment was stored privately for designated maintainers. " +
+                            "It will be deleted when this issue closes or after 30 days, whichever comes first.");
+                    }
+                    catch (Exception ex)
+                    {
+                        // Storage succeeded, so the attachment result remains true. The user-facing
+                        // response reports whether their private bytes were retained, independently
+                        // of this best-effort maintainer notification.
+                        logger.LogWarning(ex,
+                            "Stored a private attachment but failed to comment on issue #{IssueNumber}", issueNumber);
+                    }
                 }
             }
         }
 
-        return new ObjectResult(new { issueNumber, issueUrl, contactStored }) { StatusCode = StatusCodes.Status201Created };
+        return new ObjectResult(new { issueNumber, issueUrl, contactStored, attachmentStored })
+        {
+            StatusCode = StatusCodes.Status201Created,
+        };
     }
 
     private static string FirstNonEmpty(params string[] values) =>
@@ -230,4 +251,13 @@ public class SubmitBugReport(IGitHubService gitHubService, IBlobService blobServ
 
         return extension.ToLowerInvariant();
     }
+
+    private static string GetSafeReportedSaveSource(string source) => source switch
+    {
+        "Emulator export" => source,
+        "Physical cartridge dump" => source,
+        "Downloaded file" => source,
+        "Other or not sure" => source,
+        _ => string.Empty,
+    };
 }

--- a/Pkmds.Functions/GlobalUsings.cs
+++ b/Pkmds.Functions/GlobalUsings.cs
@@ -3,7 +3,6 @@ global using System.Text;
 global using System.Text.Json;
 global using Azure.Storage.Blobs;
 global using Azure.Storage.Blobs.Models;
-global using Azure.Storage.Sas;
 global using Microsoft.AspNetCore.Http;
 global using Microsoft.AspNetCore.Mvc;
 global using Microsoft.Azure.Functions.Worker;

--- a/Pkmds.Functions/Services/BlobService.cs
+++ b/Pkmds.Functions/Services/BlobService.cs
@@ -3,12 +3,13 @@ namespace Pkmds.Functions.Services;
 public class BlobService(IConfiguration configuration, ILogger<BlobService> logger) : IBlobService
 {
     private const string AttachmentBlobName = "attachment.bin";
+    private const string ClosedIssueMarkerPrefix = "issues/closed";
     private const int ContactClosureRetentionDays = 30;
     private const int ContactMaximumRetentionDays = 365;
 
     private readonly BlobContainerClient containerClient = CreateContainerClient(configuration);
 
-    public async Task UploadAttachmentAsync(
+    public async Task<bool> UploadAttachmentAsync(
         int issueNumber,
         Stream data,
         CancellationToken cancellationToken = default)
@@ -16,7 +17,17 @@ public class BlobService(IConfiguration configuration, ILogger<BlobService> logg
         var blobName = $"attachments/{issueNumber}/{AttachmentBlobName}";
         var blobClient = containerClient.GetBlobClient(blobName);
         await blobClient.UploadAsync(data, true, cancellationToken);
+
+        if (await IsIssueClosedAsync(issueNumber, cancellationToken))
+        {
+            await blobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken);
+            logger.LogInformation(
+                "Discarded a private attachment for already-closed issue #{IssueNumber}", issueNumber);
+            return false;
+        }
+
         logger.LogInformation("Stored a private attachment for issue #{IssueNumber}", issueNumber);
+        return true;
     }
 
     public async Task StoreContactAsync(
@@ -27,6 +38,12 @@ public class BlobService(IConfiguration configuration, ILogger<BlobService> logg
         var blobClient = containerClient.GetBlobClient($"contacts/open/{issueNumber}.json");
         var contact = new PrivateContactRecord(issueNumber, email, DateTimeOffset.UtcNow);
         await blobClient.UploadAsync(BinaryData.FromObjectAsJson(contact), true, cancellationToken);
+
+        if (await IsIssueClosedAsync(issueNumber, cancellationToken))
+        {
+            await MoveContactToClosedRetentionAsync(issueNumber, cancellationToken);
+        }
+
         logger.LogInformation("Stored private contact details for issue #{IssueNumber}", issueNumber);
     }
 
@@ -34,6 +51,12 @@ public class BlobService(IConfiguration configuration, ILogger<BlobService> logg
         int issueNumber,
         CancellationToken cancellationToken = default)
     {
+        // Persist the marker before cleanup. Storage operations reconcile against it after their
+        // writes, closing the race where GitHub delivers an issue-close event while the original
+        // submission is still storing private data. The marker also makes webhook retries safe.
+        var closedMarker = containerClient.GetBlobClient(GetClosedIssueMarkerName(issueNumber));
+        await closedMarker.UploadAsync(BinaryData.FromString("closed"), true, cancellationToken);
+
         var deleted = 0;
         foreach (var prefix in new[] { $"attachments/{issueNumber}/", $"{issueNumber}/" })
         {
@@ -54,12 +77,17 @@ public class BlobService(IConfiguration configuration, ILogger<BlobService> logg
     private async Task MoveContactToClosedRetentionAsync(int issueNumber, CancellationToken cancellationToken)
     {
         var openContact = containerClient.GetBlobClient($"contacts/open/{issueNumber}.json");
-        if (!await openContact.ExistsAsync(cancellationToken))
+        Azure.Response<BlobDownloadResult> content;
+        try
         {
+            content = await openContact.DownloadContentAsync(cancellationToken);
+        }
+        catch (Azure.RequestFailedException ex) when (ex.Status == StatusCodes.Status404NotFound)
+        {
+            // A concurrent webhook retry or post-write reconciliation may already have moved it.
             return;
         }
 
-        var content = await openContact.DownloadContentAsync(cancellationToken);
         var contact = content.Value.Content.ToObjectFromJson<PrivateContactRecord>();
         var latestClosedDeletion = DateTimeOffset.UtcNow.AddDays(ContactClosureRetentionDays);
         if (contact is null || latestClosedDeletion >= contact.SubmittedAtUtc.AddDays(ContactMaximumRetentionDays))
@@ -71,9 +99,30 @@ public class BlobService(IConfiguration configuration, ILogger<BlobService> logg
         }
 
         var closedContact = containerClient.GetBlobClient($"contacts/closed/{issueNumber}.json");
-        await closedContact.UploadAsync(content.Value.Content, true, cancellationToken);
+        try
+        {
+            await closedContact.UploadAsync(
+                content.Value.Content,
+                new BlobUploadOptions
+                {
+                    Conditions = new BlobRequestConditions { IfNoneMatch = Azure.ETag.All },
+                },
+                cancellationToken);
+        }
+        catch (Azure.RequestFailedException ex) when (ex.Status is StatusCodes.Status409Conflict or StatusCodes.Status412PreconditionFailed)
+        {
+            // A concurrent reconciliation or webhook retry already created the immutable closed
+            // record. Do not overwrite it: resetting creation time could extend retention.
+        }
+
         await openContact.DeleteIfExistsAsync(cancellationToken: cancellationToken);
     }
+
+    private async Task<bool> IsIssueClosedAsync(int issueNumber, CancellationToken cancellationToken) =>
+        await containerClient.GetBlobClient(GetClosedIssueMarkerName(issueNumber)).ExistsAsync(cancellationToken);
+
+    private static string GetClosedIssueMarkerName(int issueNumber) =>
+        $"{ClosedIssueMarkerPrefix}/{issueNumber}.marker";
 
     private static BlobContainerClient CreateContainerClient(IConfiguration configuration)
     {

--- a/Pkmds.Functions/Services/BlobService.cs
+++ b/Pkmds.Functions/Services/BlobService.cs
@@ -2,51 +2,77 @@ namespace Pkmds.Functions.Services;
 
 public class BlobService(IConfiguration configuration, ILogger<BlobService> logger) : IBlobService
 {
+    private const string AttachmentBlobName = "attachment.bin";
+    private const int ContactClosureRetentionDays = 30;
+    private const int ContactMaximumRetentionDays = 365;
+
     private readonly BlobContainerClient containerClient = CreateContainerClient(configuration);
 
-    public async Task UploadAsync(
+    public async Task UploadAttachmentAsync(
         int issueNumber,
-        string fileName,
         Stream data,
         CancellationToken cancellationToken = default)
     {
-        var blobName = $"{issueNumber}/{fileName}";
+        var blobName = $"attachments/{issueNumber}/{AttachmentBlobName}";
         var blobClient = containerClient.GetBlobClient(blobName);
         await blobClient.UploadAsync(data, true, cancellationToken);
-        logger.LogInformation("Uploaded blob {BlobName} for issue #{IssueNumber}", blobName, issueNumber);
+        logger.LogInformation("Stored a private attachment for issue #{IssueNumber}", issueNumber);
     }
 
-    public string? GetSasUrl(int issueNumber, string fileName, TimeSpan expiry)
+    public async Task StoreContactAsync(
+        int issueNumber,
+        string email,
+        CancellationToken cancellationToken = default)
     {
-        var blobName = $"{issueNumber}/{fileName}";
-        var blobClient = containerClient.GetBlobClient(blobName);
-        if (!blobClient.CanGenerateSasUri)
-        {
-            return null;
-        }
-
-        var sasBuilder = new BlobSasBuilder { BlobContainerName = containerClient.Name, BlobName = blobName, Resource = "b", ExpiresOn = DateTimeOffset.UtcNow.Add(expiry) };
-        sasBuilder.SetPermissions(BlobSasPermissions.Read);
-        // Use AbsoluteUri (percent-encoded) — ToString() leaves spaces unencoded, breaking Markdown links
-        return blobClient.GenerateSasUri(sasBuilder).AbsoluteUri;
+        var blobClient = containerClient.GetBlobClient($"contacts/open/{issueNumber}.json");
+        var contact = new PrivateContactRecord(issueNumber, email, DateTimeOffset.UtcNow);
+        await blobClient.UploadAsync(BinaryData.FromObjectAsJson(contact), true, cancellationToken);
+        logger.LogInformation("Stored private contact details for issue #{IssueNumber}", issueNumber);
     }
 
-    public async Task DeleteIssueFilesAsync(
+    public async Task CloseIssueAsync(
         int issueNumber,
         CancellationToken cancellationToken = default)
     {
-        var prefix = $"{issueNumber}/";
         var deleted = 0;
-
-        await foreach (var blob in containerClient.GetBlobsAsync(BlobTraits.None, BlobStates.None, prefix,
-                           cancellationToken))
+        foreach (var prefix in new[] { $"attachments/{issueNumber}/", $"{issueNumber}/" })
         {
-            var blobClient = containerClient.GetBlobClient(blob.Name);
-            await blobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken);
-            deleted++;
+            await foreach (var blob in containerClient.GetBlobsAsync(BlobTraits.None, BlobStates.None, prefix,
+                               cancellationToken))
+            {
+                var blobClient = containerClient.GetBlobClient(blob.Name);
+                await blobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken);
+                deleted++;
+            }
         }
 
-        logger.LogInformation("Deleted {Count} blob(s) for issue #{IssueNumber}", deleted, issueNumber);
+        await MoveContactToClosedRetentionAsync(issueNumber, cancellationToken);
+        logger.LogInformation("Closed private report data for issue #{IssueNumber}; deleted {Count} attachment blob(s)",
+            issueNumber, deleted);
+    }
+
+    private async Task MoveContactToClosedRetentionAsync(int issueNumber, CancellationToken cancellationToken)
+    {
+        var openContact = containerClient.GetBlobClient($"contacts/open/{issueNumber}.json");
+        if (!await openContact.ExistsAsync(cancellationToken))
+        {
+            return;
+        }
+
+        var content = await openContact.DownloadContentAsync(cancellationToken);
+        var contact = content.Value.Content.ToObjectFromJson<PrivateContactRecord>();
+        var latestClosedDeletion = DateTimeOffset.UtcNow.AddDays(ContactClosureRetentionDays);
+        if (contact is null || latestClosedDeletion >= contact.SubmittedAtUtc.AddDays(ContactMaximumRetentionDays))
+        {
+            // Moving a nearly-expired record would reset its blob creation time and could extend it
+            // beyond the 12-month ceiling. Delete it at closure instead.
+            await openContact.DeleteIfExistsAsync(cancellationToken: cancellationToken);
+            return;
+        }
+
+        var closedContact = containerClient.GetBlobClient($"contacts/closed/{issueNumber}.json");
+        await closedContact.UploadAsync(content.Value.Content, true, cancellationToken);
+        await openContact.DeleteIfExistsAsync(cancellationToken: cancellationToken);
     }
 
     private static BlobContainerClient CreateContainerClient(IConfiguration configuration)
@@ -59,4 +85,6 @@ public class BlobService(IConfiguration configuration, ILogger<BlobService> logg
         containerClient.CreateIfNotExists();
         return containerClient;
     }
+
+    private sealed record PrivateContactRecord(int IssueNumber, string Email, DateTimeOffset SubmittedAtUtc);
 }

--- a/Pkmds.Functions/Services/IBlobService.cs
+++ b/Pkmds.Functions/Services/IBlobService.cs
@@ -2,20 +2,17 @@ namespace Pkmds.Functions.Services;
 
 public interface IBlobService
 {
-    Task UploadAsync(
+    Task UploadAttachmentAsync(
         int issueNumber,
-        string fileName,
         Stream data,
         CancellationToken cancellationToken = default);
 
-    /// <summary>
-    /// Returns a time-limited SAS URL string for reading the specified blob, or <see langword="null" />
-    /// if the client was not created with a shared key credential (e.g. managed identity).
-    /// The returned string is fully percent-encoded and safe to embed in Markdown links.
-    /// </summary>
-    string? GetSasUrl(int issueNumber, string fileName, TimeSpan expiry);
+    Task StoreContactAsync(
+        int issueNumber,
+        string email,
+        CancellationToken cancellationToken = default);
 
-    Task DeleteIssueFilesAsync(
+    Task CloseIssueAsync(
         int issueNumber,
         CancellationToken cancellationToken = default);
 }

--- a/Pkmds.Functions/Services/IBlobService.cs
+++ b/Pkmds.Functions/Services/IBlobService.cs
@@ -2,7 +2,7 @@ namespace Pkmds.Functions.Services;
 
 public interface IBlobService
 {
-    Task UploadAttachmentAsync(
+    Task<bool> UploadAttachmentAsync(
         int issueNumber,
         Stream data,
         CancellationToken cancellationToken = default);

--- a/Pkmds.Functions/report-retention-policy.json
+++ b/Pkmds.Functions/report-retention-policy.json
@@ -1,0 +1,70 @@
+{
+  "rules": [
+    {
+      "enabled": true,
+      "name": "delete-report-attachments-after-30-days",
+      "type": "Lifecycle",
+      "definition": {
+        "actions": {
+          "baseBlob": {
+            "delete": {
+              "daysAfterCreationGreaterThan": 29
+            }
+          }
+        },
+        "filters": {
+          "blobTypes": [
+            "blockBlob"
+          ],
+          "prefixMatch": [
+            "bug-reports/attachments/"
+          ]
+        }
+      }
+    },
+    {
+      "enabled": true,
+      "name": "delete-open-contact-records-after-12-months",
+      "type": "Lifecycle",
+      "definition": {
+        "actions": {
+          "baseBlob": {
+            "delete": {
+              "daysAfterCreationGreaterThan": 364
+            }
+          }
+        },
+        "filters": {
+          "blobTypes": [
+            "blockBlob"
+          ],
+          "prefixMatch": [
+            "bug-reports/contacts/open/"
+          ]
+        }
+      }
+    },
+    {
+      "enabled": true,
+      "name": "delete-closed-contact-records-after-30-days",
+      "type": "Lifecycle",
+      "definition": {
+        "actions": {
+          "baseBlob": {
+            "delete": {
+              "daysAfterCreationGreaterThan": 29
+            }
+          }
+        },
+        "filters": {
+          "blobTypes": [
+            "blockBlob"
+          ],
+          "prefixMatch": [
+            "bug-reports/contacts/closed/"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/Pkmds.Functions/report-retention-policy.json
+++ b/Pkmds.Functions/report-retention-policy.json
@@ -17,7 +17,17 @@
             "blockBlob"
           ],
           "prefixMatch": [
-            "bug-reports/attachments/"
+            "bug-reports/attachments/",
+            "bug-reports/0",
+            "bug-reports/1",
+            "bug-reports/2",
+            "bug-reports/3",
+            "bug-reports/4",
+            "bug-reports/5",
+            "bug-reports/6",
+            "bug-reports/7",
+            "bug-reports/8",
+            "bug-reports/9"
           ]
         }
       }

--- a/Pkmds.Functions/report-retention-policy.json
+++ b/Pkmds.Functions/report-retention-policy.json
@@ -17,7 +17,28 @@
             "blockBlob"
           ],
           "prefixMatch": [
-            "bug-reports/attachments/",
+            "bug-reports/attachments/"
+          ]
+        }
+      }
+    },
+    {
+      "enabled": true,
+      "name": "delete-legacy-report-attachments-after-30-days",
+      "type": "Lifecycle",
+      "definition": {
+        "actions": {
+          "baseBlob": {
+            "delete": {
+              "daysAfterCreationGreaterThan": 29
+            }
+          }
+        },
+        "filters": {
+          "blobTypes": [
+            "blockBlob"
+          ],
+          "prefixMatch": [
             "bug-reports/0",
             "bug-reports/1",
             "bug-reports/2",
@@ -28,6 +49,28 @@
             "bug-reports/7",
             "bug-reports/8",
             "bug-reports/9"
+          ]
+        }
+      }
+    },
+    {
+      "enabled": true,
+      "name": "delete-closed-issue-markers-after-30-days",
+      "type": "Lifecycle",
+      "definition": {
+        "actions": {
+          "baseBlob": {
+            "delete": {
+              "daysAfterCreationGreaterThan": 29
+            }
+          }
+        },
+        "filters": {
+          "blobTypes": [
+            "blockBlob"
+          ],
+          "prefixMatch": [
+            "bug-reports/issues/closed/"
           ]
         }
       }

--- a/Pkmds.Rcl/Components/Dialogs/BugReportDialog.razor
+++ b/Pkmds.Rcl/Components/Dialogs/BugReportDialog.razor
@@ -71,11 +71,16 @@
                               Label="What did you expect to happen? (optional)"
                               Lines="2"
                               Variant="@Variant.Outlined"/>
-                <MudTextField @bind-Value="@reportedSaveSource"
-                              Label="Where did the save come from? (optional)"
-                              Lines="2"
-                              Placeholder="e.g. exported from an emulator (which one?), a real cartridge, or a download — plus the filename and extension."
-                              Variant="@Variant.Outlined"/>
+                <MudSelect T="string"
+                           @bind-Value="@reportedSaveSource"
+                           Label="Where did the save come from? (optional)"
+                           Clearable="true"
+                           Variant="@Variant.Outlined">
+                    <MudSelectItem Value="@SaveSourceEmulator">Emulator export</MudSelectItem>
+                    <MudSelectItem Value="@SaveSourceCartridge">Physical cartridge dump</MudSelectItem>
+                    <MudSelectItem Value="@SaveSourceDownload">Downloaded file</MudSelectItem>
+                    <MudSelectItem Value="@SaveSourceOther">Other / not sure</MudSelectItem>
+                </MudSelect>
             }
             else
             {

--- a/Pkmds.Rcl/Components/Dialogs/BugReportDialog.razor
+++ b/Pkmds.Rcl/Components/Dialogs/BugReportDialog.razor
@@ -18,8 +18,8 @@
             {
                 <MudAlert Severity="@Severity.Warning"
                           Dense="true">
-                    A crash was detected. The error details have been pre-filled below. Please add your name,
-                    email, and any additional context about what you were doing before the crash.
+                    A crash was detected. The error details have been pre-filled below. Please add any
+                    additional context about what you were doing before the crash.
                 </MudAlert>
             }
             else
@@ -93,18 +93,25 @@
                               Variant="@Variant.Outlined"/>
             }
 
-            <MudTextField @bind-Value="@email"
-                          Label="Email"
-                          InputType="@InputType.Email"
-                          Required
-                          Validation="@((string v) => EmailValidator.IsValid(v)
-                                          ? null
-                                          : "Please enter a valid email address.")"
-                          Variant="@Variant.Outlined"/>
-            <MudTextField @bind-Value="@name"
-                          Label="Name"
-                          Required
-                          Variant="@Variant.Outlined"/>
+            <MudSwitch @bind-Value="@contactOptIn"
+                       @bind-Value:after="OnContactOptInChanged"
+                       Label="Allow maintainers to email me about this report"
+                       Color="@Color.Primary"/>
+            @if (contactOptIn)
+            {
+                <MudTextField @bind-Value="@contactEmail"
+                              Label="Contact email (private)"
+                              InputType="@InputType.Email"
+                              Required
+                              Validation="@((string v) => ContactEmailValidation(v))"
+                              HelperText="Stored privately and never included in the public GitHub issue."
+                              Variant="@Variant.Outlined"/>
+                <MudText Typo="@Typo.caption"
+                         Color="@Color.Secondary">
+                    We may use this address to respond about this report. It is deleted 30 days after
+                    the issue closes, or 12 months after submission at the latest.
+                </MudText>
+            }
 
             @if (ShowSaveAttach)
             {
@@ -147,14 +154,19 @@
                     @submitError
                 </MudAlert>
             }
-            <MudText Typo="@Typo.caption"
-                     Color="@Color.Secondary">
-                Reports are submitted as GitHub issues to help improve the app.
-                @if (ShowSaveAttach && HasSaveFile)
-                {
-                    @:Your current save file can be attached to help diagnose the issue.
-                }
-            </MudText>
+            <MudAlert Severity="@Severity.Warning"
+                      Dense="true">
+                Your report text, app version, browser user agent, and technical diagnostics will be
+                posted publicly to GitHub. Do not include personal information in the report text.
+            </MudAlert>
+            @if (ShowSaveAttach)
+            {
+                <MudText Typo="@Typo.caption"
+                         Color="@Color.Secondary">
+                    Save-file attachments are private and available only to designated maintainers.
+                    They are deleted when the issue closes or after 30 days, whichever comes first.
+                </MudText>
+            }
         </MudStack>
     </DialogContent>
     <DialogActions>

--- a/Pkmds.Rcl/Components/Dialogs/BugReportDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/BugReportDialog.razor.cs
@@ -24,8 +24,8 @@ public partial class BugReportDialog
     // Feature / Feedback field.
     private string details = string.Empty;
 
-    private string email = string.Empty;
-    private string name = string.Empty;
+    private bool contactOptIn;
+    private string contactEmail = string.Empty;
     private bool isSubmitting;
     private string? submitError;
 
@@ -34,7 +34,8 @@ public partial class BugReportDialog
     private byte[]? uploadedBytes;
     private string? uploadedFileName;
 
-    private bool IsEmailValid => !string.IsNullOrWhiteSpace(email) && EmailValidator.IsValid(email);
+    private bool IsContactEmailValid => !contactOptIn ||
+                                        (!string.IsNullOrWhiteSpace(contactEmail) && EmailValidator.IsValid(contactEmail));
 
     // Save attachment only makes sense for bug reports; feature/feedback don't need a save.
     private bool ShowSaveAttach => CapturedException is not null || category == BugReportCategory.Bug;
@@ -46,12 +47,17 @@ public partial class BugReportDialog
     // rather than POST whitespace that the function would reject as missing primary text.
     private bool IsPrimaryValid => PrimaryText.Trim().Length >= MinPrimaryLength;
 
-    private bool IsFormValid => IsPrimaryValid && IsEmailValid && !string.IsNullOrWhiteSpace(name);
+    private bool IsFormValid => IsPrimaryValid && IsContactEmailValid;
 
     private static Func<string, string?> PrimaryValidation => v =>
         (v?.Trim().Length ?? 0) >= MinPrimaryLength
             ? null
             : $"Please provide at least {MinPrimaryLength} characters of detail.";
+
+    private string? ContactEmailValidation(string value) =>
+        !contactOptIn || EmailValidator.IsValid(value)
+            ? null
+            : "Please enter a valid email address or turn off contact permission.";
 
     [CascadingParameter]
     private IMudDialogInstance MudDialog { get; set; } = null!;
@@ -70,8 +76,6 @@ public partial class BugReportDialog
 
     protected override void OnInitialized()
     {
-        attachSaveFile = HasSaveFile;
-
         if (CapturedException is not null)
         {
             // Crashes are always bugs, and the structured split doesn't fit a stack dump — route
@@ -143,6 +147,14 @@ public partial class BugReportDialog
         }
     }
 
+    private void OnContactOptInChanged()
+    {
+        if (!contactOptIn)
+        {
+            contactEmail = string.Empty;
+        }
+    }
+
     private void Cancel() => MudDialog.Close(DialogResult.Cancel());
 
     private async Task Submit()
@@ -153,9 +165,9 @@ public partial class BugReportDialog
             return;
         }
 
-        if (!IsEmailValid || string.IsNullOrWhiteSpace(name))
+        if (!IsContactEmailValid)
         {
-            submitError = "Please provide a valid email address and name before submitting.";
+            submitError = "Please provide a valid contact email or turn off contact permission.";
             return;
         }
 
@@ -242,7 +254,9 @@ public partial class BugReportDialog
 
             var userAgent = await JSRuntime.InvokeAsync<string>("eval", "navigator.userAgent");
             var isBug = category == BugReportCategory.Bug;
-            var request = new BugReportRequest(name, email, category, AppVersion, userAgent,
+            var request = new BugReportRequest(category, AppVersion, userAgent,
+                ContactOptIn: contactOptIn,
+                ContactEmail: contactOptIn ? contactEmail.Trim() : null,
                 Actual: isBug ? actual : null,
                 Steps: isBug && !string.IsNullOrWhiteSpace(steps) ? steps : null,
                 Expected: isBug && !string.IsNullOrWhiteSpace(expected) ? expected : null,
@@ -256,7 +270,7 @@ public partial class BugReportDialog
 
             if (result.Success)
             {
-                MudDialog.Close(DialogResult.Ok(result.IssueUrl));
+                MudDialog.Close(DialogResult.Ok(result));
             }
             else
             {

--- a/Pkmds.Rcl/Components/Dialogs/BugReportDialog.razor.cs
+++ b/Pkmds.Rcl/Components/Dialogs/BugReportDialog.razor.cs
@@ -5,6 +5,10 @@ namespace Pkmds.Rcl.Components.Dialogs;
 public partial class BugReportDialog
 {
     private const int MinPrimaryLength = 20;
+    private const string SaveSourceEmulator = "Emulator export";
+    private const string SaveSourceCartridge = "Physical cartridge dump";
+    private const string SaveSourceDownload = "Downloaded file";
+    private const string SaveSourceOther = "Other or not sure";
 
     // Match the Azure Function's MaxSaveFileSizeBytes so we reject oversized attachments up front
     // instead of silently filing an issue whose save never uploads.

--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
@@ -312,10 +312,13 @@ public partial class MainLayout : IDisposable
         var options = await DialogOptionsHelper.BuildAsync(MaxWidth.Small);
         var dialog = await DialogService.ShowAsync<BugReportDialog>("Send a Report", parameters, options);
         var result = await dialog.Result;
-        if (result is { Data: string issueUrl })
+        if (result is { Data: BugReportResult { IssueUrl: { } issueUrl } submission })
         {
-            Snackbar.Add(new MarkupString($"Bug report submitted! <a href=\"{issueUrl}\" target=\"_blank\">View issue</a>"),
-                Severity.Success,
+            var message = submission.WarningMessage is null
+                ? $"Report submitted! <a href=\"{issueUrl}\" target=\"_blank\">View issue</a>"
+                : $"{submission.WarningMessage} <a href=\"{issueUrl}\" target=\"_blank\">View issue</a>";
+            Snackbar.Add(new MarkupString(message),
+                submission.WarningMessage is null ? Severity.Success : Severity.Warning,
                 options => options.RequireInteraction = true);
         }
     }

--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
@@ -312,12 +312,9 @@ public partial class MainLayout : IDisposable
         var options = await DialogOptionsHelper.BuildAsync(MaxWidth.Small);
         var dialog = await DialogService.ShowAsync<BugReportDialog>("Send a Report", parameters, options);
         var result = await dialog.Result;
-        if (result is { Data: BugReportResult { IssueUrl: { } issueUrl } submission })
+        if (result is { Data: BugReportResult submission })
         {
-            var message = submission.WarningMessage is null
-                ? $"Report submitted! <a href=\"{issueUrl}\" target=\"_blank\">View issue</a>"
-                : $"{submission.WarningMessage} <a href=\"{issueUrl}\" target=\"_blank\">View issue</a>";
-            Snackbar.Add(new MarkupString(message),
+            Snackbar.Add(submission.ToSubmissionMarkup("Report submitted!"),
                 submission.WarningMessage is null ? Severity.Success : Severity.Warning,
                 options => options.RequireInteraction = true);
         }

--- a/Pkmds.Rcl/Services/BugReportResultExtensions.cs
+++ b/Pkmds.Rcl/Services/BugReportResultExtensions.cs
@@ -1,0 +1,47 @@
+using System.Text.Encodings.Web;
+
+namespace Pkmds.Rcl.Services;
+
+public static class BugReportResultExtensions
+{
+    private const string GitHubIssuePathPrefix = "/codemonkey85/PKMDS-Blazor/issues/";
+
+    public static MarkupString ToSubmissionMarkup(this BugReportResult result, string successMessage)
+    {
+        var message = HtmlEncoder.Default.Encode(result.WarningMessage ?? successMessage);
+        if (!TryGetSafeIssueUri(result.IssueUrl, out var issueUri))
+        {
+            return new MarkupString(message);
+        }
+
+        var encodedUrl = HtmlEncoder.Default.Encode(issueUri.AbsoluteUri);
+        return new MarkupString(
+            $"{message} <a href=\"{encodedUrl}\" target=\"_blank\" rel=\"noopener noreferrer\">View issue</a>");
+    }
+
+    private static bool TryGetSafeIssueUri(string? value, [NotNullWhen(true)] out Uri? issueUri)
+    {
+        issueUri = null;
+        if (!Uri.TryCreate(value, UriKind.Absolute, out var candidate) ||
+            candidate.Scheme != Uri.UriSchemeHttps ||
+            !candidate.Host.Equals("github.com", StringComparison.OrdinalIgnoreCase) ||
+            !candidate.IsDefaultPort ||
+            !string.IsNullOrEmpty(candidate.UserInfo) ||
+            !string.IsNullOrEmpty(candidate.Query) ||
+            !string.IsNullOrEmpty(candidate.Fragment) ||
+            !candidate.AbsolutePath.StartsWith(GitHubIssuePathPrefix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var issueNumber = candidate.AbsolutePath[GitHubIssuePathPrefix.Length..];
+        if (!int.TryParse(issueNumber, CultureInfo.InvariantCulture, out var parsedIssueNumber) ||
+            parsedIssueNumber <= 0)
+        {
+            return false;
+        }
+
+        issueUri = candidate;
+        return true;
+    }
+}

--- a/Pkmds.Rcl/Services/IBugReportService.cs
+++ b/Pkmds.Rcl/Services/IBugReportService.cs
@@ -8,11 +8,11 @@ public enum BugReportCategory
 }
 
 public sealed record BugReportRequest(
-    string Name,
-    string Email,
     BugReportCategory Category,
     string AppVersion,
     string UserAgent,
+    bool ContactOptIn = false,
+    string? ContactEmail = null,
     // Bug category — structured fields. Actual is the one required field (and also carries the
     // pre-filled dump on the crash path); the rest are optional context.
     string? Actual = null,
@@ -30,7 +30,11 @@ public sealed record BugReportRequest(
     string? SaveFileType = null,
     Exception? CapturedException = null);
 
-public sealed record BugReportResult(bool Success, string? IssueUrl = null, string? ErrorMessage = null);
+public sealed record BugReportResult(
+    bool Success,
+    string? IssueUrl = null,
+    string? ErrorMessage = null,
+    string? WarningMessage = null);
 
 public interface IBugReportService
 {

--- a/Pkmds.Tests/BugReportPrivacyTests.cs
+++ b/Pkmds.Tests/BugReportPrivacyTests.cs
@@ -1,0 +1,77 @@
+namespace Pkmds.Tests;
+
+public sealed class BugReportPrivacyTests
+{
+    [Fact]
+    public void BugReportContractMakesContactOptionalAndExplicit()
+    {
+        var properties = typeof(BugReportRequest).GetProperties();
+
+        properties.Select(property => property.Name).Should().Contain(["ContactOptIn", "ContactEmail"]);
+        properties.Select(property => property.Name).Should().NotContain(["Name", "Email"]);
+
+        var anonymousRequest = new BugReportRequest(BugReportCategory.Bug, "version", "user-agent");
+        anonymousRequest.ContactOptIn.Should().BeFalse();
+        anonymousRequest.ContactEmail.Should().BeNull();
+    }
+
+    [Fact]
+    public void BugReportUiDisclosesPublicAndPrivateDataBeforeSubmission()
+    {
+        var dialog = RepoFileTestHelper.ReadAllText(
+            "Pkmds.Rcl", "Components", "Dialogs", "BugReportDialog.razor");
+
+        dialog.Should().Contain("Allow maintainers to email me about this report");
+        dialog.Should().Contain("Contact email (private)");
+        dialog.Should().Contain("posted publicly to GitHub");
+        dialog.Should().Contain("Save-file attachments are private");
+        dialog.Should().NotContain("Label=\"Name\"");
+    }
+
+    [Fact]
+    public void BugReportBackendDoesNotPublishOrLogIdentityAndDoesNotCreateSasLinks()
+    {
+        var function = RepoFileTestHelper.ReadAllText(
+            "Pkmds.Functions", "Functions", "SubmitBugReport.cs");
+        var storage = RepoFileTestHelper.ReadAllText(
+            "Pkmds.Functions", "Services", "BlobService.cs");
+
+        function.Should().NotContain("form[\"name\"]");
+        function.Should().NotContain("form[\"email\"]");
+        function.Should().NotContain("**Reporter:**");
+        function.Should().NotContain("{Email}");
+        function.Should().NotContain("GetSasUrl");
+        function.Should().Contain("contactOptIn");
+        function.Should().Contain("stored privately for designated maintainers");
+        storage.Should().NotContain("GenerateSasUri");
+        storage.Should().Contain("contacts/open/{issueNumber}.json");
+        storage.Should().Contain("attachments/{issueNumber}/{AttachmentBlobName}");
+    }
+
+    [Fact]
+    public void AttachmentTransportDoesNotExposeOriginalFilename()
+    {
+        var client = RepoFileTestHelper.ReadAllText(
+            "Pkmds.Web", "Services", "BugReportService.cs");
+
+        client.Should().Contain("\"saveFile\", \"attachment.bin\"");
+        client.Should().NotContain("\"saveFile\", request.SaveFileName");
+    }
+
+    [Fact]
+    public void ProvisioningEnforcesPrivateDataRetentionCeilings()
+    {
+        var setup = RepoFileTestHelper.ReadAllText("setup-azure.ps1");
+        var workflow = RepoFileTestHelper.ReadAllText(".github", "workflows", "main.yml");
+        var policy = RepoFileTestHelper.ReadAllText("Pkmds.Functions", "report-retention-policy.json");
+
+        setup.Should().Contain("delete-report-attachments-after-30-days");
+        setup.Should().Contain("delete-open-contact-records-after-12-months");
+        setup.Should().Contain("delete-closed-contact-records-after-30-days");
+        setup.Should().Contain("daysAfterCreationGreaterThan = 364");
+        setup.Should().Contain("daysAfterCreationGreaterThan = 29");
+        workflow.Should().Contain("--policy @Pkmds.Functions/report-retention-policy.json");
+        policy.Should().Contain("\"daysAfterCreationGreaterThan\": 364");
+        policy.Should().Contain("\"daysAfterCreationGreaterThan\": 29");
+    }
+}

--- a/Pkmds.Tests/BugReportPrivacyTests.cs
+++ b/Pkmds.Tests/BugReportPrivacyTests.cs
@@ -59,6 +59,21 @@ public sealed class BugReportPrivacyTests
     }
 
     [Fact]
+    public void SubmissionMarkupOnlyLinksValidatedRepositoryIssueUrls()
+    {
+        var validResult = new BugReportResult(true, "https://github.com/codemonkey85/PKMDS-Blazor/issues/1217");
+        var maliciousResult = new BugReportResult(
+            true,
+            "https://example.com/\" onmouseover=\"alert(1)",
+            WarningMessage: "<img src=x onerror=alert(1)>");
+
+        validResult.ToSubmissionMarkup("Submitted").Value.Should().Contain(
+            "rel=\"noopener noreferrer\"");
+        maliciousResult.ToSubmissionMarkup("Submitted").Value.Should().Be(
+            "&lt;img src=x onerror=alert(1)&gt;");
+    }
+
+    [Fact]
     public void ProvisioningEnforcesPrivateDataRetentionCeilings()
     {
         var setup = RepoFileTestHelper.ReadAllText("setup-azure.ps1");
@@ -73,5 +88,9 @@ public sealed class BugReportPrivacyTests
         workflow.Should().Contain("--policy @Pkmds.Functions/report-retention-policy.json");
         policy.Should().Contain("\"daysAfterCreationGreaterThan\": 364");
         policy.Should().Contain("\"daysAfterCreationGreaterThan\": 29");
+        policy.Should().Contain("\"bug-reports/0\"");
+        policy.Should().Contain("\"bug-reports/9\"");
+        setup.Should().Contain("\"$BlobContainer/0\"");
+        setup.Should().Contain("\"$BlobContainer/9\"");
     }
 }

--- a/Pkmds.Tests/BugReportPrivacyTests.cs
+++ b/Pkmds.Tests/BugReportPrivacyTests.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 namespace Pkmds.Tests;
 
 public sealed class BugReportPrivacyTests
@@ -26,6 +28,8 @@ public sealed class BugReportPrivacyTests
         dialog.Should().Contain("posted publicly to GitHub");
         dialog.Should().Contain("Save-file attachments are private");
         dialog.Should().NotContain("Label=\"Name\"");
+        dialog.Should().NotContain("filename and extension");
+        dialog.Should().Contain("Emulator export");
     }
 
     [Fact]
@@ -42,6 +46,8 @@ public sealed class BugReportPrivacyTests
         function.Should().NotContain("{Email}");
         function.Should().NotContain("GetSasUrl");
         function.Should().Contain("contactOptIn");
+        function.Should().Contain("GetSafeReportedSaveSource");
+        function.Should().Contain("attachmentStored");
         function.Should().Contain("stored privately for designated maintainers");
         storage.Should().NotContain("GenerateSasUri");
         storage.Should().Contain("contacts/open/{issueNumber}.json");
@@ -56,6 +62,7 @@ public sealed class BugReportPrivacyTests
 
         client.Should().Contain("\"saveFile\", \"attachment.bin\"");
         client.Should().NotContain("\"saveFile\", request.SaveFileName");
+        client.Should().Contain("Your save-file attachment could not be stored");
     }
 
     [Fact]
@@ -81,6 +88,8 @@ public sealed class BugReportPrivacyTests
         var policy = RepoFileTestHelper.ReadAllText("Pkmds.Functions", "report-retention-policy.json");
 
         setup.Should().Contain("delete-report-attachments-after-30-days");
+        setup.Should().Contain("delete-legacy-report-attachments-after-30-days");
+        setup.Should().Contain("delete-closed-issue-markers-after-30-days");
         setup.Should().Contain("delete-open-contact-records-after-12-months");
         setup.Should().Contain("delete-closed-contact-records-after-30-days");
         setup.Should().Contain("daysAfterCreationGreaterThan = 364");
@@ -92,5 +101,28 @@ public sealed class BugReportPrivacyTests
         policy.Should().Contain("\"bug-reports/9\"");
         setup.Should().Contain("\"$BlobContainer/0\"");
         setup.Should().Contain("\"$BlobContainer/9\"");
+
+        using var policyDocument = JsonDocument.Parse(policy);
+        var rules = policyDocument.RootElement.GetProperty("rules").EnumerateArray();
+        foreach (var rule in rules)
+        {
+            var prefixes = rule.GetProperty("definition").GetProperty("filters").GetProperty("prefixMatch");
+            prefixes.GetArrayLength().Should().BeLessThanOrEqualTo(10,
+                $"Azure Storage allows at most 10 prefixes per lifecycle rule ({rule.GetProperty("name").GetString()})");
+        }
+    }
+
+    [Fact]
+    public void IssueClosureIsRetryableAndRaceSafe()
+    {
+        var webhook = RepoFileTestHelper.ReadAllText(
+            "Pkmds.Functions", "Functions", "GitHubWebhook.cs");
+        var storage = RepoFileTestHelper.ReadAllText(
+            "Pkmds.Functions", "Services", "BlobService.cs");
+
+        webhook.Should().Contain("StatusCodes.Status503ServiceUnavailable");
+        storage.Should().Contain("ClosedIssueMarkerPrefix");
+        storage.Should().Contain("IsIssueClosedAsync");
+        storage.Should().Contain("Discarded a private attachment for already-closed issue");
     }
 }

--- a/Pkmds.Web/App.razor
+++ b/Pkmds.Web/App.razor
@@ -5,6 +5,7 @@
 @using Pkmds.Rcl.Theming
 @inject IJSRuntime JsRuntime
 @inject IDialogService DialogService
+@inject ISnackbar Snackbar
 @inject IAppState AppState
 
 @* Mud providers live OUTSIDE the ErrorBoundary so dialogs/snackbars/popovers      *@

--- a/Pkmds.Web/App.razor.cs
+++ b/Pkmds.Web/App.razor.cs
@@ -63,6 +63,15 @@ public partial class App : IDisposable
             closeOnEscapeKey: false,
             backdropClick: false);
         var dialog = await DialogService.ShowAsync<BugReportDialog>("Report this crash", parameters, options);
-        await dialog.Result;
+        var result = await dialog.Result;
+        if (result is { Data: BugReportResult { IssueUrl: { } issueUrl } submission })
+        {
+            var message = submission.WarningMessage is null
+                ? $"Crash report submitted! <a href=\"{issueUrl}\" target=\"_blank\">View issue</a>"
+                : $"{submission.WarningMessage} <a href=\"{issueUrl}\" target=\"_blank\">View issue</a>";
+            Snackbar.Add(new MarkupString(message),
+                submission.WarningMessage is null ? MudBlazor.Severity.Success : MudBlazor.Severity.Warning,
+                snackbarOptions => snackbarOptions.RequireInteraction = true);
+        }
     }
 }

--- a/Pkmds.Web/App.razor.cs
+++ b/Pkmds.Web/App.razor.cs
@@ -64,12 +64,9 @@ public partial class App : IDisposable
             backdropClick: false);
         var dialog = await DialogService.ShowAsync<BugReportDialog>("Report this crash", parameters, options);
         var result = await dialog.Result;
-        if (result is { Data: BugReportResult { IssueUrl: { } issueUrl } submission })
+        if (result is { Data: BugReportResult submission })
         {
-            var message = submission.WarningMessage is null
-                ? $"Crash report submitted! <a href=\"{issueUrl}\" target=\"_blank\">View issue</a>"
-                : $"{submission.WarningMessage} <a href=\"{issueUrl}\" target=\"_blank\">View issue</a>";
-            Snackbar.Add(new MarkupString(message),
+            Snackbar.Add(submission.ToSubmissionMarkup("Crash report submitted!"),
                 submission.WarningMessage is null ? MudBlazor.Severity.Success : MudBlazor.Severity.Warning,
                 snackbarOptions => snackbarOptions.RequireInteraction = true);
         }

--- a/Pkmds.Web/Services/BugReportService.cs
+++ b/Pkmds.Web/Services/BugReportService.cs
@@ -17,11 +17,15 @@ public class BugReportService(IConfiguration configuration, HttpClient httpClien
         try
         {
             using var content = new MultipartFormDataContent();
-            content.Add(new StringContent(request.Name), "name");
-            content.Add(new StringContent(request.Email), "email");
             content.Add(new StringContent(request.Category.ToString()), "category");
             content.Add(new StringContent(request.AppVersion), "appVersion");
             content.Add(new StringContent(request.UserAgent), "userAgent");
+            content.Add(new StringContent(request.ContactOptIn.ToString()), "contactOptIn");
+
+            if (request.ContactOptIn && !string.IsNullOrWhiteSpace(request.ContactEmail))
+            {
+                content.Add(new StringContent(request.ContactEmail), "contactEmail");
+            }
 
             if (!string.IsNullOrWhiteSpace(request.Actual))
             {
@@ -53,29 +57,37 @@ public class BugReportService(IConfiguration configuration, HttpClient httpClien
                 content.Add(new StringContent(request.PkhexVersion), "pkhexVersion");
             }
 
-            if (request.SaveGameName is not null)
+            if (!string.IsNullOrWhiteSpace(request.SaveGameName))
             {
                 content.Add(new StringContent(request.SaveGameName), "saveGameName");
             }
 
-            if (request.SaveRevision is not null)
+            if (!string.IsNullOrWhiteSpace(request.SaveRevision))
             {
                 content.Add(new StringContent(request.SaveRevision), "saveRevision");
             }
 
-            if (request.SaveFileSource is not null)
+            if (!string.IsNullOrWhiteSpace(request.SaveFileSource))
             {
                 content.Add(new StringContent(request.SaveFileSource), "saveFileSource");
             }
 
-            if (request.SaveFileType is not null)
+            if (!string.IsNullOrWhiteSpace(request.SaveFileType))
             {
                 content.Add(new StringContent(request.SaveFileType), "saveFileType");
             }
 
             if (request is { SaveFileBytes: { Length: > 0 } saveBytes, SaveFileName: not null })
             {
-                content.Add(new ByteArrayContent(saveBytes), "saveFile", request.SaveFileName);
+                var extension = Path.GetExtension(request.SaveFileName);
+                if (!string.IsNullOrWhiteSpace(extension))
+                {
+                    content.Add(new StringContent(extension), "saveFileExtension");
+                }
+
+                // Never place the user's original filename in multipart headers. Filenames can
+                // contain names or local paths and may be captured by infrastructure logs.
+                content.Add(new ByteArrayContent(saveBytes), "saveFile", "attachment.bin");
             }
 
             var response = await httpClient.PostAsync($"{functionUrl}/api/SubmitBugReport", content, cancellationToken);
@@ -86,7 +98,13 @@ public class BugReportService(IConfiguration configuration, HttpClient httpClien
                 var issueUrl = json.TryGetProperty("issueUrl", out var urlElement)
                     ? urlElement.GetString()
                     : null;
-                return new BugReportResult(true, IssueUrl: issueUrl);
+                var contactStored = !request.ContactOptIn ||
+                                    (json.TryGetProperty("contactStored", out var contactStoredElement) &&
+                                     contactStoredElement.ValueKind is JsonValueKind.True);
+                var warningMessage = contactStored
+                    ? null
+                    : "The report was created, but your private contact address could not be stored. Please follow the GitHub issue for updates.";
+                return new BugReportResult(true, IssueUrl: issueUrl, WarningMessage: warningMessage);
             }
 
             var errorJson = await response.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: cancellationToken);

--- a/Pkmds.Web/Services/BugReportService.cs
+++ b/Pkmds.Web/Services/BugReportService.cs
@@ -101,9 +101,26 @@ public class BugReportService(IConfiguration configuration, HttpClient httpClien
                 var contactStored = !request.ContactOptIn ||
                                     (json.TryGetProperty("contactStored", out var contactStoredElement) &&
                                      contactStoredElement.ValueKind is JsonValueKind.True);
-                var warningMessage = contactStored
+                var attachmentRequested = request.SaveFileBytes is { Length: > 0 };
+                var attachmentStored = !attachmentRequested ||
+                                       (json.TryGetProperty("attachmentStored", out var attachmentStoredElement) &&
+                                        attachmentStoredElement.ValueKind is JsonValueKind.True);
+                var warnings = new List<string>();
+                if (!contactStored)
+                {
+                    warnings.Add(
+                        "Your private contact address could not be stored. Please follow the GitHub issue for updates.");
+                }
+
+                if (!attachmentStored)
+                {
+                    warnings.Add(
+                        "Your save-file attachment could not be stored. Keep your local copy in case a maintainer asks for it.");
+                }
+
+                var warningMessage = warnings.Count == 0
                     ? null
-                    : "The report was created, but your private contact address could not be stored. Please follow the GitHub issue for updates.";
+                    : $"The report was created, but {string.Join(" ", warnings)}";
                 return new BugReportResult(true, IssueUrl: issueUrl, WarningMessage: warningMessage);
             }
 

--- a/setup-azure.ps1
+++ b/setup-azure.ps1
@@ -135,8 +135,19 @@ $RetentionPolicy = @{
                 actions = @{ baseBlob = @{ delete = @{ daysAfterCreationGreaterThan = 29 } } }
                 filters = @{
                     blobTypes = @("blockBlob")
+                    prefixMatch = @("$BlobContainer/attachments/")
+                }
+            }
+        },
+        @{
+            enabled = $true
+            name = "delete-legacy-report-attachments-after-30-days"
+            type = "Lifecycle"
+            definition = @{
+                actions = @{ baseBlob = @{ delete = @{ daysAfterCreationGreaterThan = 29 } } }
+                filters = @{
+                    blobTypes = @("blockBlob")
                     prefixMatch = @(
-                        "$BlobContainer/attachments/",
                         "$BlobContainer/0",
                         "$BlobContainer/1",
                         "$BlobContainer/2",
@@ -148,6 +159,18 @@ $RetentionPolicy = @{
                         "$BlobContainer/8",
                         "$BlobContainer/9"
                     )
+                }
+            }
+        },
+        @{
+            enabled = $true
+            name = "delete-closed-issue-markers-after-30-days"
+            type = "Lifecycle"
+            definition = @{
+                actions = @{ baseBlob = @{ delete = @{ daysAfterCreationGreaterThan = 29 } } }
+                filters = @{
+                    blobTypes = @("blockBlob")
+                    prefixMatch = @("$BlobContainer/issues/closed/")
                 }
             }
         },

--- a/setup-azure.ps1
+++ b/setup-azure.ps1
@@ -135,7 +135,19 @@ $RetentionPolicy = @{
                 actions = @{ baseBlob = @{ delete = @{ daysAfterCreationGreaterThan = 29 } } }
                 filters = @{
                     blobTypes = @("blockBlob")
-                    prefixMatch = @("$BlobContainer/attachments/")
+                    prefixMatch = @(
+                        "$BlobContainer/attachments/",
+                        "$BlobContainer/0",
+                        "$BlobContainer/1",
+                        "$BlobContainer/2",
+                        "$BlobContainer/3",
+                        "$BlobContainer/4",
+                        "$BlobContainer/5",
+                        "$BlobContainer/6",
+                        "$BlobContainer/7",
+                        "$BlobContainer/8",
+                        "$BlobContainer/9"
+                    )
                 }
             }
         },

--- a/setup-azure.ps1
+++ b/setup-azure.ps1
@@ -6,11 +6,12 @@
 .DESCRIPTION
     Creates:
       - Azure Resource Group
-      - Azure Storage Account + bug-reports blob container
-      - Azure Functions App (Consumption plan, .NET 9 isolated)
+      - Azure Storage Account + private bug-reports blob container
+      - Azure Functions App (Consumption plan, .NET 10 isolated)
     Configures:
       - All Function App application settings
       - CORS origins
+      - Storage lifecycle rules for private attachments and contact records
     Builds and deploys:
       - Pkmds.Functions project via zip deploy
     Wires up:
@@ -120,6 +121,57 @@ az storage container create `
     --auth-mode login `
     --output none
 Write-Done "Blob container ready"
+
+Write-Step "Configuring private report-data retention"
+$RetentionPolicy = @{
+    rules = @(
+        @{
+            enabled = $true
+            name = "delete-report-attachments-after-30-days"
+            type = "Lifecycle"
+            definition = @{
+                # Lifecycle evaluation is daily, so use a one-day buffer to keep the
+                # effective deletion ceiling at 30 days.
+                actions = @{ baseBlob = @{ delete = @{ daysAfterCreationGreaterThan = 29 } } }
+                filters = @{
+                    blobTypes = @("blockBlob")
+                    prefixMatch = @("$BlobContainer/attachments/")
+                }
+            }
+        },
+        @{
+            enabled = $true
+            name = "delete-open-contact-records-after-12-months"
+            type = "Lifecycle"
+            definition = @{
+                actions = @{ baseBlob = @{ delete = @{ daysAfterCreationGreaterThan = 364 } } }
+                filters = @{
+                    blobTypes = @("blockBlob")
+                    prefixMatch = @("$BlobContainer/contacts/open/")
+                }
+            }
+        },
+        @{
+            enabled = $true
+            name = "delete-closed-contact-records-after-30-days"
+            type = "Lifecycle"
+            definition = @{
+                actions = @{ baseBlob = @{ delete = @{ daysAfterCreationGreaterThan = 29 } } }
+                filters = @{
+                    blobTypes = @("blockBlob")
+                    prefixMatch = @("$BlobContainer/contacts/closed/")
+                }
+            }
+        }
+    )
+} | ConvertTo-Json -Depth 10 -Compress
+
+az storage account management-policy create `
+    --account-name $StorageAccount `
+    --resource-group $ResourceGroup `
+    --policy $RetentionPolicy `
+    --output none
+Write-Done "Private attachments: 30 days maximum; contact records: 30 days after close or 12 months maximum"
 
 $StorageConnString = az storage account show-connection-string `
     --name $StorageAccount `


### PR DESCRIPTION
## Summary

- promote the privacy-safe in-app reporting implementation from `dev`
- support anonymous reports and explicit optional contact consent
- keep contact records and save-file attachments private in Azure storage
- remove public reporter identity, filenames, SAS links, and email logging
- enforce attachment/contact retention, including legacy issue-number blob paths
- validate and encode GitHub issue links shown in success snackbars

## Validation

- local formatting and Debug builds for Web, Functions, and Tests passed with 0 warnings/errors
- official Build and Test workflow, including the full test suite, passed:
  https://github.com/codemonkey85/PKMDS-Blazor/actions/runs/32745740608
- all review threads on #1264 were resolved
- `origin/main...origin/dev` contains only the #1264 privacy implementation

Refs #1217

#1217 should remain open until this PR is merged, deployed publicly, and verified. After that, legacy public `Reporter:` lines will be removed and historical issue revisions / Function logs assessed separately. Automated outbound email notifications remain out of scope until an email delivery provider is selected and configured.
