### PR TITLE
Fix FireRed and LeafGreen save detection

### DIFF
--- a/Pkmds.Core/Utilities/ManicEmuSaveHelper.cs
+++ b/Pkmds.Core/Utilities/ManicEmuSaveHelper.cs
@@ -165,7 +165,7 @@ public static class ManicEmuSaveHelper
 
                 var entryBytes = entryStream.ToArray();
 
-                if (!SaveUtil.TryGetSaveFile(entryBytes, out var sf, fileName))
+                if (!SaveFileLoader.TryLoadRawSave(entryBytes, fileName, out var sf))
                 {
                     continue;
                 }

--- a/Pkmds.Core/Utilities/SaveFileLoader.cs
+++ b/Pkmds.Core/Utilities/SaveFileLoader.cs
@@ -73,12 +73,28 @@ public static class SaveFileLoader
         // (issue #1127). Prefer a checksum-valid Gen 5 footer before delegating to the
         // normal detector. This mirrors PKHeX's own footer validation; it does not repair or
         // guess at damaged data.
-        if (TryLoadGen5ByFooter(data, out saveFile))
+        if (!TryLoadGen5ByFooter(data, out saveFile) &&
+            !SaveUtil.TryGetSaveFile(data, out saveFile, fileName))
         {
-            return true;
+            return false;
         }
 
