### PR TITLE
Clarify legality warning wording

### DIFF
--- a/Pkmds.Rcl/Components/Dialogs/AppSettingsDialog.razor
+++ b/Pkmds.Rcl/Components/Dialogs/AppSettingsDialog.razor
@@ -118,8 +118,8 @@
                     <MudSwitch T="@bool"
                                Value="@showFishyIndicator"
                                Color="@Color.Warning"
-                               Label="Show Fishy (yellow)"
-                               title="Show a yellow warning on slots whose Pokémon pass legality but have suspicious checks"
+                               Label="Show warnings (yellow)"
+                               title="Show a yellow warning on slots whose Pokémon pass legality but have unusual details that may be legitimate"
                                ValueChanged="@(v => OnToggle(v, x => showFishyIndicator = x))"/>
                     <MudSwitch T="@bool"
                                Value="@showIllegalIndicator"

--- a/Pkmds.Rcl/Components/EditForms/Tabs/LegalityTab.razor
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/LegalityTab.razor
@@ -20,7 +20,7 @@
                                     ? Icons.Material.Filled.CheckCircle
                                     : Icons.Material.Filled.Cancel)">
                 @(IsFishy
-                    ? "This Pokémon is valid but has fishy details."
+                    ? "This Pokémon is legal, but has unusual details. These warnings can occur through normal gameplay."
                     : IsLegal
                         ? "This Pokémon is legal."
                         : "This Pokémon has legality issues.")
@@ -38,7 +38,7 @@
             @if (totalIssues > 0)
             {
                 <MudText Typo="@Typo.subtitle2"
-                         Class="mt-2">Issues (@totalIssues)
+                         Class="mt-2">@(IsFishy ? "Warnings" : "Issues") (@totalIssues)
                 </MudText>
 
                 <MudList T="@string"
@@ -222,6 +222,14 @@
 
             <MudExpansionPanels>
                 <MudExpansionPanel Text="Full Legality Report">
+                    @if (IsFishy)
+                    {
+                        <MudText Typo="@Typo.caption"
+                                 Color="@Color.Secondary"
+                                 Class="mb-2">
+                            PKHeX's technical report uses “Fishy” for warning-level findings. It does not mean this Pokémon is illegal.
+                        </MudText>
+                    }
                     <MudText Typo="@Typo.body2"
                              Style="white-space: pre-wrap; font-family: monospace; font-size: 0.75rem;">
                         @analysis.Report(true)

--- a/Pkmds.Rcl/Components/EditForms/Tabs/LegalityTab.razor.cs
+++ b/Pkmds.Rcl/Components/EditForms/Tabs/LegalityTab.razor.cs
@@ -329,7 +329,6 @@ public partial class LegalityTab : IDisposable
             return result.Result.ToString();
         }
 
-        var ctx = LegalityLocalizationContext.Create(la);
-        return ctx.Humanize(in result);
+        return LegalityUi.GetDisplayMessage(la, in result);
     }
 }

--- a/Pkmds.Rcl/Components/MainTabPages/LegalityReportTab.razor
+++ b/Pkmds.Rcl/Components/MainTabPages/LegalityReportTab.razor
@@ -82,7 +82,7 @@
                          Color="@Color.Warning"
                          Variant="@Variant.Filled"
                          Icon="@Icons.Material.Filled.Warning">
-                    @FishyCount Fishy
+                    @FishyCount Legal with warnings
                 </MudChip>
 
                 <MudChip T="@string"
@@ -118,7 +118,7 @@
 
                 <MudToggleItem T="LegalityStatus?"
                                Value="@((LegalityStatus?)LegalityStatus.Fishy)"
-                               Text="Fishy Only"/>
+                               Text="Warnings Only"/>
 
                 <MudToggleItem T="LegalityStatus?"
                                Value="@((LegalityStatus?)LegalityStatus.Illegal)"

--- a/Pkmds.Rcl/Components/MainTabPages/LegalityReportTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/LegalityReportTab.razor.cs
@@ -254,7 +254,7 @@ public partial class LegalityReportTab : RefreshAwareComponent
 
         if (fishyCount > 0)
         {
-            parts.Add($"still Fishy: {fishyCount}");
+            parts.Add($"still legal with warnings: {fishyCount}");
         }
 
         if (failureCount > 0)

