### PR TITLE
Update PKHeX.Core and CodeQL action

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,7 +54,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4.37.8
+      uses: github/codeql-action/init@v4.37.9
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -72,6 +72,6 @@ jobs:
       run: dotnet build Pkmds.Web/Pkmds.Web.csproj -c Release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4.37.8
+      uses: github/codeql-action/analyze@v4.37.9
       with:
         category: "/language:${{matrix.language}}"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,7 @@
     <!-- Windows Shell preview-handler PoC only (tools/windows-preview-poc). -->
     <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.3967.48" />
     <PackageVersion Include="MudBlazor" Version="9.9.0" />
-    <PackageVersion Include="PKHeX.Core" Version="26.7.7" />
+    <PackageVersion Include="PKHeX.Core" Version="26.8.26" />
     <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageVersion Include="Serilog.Sinks.BrowserConsole" Version="8.0.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="4.0.0" />


### PR DESCRIPTION
## Summary

- update PKHeX.Core from 26.7.7 to 26.8.26, carrying forward #1275 on dev
- update github/codeql-action from 4.37.8 to 4.37.9, carrying forward #1278 on dev

## Validation

- dotnet format (completed; reported workspace-loading warnings)
- dotnet build Pkmds.Web/Pkmds.Web.csproj -c Debug -p:SkipTailwind=true (passed with 0 warnings and 0 errors)
- full Debug build attempted; the bundled Tailwind process was killed with exit 137 before RCL compilation
- source PR checks for #1275 and #1278 are green

Per repository guidance, tests are left to GitHub Actions.