-        return SaveUtil.TryGetSaveFile(data, out saveFile, fileName);
+        // The Memory<byte> SaveUtil overload does not initialize Metadata.FileName or run the
+        // legacy language/version inference performed by its path-based overload. Browser uploads
+        // can only use the memory overload, so mirror PKHeX WinForms' load sequence here. This is
+        // required for saves whose exact version is not encoded in the data, notably FireRed vs.
+        // LeafGreen (issue #1282).
+        if (!string.IsNullOrWhiteSpace(fileName))
+        {
+            saveFile.Metadata.SetExtraInfo(fileName);
+        }
+
+        if (saveFile.Generation <= 3)
+        {
+            SaveLanguage.TryRevise(saveFile);
+        }
+
+        return true;
     }
 
     private static bool TryLoadGen5ByFooter(

--- a/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
+++ b/Pkmds.Rcl/Components/Layout/MainLayout.razor.cs
@@ -449,6 +449,12 @@ public partial class MainLayout : IDisposable
 
             if (SaveFileLoader.TryLoad(data, fileName, out var saveFile, out var archiveContext))
             {
+                if (!await SaveVersionResolver.ResolveAmbiguousVersionAsync(saveFile, DialogService))
+                {
+                    AppState.ShowProgressIndicator = false;
+                    return;
+                }
+
                 if (!saveFile.IsSupportedForEditing(out var unsupportedReason))
                 {
                     Logger.LogWarning("Backup save file rejected (unsupported format/ROM hack): {FileName}", fileName);
@@ -578,6 +584,12 @@ public partial class MainLayout : IDisposable
             // raw bytes under a ZIP filename (see issues #750 and #1131-#1133).
             if (SaveFileLoader.TryLoad(data, selectedFile.Name, out var saveFile, out var archiveContext))
             {
+                if (!await SaveVersionResolver.ResolveAmbiguousVersionAsync(saveFile, DialogService))
+                {
+                    AppState.ShowProgressIndicator = false;
+                    return;
+                }
+
                 if (!saveFile.IsSupportedForEditing(out var unsupportedReason))
                 {
                     Logger.LogWarning("Save file rejected (unsupported format/ROM hack): {FileName}", selectedFile.Name);

--- a/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor.cs
@@ -97,6 +97,11 @@ public partial class TradeTab : RefreshAwareComponent
 
             if (SaveFileLoader.TryLoad(data, selectedFile.Name, out var saveFile, out archiveContext))
             {
+                if (!await SaveVersionResolver.ResolveAmbiguousVersionAsync(saveFile, DialogService))
+                {
+                    return;
+                }
+
                 if (!saveFile.IsSupportedForEditing(out var unsupportedReason))
                 {
                     await DialogService.ShowMessageBoxAsync("Unsupported save file", unsupportedReason);

--- a/Pkmds.Rcl/Services/SaveVersionResolver.cs
+++ b/Pkmds.Rcl/Services/SaveVersionResolver.cs
@@ -1,0 +1,38 @@
+namespace Pkmds.Rcl.Services;
+
+/// <summary>
+/// Resolves save sub-versions that cannot be determined from the save data or filename alone.
+/// </summary>
+public static class SaveVersionResolver
+{
+    /// <summary>
+    /// Prompts for the FireRed/LeafGreen version when PKHeX could only identify their shared
+    /// save format.
+    /// </summary>
+    /// <returns><see langword="false" /> when the user cancels the load.</returns>
+    public static async Task<bool> ResolveAmbiguousVersionAsync(
+        SaveFile saveFile,
+        IDialogService dialogService)
+    {
+        if (saveFile is not SAV3FRLG frlg || frlg.Version.IsValidSavedVersion())
+        {
+            return true;
+        }
+
+        var isFireRed = await dialogService.ShowMessageBoxAsync(
+            "Choose game version",
+            "FireRed and LeafGreen use the same save format, and the filename does not identify " +
+            "which game this save came from. Which version is it?",
+            yesText: "FireRed",
+            noText: "LeafGreen",
+            cancelText: "Cancel");
+
+        if (!isFireRed.HasValue)
+        {
+            return false;
+        }
+
+        var version = isFireRed.Value ? GameVersion.FR : GameVersion.LG;
+        return frlg.ResetPersonal(version);
+    }
+}

--- a/Pkmds.Tests/SaveFileLoaderTests.cs
+++ b/Pkmds.Tests/SaveFileLoaderTests.cs
@@ -253,4 +253,34 @@ public class SaveFileLoaderTests
         result.Should().BeOfType<SAV4HGSS>();
         archiveContext.Should().BeNull();
     }
+
+    [Theory]
+    [InlineData("POKEMON FIRE_BPRE-0.sav", GameVersion.FR)]
+    [InlineData("POKEMON LEAF_BPGE-0.sav", GameVersion.LG)]
+    public void TryLoad_FireRedLeafGreen_InfersVersionFromFileName(
+        string fileName,
+        GameVersion expectedVersion)
+    {
+        var data = File.ReadAllBytes(Path.Combine(TestFilesPath, fileName));
+
+        SaveFileLoader.TryLoad(data, fileName, out var result, out var archiveContext).Should().BeTrue();
+
+        var frlg = result.Should().BeOfType<SAV3FRLG>().Subject;
+        frlg.Version.Should().Be(expectedVersion);
+        frlg.Personal.Should().BeSameAs(expectedVersion == GameVersion.FR
+            ? PersonalTable.FR
+            : PersonalTable.LG);
+        archiveContext.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryLoad_FireRedLeafGreen_WithAmbiguousFileName_DoesNotDefaultToFireRed()
+    {
+        var data = File.ReadAllBytes(Path.Combine(TestFilesPath, "POKEMON LEAF_BPGE-0.sav"));
+
+        SaveFileLoader.TryLoad(data, "save.srm", out var result, out _).Should().BeTrue();
+
+        result.Should().BeOfType<SAV3FRLG>()
+            .Which.Version.Should().Be(GameVersion.FRLG);
+    }
 }


### PR DESCRIPTION
## Summary

- initialize browser-loaded save metadata before running PKHeX's legacy language/version inference
- detect FireRed and LeafGreen from recognizable filenames and prompt when the filename is ambiguous
- apply the same resolution path to backups, archive uploads, and secondary Trade-tab saves
- add regression coverage for FireRed, LeafGreen, and neutral filenames

## Validation

- `dotnet format`
- `dotnet build Pkmds.Web/Pkmds.Web.csproj -c Debug --nologo`
- `dotnet build Pkmds.Tests/Pkmds.Tests.csproj -c Debug --nologo`

Tests were not run locally per repository policy; CI will run them.

Fixes #1282