--- a/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeSlot.razor.cs
@@ -281,12 +281,7 @@ public partial class TradeSlot : RefreshAwareComponent
         _ => false
     };
 
-    private static string StatusTitle(LegalityStatus status) => status switch
-    {
-        LegalityStatus.Legal => "Legal",
-        LegalityStatus.Fishy => "Fishy",
-        _ => "Illegal"
-    };
+    private static string StatusTitle(LegalityStatus status) => LegalityUi.GetStatusLabel(status);
 
     // Use solid glyphs rather than the *Circle / Cancel variants — those are drawn as
     // cutouts and inherit the sprite behind them. The coloured disc comes from the

--- a/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor.cs
@@ -930,7 +930,7 @@ public partial class TradeTab : RefreshAwareComponent
             {
                 continue;
             }
-            var humanized = LegalityUi.GetDisplayMessage(la, in r);
+            var humanized = LegalityUi.GetDisplayMessage(la, in r, verbose: false);
             if (!string.IsNullOrWhiteSpace(humanized))
             {
                 messages.Add(humanized);

--- a/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor.cs
+++ b/Pkmds.Rcl/Components/MainTabPages/TradeTab.razor.cs
@@ -921,9 +921,8 @@ public partial class TradeTab : RefreshAwareComponent
             return true;
         }
 
-        // LegalityLocalizationContext is a ref struct, so we can't use LINQ over it —
-        // materialise the humanized strings via a plain loop.
-        var ctx = LegalityLocalizationContext.Create(la);
+        // Materialise the user-facing strings via a plain loop so the warning and
+        // invalid findings retain their order from PKHeX.
         var messages = new List<string>(3);
         foreach (var r in la.Results)
         {
@@ -931,7 +930,7 @@ public partial class TradeTab : RefreshAwareComponent
             {
                 continue;
             }
-            var humanized = ctx.Humanize(in r, verbose: false);
+            var humanized = LegalityUi.GetDisplayMessage(la, in r);
             if (!string.IsNullOrWhiteSpace(humanized))
             {
                 messages.Add(humanized);
@@ -942,14 +941,14 @@ public partial class TradeTab : RefreshAwareComponent
             }
         }
 
-        var severity = invalid ? "illegal" : "fishy";
+        var statusDescription = invalid ? "illegal" : "legal, but has warnings";
         // MudBlazor's message box collapses whitespace in plain strings, so a bulleted list
         // has to be rendered as HTML via the MarkupString overload (same pattern as
         // ConfirmHeldItemLossAsync) — otherwise the bullets all wrap onto one line.
         var body = new StringBuilder();
         if (messages.Count > 0)
         {
-            body.Append("<p>The converted Pokémon is ").Append(severity).Append(":</p>");
+            body.Append("<p>The converted Pokémon is ").Append(statusDescription).Append(":</p>");
             body.Append("<ul style=\"margin:8px 0 0 0;padding-left:1.25rem;\">");
             foreach (var msg in messages)
             {
@@ -960,10 +959,10 @@ public partial class TradeTab : RefreshAwareComponent
         }
         else
         {
-            body.Append("<p>The converted Pokémon is ").Append(severity).Append(". Proceed with the transfer?</p>");
+            body.Append("<p>The converted Pokémon is ").Append(statusDescription).Append(". Proceed with the transfer?</p>");
         }
         var result = await DialogService.ShowMessageBoxAsync(
-            invalid ? "Illegal after conversion" : "Fishy after conversion",
+            invalid ? "Illegal after conversion" : "Warnings after conversion",
             new MarkupString(body.ToString()),
             yesText: "Transfer anyway",
             cancelText: "Cancel");

--- a/Pkmds.Rcl/Components/PokemonSlotComponent.razor
+++ b/Pkmds.Rcl/Components/PokemonSlotComponent.razor
@@ -76,12 +76,7 @@
                                 LegalityStatus.Fishy => "legality-indicator-icon--fishy",
                                 _ => "legality-indicator-icon--illegal"
                             }}")"
