### PR TITLE
Fix LGPE Trade tab party crash

### DIFF
--- a/Pkmds.Core/Utilities/SaveSourceDetector.cs
+++ b/Pkmds.Core/Utilities/SaveSourceDetector.cs
@@ -17,8 +17,9 @@ public static partial class SaveSourceDetector
     /// <summary>
     /// Returns a concise label for the save's origin. Decision order is most-specific first:
     /// explicit Manic EMU archive context → known filename conventions (DeSmuME .dsv,
-    /// <c>sav*.dat</c> VC dumps) → SAV-type-specific flags (<see cref="SAV1.IsVirtualConsole" />)
-    /// → generation-based fallback. Returns <c>"Unknown"</c> if no signal matches.
+    /// <c>sav*.dat</c> VC dumps) → SAV-type-specific platform/VC signals
+    /// (<see cref="SAV7b" />, <see cref="SAV1.IsVirtualConsole" />) → generation-based fallback.
+    /// Returns <c>"Unknown"</c> if no signal matches.
     /// </summary>
     public static string Detect(SaveFile saveFile, string? fileName, bool isManicEmuArchive)
     {
@@ -55,9 +56,10 @@ public static partial class SaveSourceDetector
             return "Virtual Console (sav*.dat)";
         }
 
-        // SAV-type specific detection (IsVirtualConsole on Gen 1/2).
+        // SAV-type specific detection (LGPE platform and IsVirtualConsole on Gen 1/2).
         var sourceFromType = saveFile switch
         {
+            SAV7b => "Switch save (raw)",
             SAV1 { IsVirtualConsole: true } => "Gen 1 Virtual Console",
             SAV1 => "Gen 1 physical cartridge",
             SAV2 { IsVirtualConsole: true } => "Gen 2 Virtual Console",

--- a/Pkmds.Rcl/Components/MainTabPages/TradePane.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/TradePane.razor
@@ -12,8 +12,9 @@
             @for (var i = 0; i < 6; i++)
             {
                 var slotNum = i;
+                @* SAV7b can report party pointers that cannot be dereferenced; render those as empty. *@
                 var pkm = i < saveFile.PartyCount
-                    ? saveFile.GetPartySlotAtIndex(slotNum)
+                    ? saveFile.TryGetPartySlot(slotNum)
                     : null;
                 <div class="min-w-0">
                     <TradeSlot Pokemon="@pkm"

--- a/Pkmds.Rcl/Components/MainTabPages/TradePane.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradePane.razor.cs
@@ -98,7 +98,7 @@ public partial class TradePane : RefreshAwareComponent
 
             if (SelectedPartySlot is { } partySlot && partySlot < sav.PartyCount)
             {
-                return sav.GetPartySlotAtIndex(partySlot);
+                return sav.TryGetPartySlot(partySlot);
             }
 
             if (SelectedBox is { } boxNum && SelectedBoxSlot is { } boxSlot)

--- a/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor.cs
@@ -279,7 +279,7 @@ public partial class TradeTab : RefreshAwareComponent
         if (!TryGetSelectedSource(fromA: true, out _, out var isParty, out var boxNum, out var slotNum))
             return false;
         var pkm = isParty
-            ? srcSave.GetPartySlotAtIndex(slotNum)
+            ? srcSave.TryGetPartySlot(slotNum)
             : boxNum.HasValue ? srcSave.GetBoxSlotAtIndex(boxNum.Value, slotNum) : null;
         return IsCrossTransferEligible(pkm, srcSave, destSave, AppState.IsHaXEnabled);
     }
@@ -291,7 +291,7 @@ public partial class TradeTab : RefreshAwareComponent
         if (!TryGetSelectedSource(fromA: false, out _, out var isParty, out var boxNum, out var slotNum))
             return false;
         var pkm = isParty
-            ? srcSave.GetPartySlotAtIndex(slotNum)
+            ? srcSave.TryGetPartySlot(slotNum)
             : boxNum.HasValue ? srcSave.GetBoxSlotAtIndex(boxNum.Value, slotNum) : null;
         return IsCrossTransferEligible(pkm, srcSave, destSave, AppState.IsHaXEnabled);
     }
