### PR TITLE
Fix Legends: Arceus research completion crash

### DIFF
--- a/Pkmds.Rcl/Components/MainTabPages/Pokedex/Gen8La/PokedexLaResearchPanel.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/Pokedex/Gen8La/PokedexLaResearchPanel.razor.cs
@@ -114,6 +114,12 @@ public partial class PokedexLaResearchPanel : BasePkmdsComponent
 
     private void CompleteThisSpecies(PokedexSave8a dex, ushort species)
     {
+        CompleteSpeciesResearch(dex, species);
+        StateHasChanged();
+    }
+
+    internal static void CompleteSpeciesResearch(PokedexSave8a dex, ushort species)
+    {
         var dexIndex = PokedexSave8a.GetDexIndex(PokedexType8a.Hisui, species);
         if (dexIndex == 0)
         {
@@ -122,7 +128,9 @@ public partial class PokedexLaResearchPanel : BasePkmdsComponent
 
         foreach (var task in PokedexConstants8a.ResearchTasks[dexIndex - 1])
         {
-            if (task.TaskThresholds.Length == 0)
+            // ObtainForms / PartOfArceus / SpeciesQuest tasks have no settable
+            // counter. PKHeX throws if they are passed to SetResearchTaskProgressByForce.
+            if (!task.Task.CanSetCurrentValue() || task.TaskThresholds.Length == 0)
             {
                 continue;
             }
@@ -134,7 +142,6 @@ public partial class PokedexLaResearchPanel : BasePkmdsComponent
         // from scratch (all levels newly unreported) rather than accumulating on old data.
         dex.ResetResearchEntry(species);
         dex.UpdateSpecificReportPoke(species);
-        StateHasChanged();
     }
 
     private async Task OpenResearchEditorDialog(ushort species)

--- a/Pkmds.Tests/PokedexLaResearchPanelTests.cs
+++ b/Pkmds.Tests/PokedexLaResearchPanelTests.cs
@@ -19,13 +19,17 @@ public class PokedexLaResearchPanelTests
                 var tasks = dexIndex == 0 ? [] : PokedexConstants8a.ResearchTasks[dexIndex - 1];
                 return (Species: species, Tasks: tasks);
             })
-            .First(x => x.Tasks.Any(task => !task.Task.CanSetCurrentValue()) &&
-                        x.Tasks.Any(task => task.Task.CanSetCurrentValue() && task.TaskThresholds.Length > 0));
+            .FirstOrDefault(x => x.Tasks.Any(task => !task.Task.CanSetCurrentValue()) &&
+                                 x.Tasks.Any(task => task.Task.CanSetCurrentValue() && task.TaskThresholds.Length > 0));
+
+        speciesWithNonSettableTask.Tasks.Should().NotBeNull(
+            "the Legends: Arceus fixture should contain a species with both settable and non-settable research tasks");
+        var tasks = speciesWithNonSettableTask.Tasks!;
 
         var editableTaskIndex = Array.FindIndex(
-            speciesWithNonSettableTask.Tasks,
+            tasks,
             task => task.Task.CanSetCurrentValue() && task.TaskThresholds.Length > 0);
-        var editableTask = speciesWithNonSettableTask.Tasks[editableTaskIndex];
+        var editableTask = tasks[editableTaskIndex];
 
         // Act
         var act = () => PokedexLaResearchPanel.CompleteSpeciesResearch(

--- a/Pkmds.Tests/PokedexLaResearchPanelTests.cs
+++ b/Pkmds.Tests/PokedexLaResearchPanelTests.cs
@@ -1,0 +1,45 @@
+using Pkmds.Rcl.Components.MainTabPages.Pokedex.Gen8La;
+
+namespace Pkmds.Tests;
+
+public class PokedexLaResearchPanelTests
+{
+    [Fact]
+    public void CompleteSpeciesResearch_SkipsNonSettableTasksAndCompletesEditableTasks()
+    {
+        // Arrange
+        var (saveFile, _, _, _) = BunitTestHelpers.LoadSave("legends-arceus");
+        var sav = saveFile.Should().BeOfType<SAV8LA>().Subject;
+
+        var speciesWithNonSettableTask = Enumerable.Range(1, sav.MaxSpeciesID)
+            .Select(static species => (ushort)species)
+            .Select(species =>
+            {
+                var dexIndex = PokedexSave8a.GetDexIndex(PokedexType8a.Hisui, species);
+                var tasks = dexIndex == 0 ? [] : PokedexConstants8a.ResearchTasks[dexIndex - 1];
+                return (Species: species, Tasks: tasks);
+            })
+            .First(x => x.Tasks.Any(task => !task.Task.CanSetCurrentValue()) &&
+                        x.Tasks.Any(task => task.Task.CanSetCurrentValue() && task.TaskThresholds.Length > 0));
+
+        var editableTaskIndex = Array.FindIndex(
+            speciesWithNonSettableTask.Tasks,
+            task => task.Task.CanSetCurrentValue() && task.TaskThresholds.Length > 0);
+        var editableTask = speciesWithNonSettableTask.Tasks[editableTaskIndex];
+
+        // Act
+        var act = () => PokedexLaResearchPanel.CompleteSpeciesResearch(
+            sav.PokedexSave,
+            speciesWithNonSettableTask.Species);
+
+        // Assert
+        act.Should().NotThrow();
+        sav.PokedexSave.GetResearchTaskLevel(
+            speciesWithNonSettableTask.Species,
+            editableTaskIndex,
+            out _,
+            out var currentValue,
+            out _);
+        currentValue.Should().Be(editableTask.TaskThresholds[^1]);
+    }
+}


### PR DESCRIPTION
Fixes #1284

## Summary

- skip non-settable Legends: Arceus research tasks in the per-species Complete action
- keep completing editable tasks and recomputing the species research report
- add regression coverage using the existing Legends: Arceus save fixture

## Validation

- dotnet format
- dotnet build Pkmds.Web/Pkmds.Web.csproj -c Debug --nologo
- dotnet build Pkmds.Tests/Pkmds.Tests.csproj -c Debug --nologo

Tests were not run locally per repository policy; GitHub Actions will execute them.