-                     title="@(status switch
-                            {
-                                LegalityStatus.Legal => "Legal",
-                                LegalityStatus.Fishy => "Fishy",
-                                _ => "Illegal"
-                            })">
+                     title="@LegalityUi.GetStatusLabel(status)">
                     <MudIcon Icon="@(status switch
                                    {
                                        LegalityStatus.Legal => Icons.Material.Filled.Check,

--- a/Pkmds.Rcl/Components/PokemonStorageComponent.razor.cs
+++ b/Pkmds.Rcl/Components/PokemonStorageComponent.razor.cs
@@ -411,7 +411,7 @@ public partial class PokemonStorageComponent : RefreshAwareComponent
 
         if (fishyCount > 0)
         {
-            parts.Add($"still Fishy: {fishyCount}");
+            parts.Add($"still legal with warnings: {fishyCount}");
         }
 
         if (failureCount > 0)

--- a/Pkmds.Rcl/IAppState.cs
+++ b/Pkmds.Rcl/IAppState.cs
@@ -161,7 +161,7 @@ public interface IAppState
     /// <summary>Whether to render the green "legal" indicator on slots.</summary>
     bool ShowLegalIndicator { get; set; }
 
-    /// <summary>Whether to render the yellow "fishy" indicator on slots.</summary>
+    /// <summary>Whether to render the yellow warning indicator on slots.</summary>
     bool ShowFishyIndicator { get; set; }
 
     /// <summary>Whether to render the red "illegal" indicator on slots.</summary>

--- a/Pkmds.Rcl/LegalityUi.cs
+++ b/Pkmds.Rcl/LegalityUi.cs
@@ -64,10 +64,13 @@ public static class LegalityUi
     /// Humanizes a PKHeX check result while translating its technical Fishy severity
     /// into the warning terminology used by the app.
     /// </summary>
-    public static string GetDisplayMessage(LegalityAnalysis la, in CheckResult result)
+    /// <param name="la">Legality analysis that produced the result.</param>
+    /// <param name="result">Check result to humanize.</param>
+    /// <param name="verbose">Whether to include the check identifier in the PKHeX message.</param>
+    public static string GetDisplayMessage(LegalityAnalysis la, in CheckResult result, bool verbose = false)
     {
         var ctx = LegalityLocalizationContext.Create(la);
-        var message = ctx.Humanize(in result);
+        var message = ctx.Humanize(in result, verbose);
         if (result.Judgement != PKHexSeverity.Fishy)
         {
             return message;

--- a/Pkmds.Rcl/LegalityUi.cs
+++ b/Pkmds.Rcl/LegalityUi.cs
@@ -29,15 +29,13 @@ public static class LegalityUi
 
     public static string GetFirstIssue(LegalityAnalysis la)
     {
-        var ctx = LegalityLocalizationContext.Create(la);
-
         // Prefer Invalid over Fishy so the more severe issue wins when both are present.
         // CheckResult.Valid is true for Fishy judgements, so match on Judgement directly.
         foreach (var result in la.Results)
         {
             if (result.Judgement == PKHexSeverity.Invalid)
             {
-                return ctx.Humanize(in result);
+                return GetDisplayMessage(la, in result);
             }
         }
 
@@ -55,11 +53,30 @@ public static class LegalityUi
         {
             if (result.Judgement == PKHexSeverity.Fishy)
             {
-                return ctx.Humanize(in result);
+                return GetDisplayMessage(la, in result);
             }
         }
 
         return string.Empty;
+    }
+
+    /// <summary>
+    /// Humanizes a PKHeX check result while translating its technical Fishy severity
+    /// into the warning terminology used by the app.
+    /// </summary>
+    public static string GetDisplayMessage(LegalityAnalysis la, in CheckResult result)
+    {
+        var ctx = LegalityLocalizationContext.Create(la);
+        var message = ctx.Humanize(in result);
+        if (result.Judgement != PKHexSeverity.Fishy)
+        {
+            return message;
+        }
+
+        var technicalLabel = ctx.Settings.Description(PKHexSeverity.Fishy);
+        return message.StartsWith(technicalLabel, StringComparison.Ordinal)
+            ? $"Warning{message[technicalLabel.Length..]}"
+            : message;
     }
 
     public static Color GetStatusColor(LegalityStatus status) => status switch
@@ -81,7 +98,7 @@ public static class LegalityUi
     public static string GetStatusLabel(LegalityStatus status) => status switch
     {
         LegalityStatus.Legal => "Legal",
-        LegalityStatus.Fishy => "Fishy",
+        LegalityStatus.Fishy => "Legal with warnings",
         LegalityStatus.Illegal => "Illegal",
         _ => "Unknown"
     };

--- a/Pkmds.Rcl/Models/AppSettings.cs
+++ b/Pkmds.Rcl/Models/AppSettings.cs
@@ -64,7 +64,7 @@ public record AppSettings
     public bool ShowLegalIndicator { get; init; } = true;
 
     /// <summary>
-    /// Whether to show the yellow "fishy" indicator on box/party slots.
+    /// Whether to show the yellow warning indicator on box/party slots.
     /// </summary>
     public bool ShowFishyIndicator { get; init; } = true;
 

--- a/Pkmds.Rcl/Services/LegalityHelpers.cs
+++ b/Pkmds.Rcl/Services/LegalityHelpers.cs
@@ -31,8 +31,7 @@ public static class LegalityHelpers
             return string.Empty;
         }
 
-        var ctx = LegalityLocalizationContext.Create(la);
-        return ctx.Humanize(in r);
+        return LegalityUi.GetDisplayMessage(la, in r);
     }
 
     public static string GetIdentifierLabel(CheckIdentifier id) => id switch
@@ -77,7 +76,7 @@ public static class LegalityHelpers
     public static string GetSeverityLabel(PKHexSeverity severity) => severity switch
     {
         PKHexSeverity.Valid => "Valid",
-        PKHexSeverity.Fishy => "Fishy",
+        PKHexSeverity.Fishy => "Warning",
         _ => "Invalid"
     };
 }