@@ -329,7 +329,7 @@ public partial class TradeTab : RefreshAwareComponent
         var partySel = fromA ? AppState.SelectedPartySlotNumber : AppState.SelectedPartySlotNumberB;
         if (partySel is { } partySlot && partySlot < sav.PartyCount)
         {
-            var pkm = sav.GetPartySlotAtIndex(partySlot);
+            var pkm = sav.TryGetPartySlot(partySlot);
             if (pkm is { Species: > 0 })
             {
                 source = sav;
@@ -374,7 +374,7 @@ public partial class TradeTab : RefreshAwareComponent
 
         // Belt-and-suspenders: same eligibility gate as CanTransferFrom* / TradeSlot.HandleDrop.
         if (!IsCrossTransferEligible(
-                srcIsParty ? srcSave.GetPartySlotAtIndex(srcSlot)
+                srcIsParty ? srcSave.TryGetPartySlot(srcSlot)
                            : srcBox.HasValue ? srcSave.GetBoxSlotAtIndex(srcBox.Value, srcSlot) : null,
                 srcSave, destSave, AppState.IsHaXEnabled))
         {
@@ -507,7 +507,7 @@ public partial class TradeTab : RefreshAwareComponent
         }
 
         var srcPkm = srcIsParty
-            ? srcSave.GetPartySlotAtIndex(srcSlot)
+            ? srcSave.TryGetPartySlot(srcSlot)
             : srcBox.HasValue
                 ? srcSave.GetBoxSlotAtIndex(srcBox.Value, srcSlot)
                 : null;
@@ -542,7 +542,7 @@ public partial class TradeTab : RefreshAwareComponent
         }
 
         var destPkmPrev = destIsParty
-            ? destSave.GetPartySlotAtIndex(destSlot)
+            ? destSave.TryGetPartySlot(destSlot)
             : destBox.HasValue
                 ? destSave.GetBoxSlotAtIndex(destBox.Value, destSlot)
                 : null;
@@ -976,7 +976,7 @@ public partial class TradeTab : RefreshAwareComponent
         bool destIsParty, int? destBox, int destSlot)
     {
         var source = srcIsParty
-            ? save.GetPartySlotAtIndex(srcSlot)
+            ? save.TryGetPartySlot(srcSlot)
             : srcBox.HasValue ? save.GetBoxSlotAtIndex(srcBox.Value, srcSlot) : null;
         if (source is null)
         {
@@ -984,7 +984,7 @@ public partial class TradeTab : RefreshAwareComponent
         }
 
         var dest = destIsParty
-            ? save.GetPartySlotAtIndex(destSlot)
+            ? save.TryGetPartySlot(destSlot)
             : destBox.HasValue ? save.GetBoxSlotAtIndex(destBox.Value, destSlot) : null;
         if (dest is null)
         {
@@ -1003,7 +1003,7 @@ public partial class TradeTab : RefreshAwareComponent
                 {
                     continue;
                 }
-                var partyMon = save.GetPartySlotAtIndex(i);
+                var partyMon = save.TryGetPartySlot(i);
                 if (partyMon is { Species: > 0, IsEgg: false })
                 {
                     battleReady++;

--- a/Pkmds.Tests/LgpePartySafetyTests.cs
+++ b/Pkmds.Tests/LgpePartySafetyTests.cs
@@ -1,10 +1,13 @@
+using Bunit;
+using Pkmds.Rcl.Components.MainTabPages;
+
 namespace Pkmds.Tests;
 
 /// <summary>
 /// Regression tests for LGPE (SAV7b) party handling. Let's Go stores the party as a pointer list
 /// into unified storage; an empty slot holds the SLOT_EMPTY sentinel, and reading or writing such
 /// a slot via the index API throws <see cref="ArgumentOutOfRangeException"/>. Saves in the wild
-/// (emulator / JKSM dumps) can report a <see cref="SaveFile.PartyCount"/> larger than the number of
+/// (extracted or emulator saves) can report a <see cref="SaveFile.PartyCount"/> larger than the number of
 /// populated pointer slots, which crashed the party grid, the editor save path, and CompactParty
 /// (issues #942–#948). The safe extension helpers must tolerate that state instead of throwing.
 /// </summary>
@@ -79,5 +82,23 @@ public class LgpePartySafetyTests
         var sav = new SAV8SWSH();
 
         sav.GetSafePartyCount().Should().Be(sav.PartyCount);
+    }
+
+    [Fact]
+    public async Task TradePane_PhantomPartySlot_RendersWithoutThrowing()
+    {
+        var sav = CreateLgpeWithOverReportedParty(2);
+        var appState = new TestAppState { SaveFile = sav };
+        var refreshService = new TestRefreshService();
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
+        await using var ctx = BunitTestHelpers.CreateBunitContext(appState, refreshService, appService);
+
+        var render = () => ctx.Render<TradePane>(parameters => parameters
+            .Add(component => component.Title, "Let's Go Pikachu")
+            .Add(component => component.SaveFile, sav)
+            .Add(component => component.SelectedPartySlot, 0));
+
+        render.Should().NotThrow(
+            "the Trade tab must treat an unreadable SAV7b party pointer as an empty slot");
     }
 }

--- a/Pkmds.Tests/SaveSourceDetectorTests.cs
+++ b/Pkmds.Tests/SaveSourceDetectorTests.cs
@@ -1,0 +1,14 @@
+namespace Pkmds.Tests;
+
+public class SaveSourceDetectorTests
+{
+    [Fact]
+    public void Detect_LgpeSave_ReportsSwitchSource()
+    {
+        var sav = new SAV7b();
+
+        var source = SaveSourceDetector.Detect(sav, "savedata.bin", isManicEmuArchive: false);
+
+        source.Should().Be("Switch save (raw)");
+    }
+}


### PR DESCRIPTION
## Summary

- route Trade-tab party reads through the existing safe LGPE helper so phantom SAV7b party pointers render as empty instead of crashing
- add bUnit regression coverage for rendering and selecting an unreadable LGPE party slot
- report SAV7b bug-report sources as Switch saves instead of the generic generation-7 3DS fallback

## Validation

- dotnet format Pkmds.slnx --no-restore
- dotnet build Pkmds.Web/Pkmds.Web.csproj -c Debug -p:SkipTailwind=true --no-restore
- dotnet build Pkmds.Tests/Pkmds.Tests.csproj -c Debug -p:SkipTailwind=true --no-restore
- git diff --check

Fixes #1273