### PR TITLE
Fix bag item autocomplete selection

### DIFF
--- a/Pkmds.Rcl/Components/AutocompleteSelect.razor
+++ b/Pkmds.Rcl/Components/AutocompleteSelect.razor
@@ -6,6 +6,7 @@
                  Margin="@Margin"
                  Value="@WrappedValue"
                  ValueChanged="@OnWrappedValueChanged"
+                 TextChanged="@OnWrappedTextChanged"
                  SearchFunc="@WrappedSearchFunc"
                  ToStringFunc="@WrappedToStringFunc"
                  ItemTemplate="@WrappedItemTemplate"

--- a/Pkmds.Rcl/Components/AutocompleteSelect.razor.cs
+++ b/Pkmds.Rcl/Components/AutocompleteSelect.razor.cs
@@ -88,16 +88,31 @@ public partial class AutocompleteSelect<T>
             return;
         }
 
-        var matches = (Items ?? [])
-            .Where(item => string.Equals(EffectiveToStringFunc(item), text, StringComparison.OrdinalIgnoreCase))
-            .Take(2)
-            .ToList();
-        if (matches.Count != 1 || EqualityComparer<T>.Default.Equals(Value!, matches[0]))
+        var toString = EffectiveToStringFunc;
+        T? match = default;
+        var foundMatch = false;
+        foreach (var item in Items ?? [])
+        {
+            if (!string.Equals(toString(item), text, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (foundMatch)
+            {
+                return;
+            }
+
+            match = item;
+            foundMatch = true;
+        }
+
+        if (!foundMatch || EqualityComparer<T>.Default.Equals(Value!, match!))
         {
             return;
         }
 
-        await OnWrappedValueChanged(new Option(matches[0]));
+        await OnWrappedValueChanged(new Option(match));
     }
 
     private Func<T?, string?> EffectiveToStringFunc =>

--- a/Pkmds.Rcl/Components/AutocompleteSelect.razor.cs
+++ b/Pkmds.Rcl/Components/AutocompleteSelect.razor.cs
@@ -30,6 +30,8 @@ public partial class AutocompleteSelect<T>
 
     [Parameter] public bool Strict { get; set; } = true;
 
+    [Parameter] public bool SelectExactMatchOnTextChange { get; set; }
+
     // Keep MudAutocomplete's own bounded default. Leaving this null overrides MudBlazor's
     // default of 10 and renders every match, which made one-letter item searches stall for
     // several seconds on mobile devices (issue #1122).
@@ -77,6 +79,25 @@ public partial class AutocompleteSelect<T>
         var newValue = opt is null ? default : opt.Value;
         Value = newValue;
         await ValueChanged.InvokeAsync(newValue);
+    }
+
+    private async Task OnWrappedTextChanged(string? text)
+    {
+        if (!SelectExactMatchOnTextChange || string.IsNullOrWhiteSpace(text))
+        {
+            return;
+        }
+
+        var matches = (Items ?? [])
+            .Where(item => string.Equals(EffectiveToStringFunc(item), text, StringComparison.OrdinalIgnoreCase))
+            .Take(2)
+            .ToList();
+        if (matches.Count != 1 || EqualityComparer<T>.Default.Equals(Value!, matches[0]))
+        {
+            return;
+        }
+
+        await OnWrappedValueChanged(new Option(matches[0]));
     }
 
     private Func<T?, string?> EffectiveToStringFunc =>

--- a/Pkmds.Rcl/Components/MainTabPages/BagTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/BagTab.razor
@@ -113,6 +113,7 @@
                                                                 Value="@GetItem(context)"
                                                                 ValueChanged="@(newItem => SetItem(context, newItem))"
                                                                 Items="@GetPouchItems(pouch)"
+                                                                SelectExactMatchOnTextChange
                                                                 ToStringFunc="@(item => item?.Text ?? GetItemName(context.Item.Index))">
                                                 <ItemTemplate Context="item">
                                                     <MudStack Row>

--- a/Pkmds.Tests/AutocompleteSelectTests.cs
+++ b/Pkmds.Tests/AutocompleteSelectTests.cs
@@ -1,3 +1,5 @@
+using Bunit;
+
 namespace Pkmds.Tests;
 
 public class AutocompleteSelectTests
@@ -8,5 +10,51 @@ public class AutocompleteSelectTests
         var component = new AutocompleteSelect<ComboItem>();
 
         component.MaxItems.Should().Be(10);
+    }
+
+    [Fact]
+    public async Task ExactTextMatch_CommitsMatchingValueWhenEnabled()
+    {
+        var appState = new TestAppState { SaveFile = new SAV8SWSH() };
+        var refreshService = new TestRefreshService();
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
+        await using var ctx = BunitTestHelpers.CreateBunitContext(appState, refreshService, appService);
+
+        var pokeBall = new ComboItem("Poké Ball", 4);
+        var masterBall = new ComboItem("Master Ball", 1);
+        ComboItem? selected = pokeBall;
+        var cut = ctx.Render<AutocompleteSelect<ComboItem>>(parameters => parameters
+            .Add(component => component.Items, [pokeBall, masterBall])
+            .Add(component => component.Value, selected)
+            .Add(component => component.ValueChanged, value => selected = value)
+            .Add(component => component.SelectExactMatchOnTextChange, true)
+            .Add(component => component.ToStringFunc, item => item?.Text));
+
+        cut.Find("input").Input("Master Ball");
+
+        selected.Should().Be(masterBall);
+    }
+
+    [Fact]
+    public async Task PartialText_DoesNotReplaceCurrentValue()
+    {
+        var appState = new TestAppState { SaveFile = new SAV8SWSH() };
+        var refreshService = new TestRefreshService();
+        var appService = new AppService(appState, refreshService, new LegalizationService(appState));
+        await using var ctx = BunitTestHelpers.CreateBunitContext(appState, refreshService, appService);
+
+        var pokeBall = new ComboItem("Poké Ball", 4);
+        var masterBall = new ComboItem("Master Ball", 1);
+        ComboItem? selected = pokeBall;
+        var cut = ctx.Render<AutocompleteSelect<ComboItem>>(parameters => parameters
+            .Add(component => component.Items, [pokeBall, masterBall])
+            .Add(component => component.Value, selected)
+            .Add(component => component.ValueChanged, value => selected = value)
+            .Add(component => component.SelectExactMatchOnTextChange, true)
+            .Add(component => component.ToStringFunc, item => item?.Text));
+
+        cut.Find("input").Input("Master");
+
+        selected.Should().Be(pokeBall);
     }
 }


### PR DESCRIPTION
## Summary

- commit unique exact-name autocomplete matches when explicitly enabled
- enable exact-match commits for Bag item editing so typed item names update the selected item ID
- add regression coverage for exact and partial item-name input

## Validation

- `dotnet format --no-restore --verbosity minimal` (completed with the existing workspace-load warning)
- `dotnet build Pkmds.Web/Pkmds.Web.csproj -c Debug --no-restore -p:SkipTailwind=true`
- `dotnet build Pkmds.Tests/Pkmds.Tests.csproj -c Debug --no-restore -p:SkipTailwind=true`
- `git diff --check`
- local tests were not run, per `AGENTS.md`

## Browser verification

Using the same Pokémon Black save and Bag-edit sequence:

- untouched `dev`: typing `Master Ball`, changing the count to `99`, and saving produced `Poké Ball ×99`
- fixed build: the committed row changed to `Master Ball` immediately and remained `Master Ball ×99` after saving
- no browser warnings or errors were logged in either run

Fixes #1276