--- a/Pkmds.Tests/LegalityUiTests.cs
+++ b/Pkmds.Tests/LegalityUiTests.cs
@@ -25,7 +25,8 @@ public class LegalityUiTests
 
         var message = LegalityUi.GetDisplayMessage(analysis, in result);
 
-        message.Should().Be("Warning: All EVs are zero, but leveled above Met Level.");
+        message.Should().StartWith("Warning:");
+        message.Should().Contain("EVs", "the underlying PKHeX finding must be preserved");
         message.Should().NotContain("Fishy");
     }
 }

--- a/Pkmds.Tests/LegalityUiTests.cs
+++ b/Pkmds.Tests/LegalityUiTests.cs
@@ -1,0 +1,31 @@
+namespace Pkmds.Tests;
+
+public class LegalityUiTests
+{
+    [Theory]
+    [InlineData(LegalityStatus.Legal, "Legal")]
+    [InlineData(LegalityStatus.Fishy, "Legal with warnings")]
+    [InlineData(LegalityStatus.Illegal, "Illegal")]
+    public void GetStatusLabel_UsesUserFacingLegalityLanguage(LegalityStatus status, string expected) =>
+        LegalityUi.GetStatusLabel(status).Should().Be(expected);
+
+    [Fact]
+    public void GetSeverityLabel_FishyResult_IsPresentedAsWarning() =>
+        LegalityHelpers.GetSeverityLabel(PKHeX.Core.Severity.Fishy).Should().Be("Warning");
+
+    [Fact]
+    public void GetDisplayMessage_FishyResult_ReplacesTechnicalSeverityLabel()
+    {
+        var (saveFile, _, _, appService) = BunitTestHelpers.LoadSave("Black - Full Completion.sav");
+        var analysis = appService.GetLegalityAnalysis(saveFile.GetPartySlotAtIndex(0));
+        var result = CheckResult.Get(
+            PKHeX.Core.Severity.Fishy,
+            CheckIdentifier.EVs,
+            LegalityCheckResultCode.EffortEXPIncreased);
+
+        var message = LegalityUi.GetDisplayMessage(analysis, in result);
+
+        message.Should().Be("Warning: All EVs are zero, but leveled above Met Level.");
+        message.Should().NotContain("Fishy");
+    }
+}


### PR DESCRIPTION
## Summary

- present PKHeX Fishy results as Legal with warnings throughout the app
- label individual findings as Warning and explain that normal gameplay can produce them
- retain the raw PKHeX terminology in the expandable technical report with an explicit clarification
- update slot tooltips, report filters and counts, settings, legalization summaries, and trade-conversion prompts consistently
- add regression coverage for status labels and the zero-EV warning reported in #1268

## Validation

- dotnet format
- dotnet build Pkmds.Web/Pkmds.Web.csproj -c Debug --nologo
- dotnet build Pkmds.Tests/Pkmds.Tests.csproj -c Debug --nologo

Tests were not run locally per repository policy; GitHub Actions will execute them.

Fixes #1268

Follow-up false-positive reporting is tracked in #1291.